### PR TITLE
feat(benchmarks): add unified benchmark suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,8 @@ check both containers are running with `docker ps`.
 python benchmarks/suite.py --executor local --shots 1000
 ```
 
+Pass `--executor` more than once to compare multiple configured executors.
+
 Output format — one row per (backend × circuit) combination:
 
 | backend | circuit   | shots | exec_time_ms | top_3_outcomes         |

--- a/benchmarks/suite.py
+++ b/benchmarks/suite.py
@@ -1,0 +1,161 @@
+"""Unified executor benchmark harness."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import random
+import sys
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+from marqov.circuits import Circuit, bell_state, ghz_state
+from marqov.executors.base import BaseExecutor, ExecutionResult
+from marqov.executors.local import LocalExecutor
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    """A named circuit benchmark."""
+
+    name: str
+    build: Callable[[], Circuit]
+
+
+@dataclass(frozen=True)
+class BenchmarkRow:
+    """One rendered benchmark result row."""
+
+    backend: str
+    circuit: str
+    shots: int
+    exec_time_ms: float
+    top_3_outcomes: dict[str, int]
+
+
+def random_depth_5(seed: int = 42) -> Circuit:
+    """Build a deterministic 3-qubit depth-5 random circuit."""
+    rng = random.Random(seed)
+    circuit = Circuit()
+    one_qubit_gates = ["h", "x", "y", "z", "s", "t"]
+
+    for _ in range(5):
+        gate = rng.choice(one_qubit_gates)
+        qubit = rng.randrange(3)
+        getattr(circuit, gate)(qubit)
+
+        control, target = rng.sample(range(3), 2)
+        circuit.cnot(control, target)
+
+    return circuit
+
+
+def benchmark_cases() -> list[BenchmarkCase]:
+    """Return the default benchmark circuit suite."""
+    return [
+        BenchmarkCase("bell", bell_state),
+        BenchmarkCase("ghz", lambda: ghz_state(3)),
+        BenchmarkCase("random_d5", random_depth_5),
+    ]
+
+
+def create_executor(name: str) -> tuple[str, BaseExecutor]:
+    """Create an executor by CLI name."""
+    if name == "local":
+        return "local", LocalExecutor()
+    raise ValueError(f"Unsupported executor: {name}. Supported executors: local")
+
+
+def top_outcomes(counts: dict[str, int], limit: int = 3) -> dict[str, int]:
+    """Return the top measurement outcomes sorted by count descending."""
+    return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:limit])
+
+
+async def run_suite(
+    executors: Sequence[tuple[str, BaseExecutor]],
+    cases: Sequence[BenchmarkCase],
+    shots: int,
+) -> list[BenchmarkRow]:
+    """Run all benchmark cases against all executors."""
+    rows: list[BenchmarkRow] = []
+
+    for backend_name, executor in executors:
+        for case in cases:
+            try:
+                result = await executor.execute(case.build(), shots=shots)
+            except Exception as exc:
+                print(
+                    f"skipping {backend_name}/{case.name}: {exc}",
+                    file=sys.stderr,
+                )
+                continue
+
+            rows.append(row_from_result(backend_name, case.name, result))
+
+    return rows
+
+
+def row_from_result(backend_name: str, circuit_name: str, result: ExecutionResult) -> BenchmarkRow:
+    """Convert an execution result to a benchmark row."""
+    return BenchmarkRow(
+        backend=backend_name,
+        circuit=circuit_name,
+        shots=result.shots,
+        exec_time_ms=result.execution_time_ms,
+        top_3_outcomes=top_outcomes(result.counts),
+    )
+
+
+def format_rows(rows: Sequence[BenchmarkRow]) -> str:
+    """Render benchmark rows as the CONTRIBUTING.md §5 table format."""
+    lines = [
+        "backend | circuit | shots | exec_time_ms | top_3_outcomes",
+    ]
+
+    for row in rows:
+        lines.append(
+            " | ".join(
+                [
+                    row.backend,
+                    row.circuit,
+                    str(row.shots),
+                    f"{row.exec_time_ms:.1f}",
+                    json.dumps(row.top_3_outcomes, sort_keys=True),
+                ]
+            )
+        )
+
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description="Run Marqov executor benchmarks.")
+    parser.add_argument(
+        "--executor",
+        action="append",
+        default=None,
+        help="Executor to benchmark. May be passed multiple times. Defaults to local.",
+    )
+    parser.add_argument("--shots", type=int, default=1000, help="Number of shots per circuit.")
+    return parser.parse_args(argv)
+
+
+async def async_main(argv: Sequence[str] | None = None) -> int:
+    """Async CLI entrypoint."""
+    args = parse_args(argv)
+    executor_names = args.executor or ["local"]
+    executors = [create_executor(name) for name in executor_names]
+    rows = await run_suite(executors, benchmark_cases(), shots=args.shots)
+    print(format_rows(rows))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entrypoint."""
+    return asyncio.run(async_main(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -1,0 +1,116 @@
+"""Tests for the unified benchmark suite."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmarks.suite import (
+    BenchmarkCase,
+    BenchmarkRow,
+    format_rows,
+    row_from_result,
+    run_suite,
+    top_outcomes,
+)
+from marqov.circuits import Circuit
+from marqov.executors.base import BaseExecutor, ExecutionResult
+
+
+class FakeExecutor(BaseExecutor):
+    """Executor that returns a fixed result."""
+
+    async def execute(self, circuit: Circuit, shots: int = 1000, **kwargs) -> ExecutionResult:
+        return ExecutionResult(
+            counts={"11": 2, "00": 5, "01": 3, "10": 1},
+            backend="fake",
+            execution_time_ms=12.34,
+            shots=shots,
+        )
+
+
+class FailingExecutor(BaseExecutor):
+    """Executor that always fails."""
+
+    async def execute(self, circuit: Circuit, shots: int = 1000, **kwargs) -> ExecutionResult:
+        raise RuntimeError("backend offline")
+
+
+@pytest.mark.parametrize(
+    ("counts", "expected"),
+    [
+        ({"00": 5, "11": 2, "01": 3, "10": 1}, {"00": 5, "01": 3, "11": 2}),
+        ({"1": 7, "0": 7, "10": 1}, {"0": 7, "1": 7, "10": 1}),
+        ({}, {}),
+    ],
+)
+def test_top_outcomes(counts: dict[str, int], expected: dict[str, int]) -> None:
+    assert top_outcomes(counts) == expected
+
+
+def test_row_from_result() -> None:
+    result = ExecutionResult(
+        counts={"00": 4, "11": 6},
+        backend="ignored",
+        execution_time_ms=8.25,
+        shots=10,
+    )
+
+    row = row_from_result("local", "bell", result)
+
+    assert row == BenchmarkRow(
+        backend="local",
+        circuit="bell",
+        shots=10,
+        exec_time_ms=8.25,
+        top_3_outcomes={"11": 6, "00": 4},
+    )
+
+
+def test_format_rows_matches_contributing_columns() -> None:
+    rendered = format_rows(
+        [
+            BenchmarkRow(
+                backend="local",
+                circuit="bell",
+                shots=1000,
+                exec_time_ms=12.34,
+                top_3_outcomes={"00": 503, "11": 497},
+            )
+        ]
+    )
+
+    assert rendered.splitlines() == [
+        "backend | circuit | shots | exec_time_ms | top_3_outcomes",
+        'local | bell | 1000 | 12.3 | {"00": 503, "11": 497}',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_suite_returns_rows_for_each_case() -> None:
+    rows = await run_suite(
+        [("fake", FakeExecutor())],
+        [
+            BenchmarkCase("bell", Circuit),
+            BenchmarkCase("ghz", Circuit),
+        ],
+        shots=25,
+    )
+
+    assert [row.circuit for row in rows] == ["bell", "ghz"]
+    assert all(row.backend == "fake" for row in rows)
+    assert all(row.shots == 25 for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_run_suite_skips_and_logs_executor_errors(capsys: pytest.CaptureFixture) -> None:
+    rows = await run_suite(
+        [
+            ("bad", FailingExecutor()),
+            ("good", FakeExecutor()),
+        ],
+        [BenchmarkCase("bell", Circuit)],
+        shots=10,
+    )
+
+    assert [row.backend for row in rows] == ["good"]
+    assert "skipping bad/bell: backend offline" in capsys.readouterr().err


### PR DESCRIPTION
Closes #5.

## Summary
- add `benchmarks/suite.py` with Bell, 3-qubit GHZ, and deterministic random depth-5 circuits
- support `--executor local --shots N` and repeated `--executor` flags for comparison runs
- render the CONTRIBUTING.md §5 table columns exactly
- skip executor/circuit failures, log to stderr, and continue the suite
- add parametrized tests plus skip-and-log coverage

## Verification
- `/tmp/marqov-sdk-venv/bin/python -m ruff check benchmarks/suite.py tests/test_benchmark_suite.py`
- focused benchmark-suite tests: `7 passed` using explicit lightweight stubs for optional cloud/circuit SDK imports

## Local environment note
- Full `uv run --extra dev --extra all ...` setup remains blocked locally because `llvmlite` needs `cmake`, which is not installed on this machine. The failure is in Braket simulator dependency setup before the benchmark tests run.