### PR TITLE
feat: add Circuit.from_pyquil import

### DIFF
--- a/marqov/circuits.py
+++ b/marqov/circuits.py
@@ -18,6 +18,7 @@ import quantumflow as qf
 
 if TYPE_CHECKING:
     from braket.circuits import Circuit as BraketCircuit
+    from pyquil import Program as PyQuilProgram
 
 
 class Circuit:
@@ -291,6 +292,102 @@ class Circuit:
         """
         circuit = cls()
         circuit._qf = qf.braket_to_circuit(braket_circuit)
+        return circuit
+
+    _PYQUIL_GATE_MAP: dict[str, str] = {
+        "H": "h",
+        "X": "x",
+        "Y": "y",
+        "Z": "z",
+        "S": "s",
+        "T": "t",
+        "RX": "rx",
+        "RY": "ry",
+        "RZ": "rz",
+        "CNOT": "cnot",
+        "CZ": "cz",
+        "SWAP": "swap",
+    }
+
+    _PYQUIL_ROTATION_GATES: set[str] = {"RX", "RY", "RZ"}
+
+    @staticmethod
+    def _pyquil_angle(param) -> float:
+        """Convert a pyQuil numeric angle to float."""
+        try:
+            value = complex(param)
+        except (TypeError, ValueError) as exc:
+            raise NotImplementedError(
+                "Circuit.from_pyquil() only supports numeric real-valued "
+                "rotation parameters."
+            ) from exc
+
+        if abs(value.imag) > 1e-12:
+            raise NotImplementedError(
+                "Circuit.from_pyquil() only supports real-valued rotation parameters."
+            )
+        return float(value.real)
+
+    @classmethod
+    def from_pyquil(cls, program: PyQuilProgram) -> "Circuit":
+        """Import from a pyQuil Program.
+
+        Requires pyQuil to be installed (``pip install marqov[pyquil]``).
+
+        Args:
+            program: A pyQuil ``Program`` instance.
+
+        Returns:
+            New Circuit instance.
+
+        Raises:
+            ImportError: If pyQuil is not installed.
+            TypeError: If the input is not a pyQuil Program.
+            NotImplementedError: If a Quil instruction is outside the canonical
+                Marqov gate set.
+        """
+        try:
+            from pyquil import Program
+            from pyquil.quilbase import Declare, Gate, Halt, Measurement, Pragma
+        except ImportError as exc:
+            raise ImportError(
+                "pyQuil is required for Circuit.from_pyquil(). "
+                "Install with: pip install marqov[pyquil]"
+            ) from exc
+
+        if not isinstance(program, Program):
+            raise TypeError(f"Expected a pyQuil Program, got {type(program).__name__}")
+
+        circuit = cls()
+
+        for instruction in program:
+            if isinstance(instruction, (Declare, Halt, Pragma, Measurement)):
+                continue
+
+            if not isinstance(instruction, Gate):
+                raise NotImplementedError(
+                    f"Unsupported pyQuil instruction '{type(instruction).__name__}'."
+                )
+
+            name = instruction.name.upper()
+            if name not in cls._PYQUIL_GATE_MAP:
+                supported = ", ".join(sorted(cls._PYQUIL_GATE_MAP))
+                raise NotImplementedError(
+                    f"Unsupported pyQuil gate '{instruction.name}'. "
+                    f"Supported gates: {supported}"
+                )
+
+            qubits = list(instruction.get_qubit_indices())
+            method_name = cls._PYQUIL_GATE_MAP[name]
+
+            if name in cls._PYQUIL_ROTATION_GATES:
+                angle = cls._pyquil_angle(instruction.params[0])
+                getattr(circuit, method_name)(angle, qubits[0])
+            elif len(qubits) == 1:
+                getattr(circuit, method_name)(qubits[0])
+            else:
+                getattr(circuit, method_name)(qubits[0], qubits[1])
+
         return circuit
 
     # Qiskit gate name -> Circuit fluent method mapping.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ ibm = [
 cirq = [
     "cirq-core>=1.0.0",
 ]
+pyquil = [
+    "pyquil>=4.0.0",
+]
 pennylane = [
     "pennylane>=0.35.0",
 ]
@@ -60,6 +63,7 @@ all = [
     "qiskit-ibm-runtime>=0.20.0",
     "qiskit-qasm3-import>=0.5.0",
     "cirq-core>=1.0.0",
+    "pyquil>=4.0.0",
     "pennylane>=0.35.0",
 ]
 

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -325,6 +325,125 @@ class TestFromCirq:
         assert np.isclose(np.abs(amps[3]) ** 2, 0.5, atol=0.01)
 
 
+class TestFromPyquil:
+    """Tests for Circuit.from_pyquil()."""
+
+    def test_known_pyquil_gates_map_to_circuit_methods(self, monkeypatch) -> None:
+        """Canonical pyQuil gates are mapped to Marqov circuit methods."""
+        from pyquil import Program
+        from pyquil.gates import CNOT, CZ, H, RX, RY, RZ, S, SWAP, T, X, Y, Z
+
+        calls = []
+
+        def record(method):
+            def _inner(self, *args):
+                calls.append((method, args))
+                return self
+
+            return _inner
+
+        for method in ("h", "x", "y", "z", "s", "t", "rx", "ry", "rz", "cnot", "cz", "swap"):
+            monkeypatch.setattr(Circuit, method, record(method))
+
+        program = Program(
+            H(0),
+            X(1),
+            Y(2),
+            Z(3),
+            S(4),
+            T(5),
+            RX(0.1, 6),
+            RY(0.2, 7),
+            RZ(0.3, 8),
+            CNOT(0, 1),
+            CZ(1, 2),
+            SWAP(2, 3),
+        )
+
+        Circuit.from_pyquil(program)
+
+        assert calls == [
+            ("h", (0,)),
+            ("x", (1,)),
+            ("y", (2,)),
+            ("z", (3,)),
+            ("s", (4,)),
+            ("t", (5,)),
+            ("rx", (0.1, 6)),
+            ("ry", (0.2, 7)),
+            ("rz", (0.3, 8)),
+            ("cnot", (0, 1)),
+            ("cz", (1, 2)),
+            ("swap", (2, 3)),
+        ]
+
+    def test_unsupported_pyquil_gate_raises_not_implemented(self) -> None:
+        """Gates outside the canonical set raise a clear error."""
+        from pyquil import Program
+        from pyquil.gates import CCNOT
+
+        with pytest.raises(NotImplementedError, match="Unsupported pyQuil gate 'CCNOT'"):
+            Circuit.from_pyquil(Program(CCNOT(0, 1, 2)))
+
+    def test_type_error_on_wrong_input(self) -> None:
+        """TypeError raised for non-Program input."""
+        with pytest.raises(TypeError, match="Expected a pyQuil Program"):
+            Circuit.from_pyquil("not a program")
+
+    def test_symbolic_rotation_parameter_raises_not_implemented(self) -> None:
+        """Symbolic pyQuil rotation parameters fail with a clear error."""
+        from pyquil import Program
+        from pyquil.gates import RX
+        from pyquil.quilatom import Parameter
+
+        with pytest.raises(NotImplementedError, match="numeric real-valued"):
+            Circuit.from_pyquil(Program(RX(Parameter("theta"), 0)))
+
+    def test_clean_python_pyquil_roundtrip_acceptance(self) -> None:
+        """Real pyQuil programs round-trip in a clean process."""
+        import importlib.metadata
+        import subprocess
+        import sys
+        import textwrap
+
+        try:
+            importlib.metadata.version("pyquil")
+        except importlib.metadata.PackageNotFoundError:
+            pytest.skip("pyQuil optional dependency is not installed")
+
+        script = textwrap.dedent(
+            """
+            import numpy as np
+
+            from marqov.circuits import Circuit, bell_state
+            from pyquil import Program
+            from pyquil.gates import CNOT, H
+
+            imported = Circuit.from_pyquil(Program(H(0), CNOT(0, 1)))
+            expected = bell_state()
+
+            assert np.allclose(
+                np.abs(imported.simulate().tensor.flatten()),
+                np.abs(expected.simulate().tensor.flatten()),
+            )
+
+            original = Circuit().h(0).cnot(0, 1).x(1).swap(0, 1)
+            restored = Circuit.from_pyquil(original.to_pyquil())
+
+            assert np.allclose(
+                np.abs(original.simulate().tensor.flatten()),
+                np.abs(restored.simulate().tensor.flatten()),
+                atol=1e-6,
+            )
+            """
+        )
+
+        subprocess.run(
+            [sys.executable, "-c", script],
+            check=True,
+        )
+
+
 class TestFromPennylane:
     """Tests for Circuit.from_pennylane()."""
 


### PR DESCRIPTION
## Summary

- Add `Circuit.from_pyquil()` to import pyQuil `Program` objects into Marqov circuits.
- Support the canonical gate set from `CONTRIBUTING.md`: H, X, Y, Z, S, T, RX, RY, RZ, CNOT, CZ, and SWAP.
- Add a `pyquil` optional dependency extra and include it in the `all` extra.
- Add focused tests for canonical gate mapping, unsupported gates, symbolic rotation parameters, a hand-written Bell-pair Quil program, and a `to_pyquil()` / `from_pyquil()` round-trip.

Closes #4

## Tests

- `python3 -m py_compile marqov/circuits.py tests/test_circuits.py`
- `uv run --python 3.12 --with ruff ruff check marqov/circuits.py tests/test_circuits.py`
- `uv run --python 3.12 --extra dev --extra pyquil python -m pytest tests/test_circuits.py::TestFromPyquil -q`
- `git diff --check`

## AI Assistance Disclosure

This contribution was AI-assisted. I used Codex as a coding assistant, reviewed the issue requirements and implementation scope, and verified the change locally with the tests listed above.
