### PR TITLE
feat(executors): add Quantinuum executor

### DIFF
--- a/marqov/circuits.py
+++ b/marqov/circuits.py
@@ -238,6 +238,50 @@ class Circuit:
         """
         return qf.transpile(self._qf, output_format="pyquil")
 
+    _PYTKET_SUPPORTED_QF_GATES: set[str] = {
+        "H",
+        "X",
+        "Y",
+        "Z",
+        "S",
+        "T",
+        "Rx",
+        "Ry",
+        "Rz",
+        "CNot",
+        "CZ",
+        "Swap",
+    }
+
+    def to_pytket(self):
+        """Convert to a pytket circuit.
+
+        Returns:
+            pytket Circuit object.
+
+        Raises:
+            ImportError: If pytket or pytket-qiskit is not installed.
+            NotImplementedError: If the circuit contains a noncanonical gate.
+        """
+        for op in self._qf._elements:
+            gate_name = getattr(op, "name", type(op).__name__)
+            if gate_name not in self._PYTKET_SUPPORTED_QF_GATES:
+                raise NotImplementedError(
+                    f"Circuit.to_pytket() does not support gate '{gate_name}'. "
+                    "Supported gates: "
+                    f"{', '.join(sorted(self._PYTKET_SUPPORTED_QF_GATES))}"
+                )
+
+        try:
+            from pytket.extensions.qiskit import qiskit_to_tk
+        except ImportError:
+            raise ImportError(
+                "pytket and pytket-qiskit are required for Circuit.to_pytket(). "
+                "Install with: pip install marqov[pytket]"
+            )
+
+        return qiskit_to_tk(self.to_qiskit())
+
     def to_openqasm(self, version: int = 2) -> str:
         """Export circuit as an OpenQASM string.
 

--- a/marqov/executors/__init__.py
+++ b/marqov/executors/__init__.py
@@ -7,6 +7,7 @@ Available executors:
 - BraketExecutor: AWS Braket (simulators and QPUs)
 - AzureQuantumExecutor: Azure Quantum (Quantinuum, PASQAL, IonQ, Rigetti)
 - IBMExecutor: IBM Quantum (Heron r2, Eagle, etc. via Qiskit Runtime)
+- QuantinuumExecutor: Quantinuum H-Series devices and emulators via pytket
 
 Example:
     >>> from marqov.executors import LocalExecutor
@@ -23,6 +24,7 @@ from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
 from marqov.executors.factory import ExecutorFactory
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
 from marqov.executors.local import LocalExecutor
+from marqov.executors.quantinuum import QuantinuumExecutor, QuantinuumExecutorConfig
 from marqov.simulation.executor import SimulationExecutor
 
 __all__ = [
@@ -37,5 +39,7 @@ __all__ = [
     "IBMExecutor",
     "IBMExecutorConfig",
     "LocalExecutor",
+    "QuantinuumExecutor",
+    "QuantinuumExecutorConfig",
     "SimulationExecutor",
 ]

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -23,6 +23,7 @@ from marqov.executors.base import BaseExecutor
 from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
 from marqov.executors.local import LocalExecutor
+from marqov.executors.quantinuum import QuantinuumExecutor, QuantinuumExecutorConfig
 from marqov.simulation.config import SimulationConfig
 from marqov.simulation.executor import SimulationExecutor
 
@@ -42,6 +43,7 @@ class ExecutorFactory:
         - IBM Quantum: Heron r2, Eagle processors via Qiskit Runtime SamplerV2
         - Azure Quantum: Quantinuum, PASQAL, IonQ, Rigetti (Qiskit/Cirq support)
         - Local: QuantumFlow simulator (no cloud required)
+        - Quantinuum: H-Series devices and emulators via pytket-quantinuum
         - IonQ Direct API: Coming soon
 
     Example:
@@ -105,11 +107,15 @@ class ExecutorFactory:
         if provider == "Azure Quantum":
             return cls._create_azure_executor(backend_slug, backend_config)
 
+        # Quantinuum
+        if provider == "Quantinuum":
+            return cls._create_quantinuum_executor(backend_slug, backend_config)
+
         # IonQ Direct API (future)
         if provider == "IonQ Direct":
             raise NotImplementedError(
-                f"IonQ Direct API support coming soon. "
-                f"See docs/MULTI_CLOUD_EXECUTOR_DESIGN.md for roadmap."
+                "IonQ Direct API support coming soon. "
+                "See docs/MULTI_CLOUD_EXECUTOR_DESIGN.md for roadmap."
             )
 
         # C++ simulation backends (qpp, tnqvm, cudaq, aer)
@@ -118,7 +124,8 @@ class ExecutorFactory:
 
         raise ValueError(
             f"Unsupported provider: {provider}. "
-            f"Supported providers: AWS Braket, IBM Quantum, Azure Quantum, Quantum Brilliance, Local. "
+            f"Supported providers: AWS Braket, IBM Quantum, Azure Quantum, Quantinuum, "
+            f"Quantum Brilliance, Local. "
             f"Coming soon: IonQ Direct."
         )
 
@@ -245,6 +252,32 @@ class ExecutorFactory:
         return IBMExecutor(config)
 
     @classmethod
+    def _create_quantinuum_executor(
+        cls,
+        backend_slug: str,
+        backend_config: dict[str, Any],
+    ) -> QuantinuumExecutor:
+        """Create Quantinuum executor from configuration."""
+        device_name = backend_config.get("device_name") or backend_config.get("target") or backend_slug
+        if not device_name:
+            raise ValueError(f"QuantinuumExecutor config missing device_name for {backend_slug}")
+
+        config = QuantinuumExecutorConfig(
+            device_name=device_name,
+            label=backend_config.get("label", "marqov"),
+            simulator=backend_config.get("simulator", "state-vector"),
+            group=backend_config.get("group"),
+            provider=backend_config.get("auth_provider"),
+            machine_debug=backend_config.get("machine_debug", False),
+            optimisation_level=backend_config.get("optimisation_level", 2),
+            timeout_seconds=backend_config.get("timeout_seconds"),
+            api_handler=backend_config.get("api_handler"),
+            options=backend_config.get("options"),
+        )
+
+        return QuantinuumExecutor(config)
+
+    @classmethod
     def _create_simulation_executor(
         cls,
         backend_slug: str,
@@ -277,6 +310,7 @@ class ExecutorFactory:
             "AWS Braket",
             "IBM Quantum",
             "Azure Quantum",
+            "Quantinuum",
             "Quantum Brilliance",
             "Local",
             # "IonQ Direct",     # Coming soon

--- a/marqov/executors/quantinuum.py
+++ b/marqov/executors/quantinuum.py
@@ -1,0 +1,210 @@
+"""Quantinuum executor for running circuits via pytket-quantinuum."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from functools import partial
+from typing import TYPE_CHECKING, Any
+
+from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
+
+if TYPE_CHECKING:
+    from marqov.circuits import Circuit
+
+
+@dataclass
+class QuantinuumExecutorConfig:
+    """Configuration for Quantinuum executor.
+
+    Attributes:
+        device_name: Quantinuum target name, e.g. "H2-1" or "H2-1E".
+        label: Default job label used by pytket-quantinuum.
+        simulator: Simulator mode for emulator devices.
+        group: Optional Quantinuum job group identifier.
+        provider: Optional federated authentication provider.
+        machine_debug: Use pytket-quantinuum's debug/offline machine mode.
+        optimisation_level: pytket compilation optimisation level.
+        timeout_seconds: Maximum time to wait for result retrieval.
+        api_handler: Optional pytket-quantinuum API handler for tests/offline use.
+        options: Optional Quantinuum request options.
+    """
+
+    device_name: str
+    label: str = "marqov"
+    simulator: str = "state-vector"
+    group: str | None = None
+    provider: str | None = None
+    machine_debug: bool = False
+    optimisation_level: int = 2
+    timeout_seconds: float | None = None
+    api_handler: Any | None = None
+    options: dict[str, Any] | None = None
+
+
+class QuantinuumExecutor(BaseExecutor):
+    """Execute circuits on Quantinuum systems through pytket-quantinuum."""
+
+    _STATUS_MAP = {
+        "online": "online",
+        "available": "online",
+        "active": "online",
+        "offline": "offline",
+        "unavailable": "offline",
+        "retired": "offline",
+    }
+
+    def __init__(self, config: QuantinuumExecutorConfig) -> None:
+        """Initialize a Quantinuum executor."""
+        self.config = config
+        self._backend = None
+        self._current_handle: str | None = None
+
+    def _create_backend_sync(self):
+        """Create a pytket-quantinuum backend."""
+        try:
+            from pytket.extensions.quantinuum import QuantinuumBackend
+        except ImportError:
+            raise ImportError(
+                "pytket-quantinuum is required for QuantinuumExecutor. "
+                "Install with: pip install marqov[quantinuum]"
+            )
+
+        kwargs: dict[str, Any] = {
+            "device_name": self.config.device_name,
+            "label": self.config.label,
+            "simulator": self.config.simulator,
+            "machine_debug": self.config.machine_debug,
+        }
+        if self.config.group is not None:
+            kwargs["group"] = self.config.group
+        if self.config.provider is not None:
+            kwargs["provider"] = self.config.provider
+        if self.config.api_handler is not None:
+            kwargs["api_handler"] = self.config.api_handler
+        if self.config.options is not None:
+            kwargs["options"] = self.config.options
+
+        return QuantinuumBackend(**kwargs)
+
+    async def _get_backend(self):
+        """Get or create the pytket-quantinuum backend."""
+        if self._backend is None:
+            loop = asyncio.get_running_loop()
+            self._backend = await loop.run_in_executor(None, self._create_backend_sync)
+        return self._backend
+
+    async def execute(
+        self,
+        circuit: Circuit,
+        shots: int = 1000,
+        **kwargs: Any,
+    ) -> ExecutionResult:
+        """Execute a circuit on Quantinuum via pytket-quantinuum."""
+        circuit = self._validate_circuit(circuit)
+
+        loop = asyncio.get_running_loop()
+        start_time = time.perf_counter()
+        backend = await self._get_backend()
+
+        pytket_circuit = circuit.to_pytket()
+        if getattr(pytket_circuit, "n_bits", 0) == 0:
+            pytket_circuit.measure_all()
+
+        compiled_circuit = await loop.run_in_executor(
+            None,
+            partial(
+                backend.get_compiled_circuit,
+                pytket_circuit,
+                optimisation_level=self.config.optimisation_level,
+            ),
+        )
+        handle = await loop.run_in_executor(
+            None,
+            partial(backend.process_circuit, compiled_circuit, n_shots=shots, **kwargs),
+        )
+        self._current_handle = str(handle)
+
+        result_future = loop.run_in_executor(None, partial(backend.get_result, handle))
+        if self.config.timeout_seconds is not None:
+            raw_result = await asyncio.wait_for(result_future, timeout=self.config.timeout_seconds)
+        else:
+            raw_result = await result_future
+
+        wall_time_ms = (time.perf_counter() - start_time) * 1000
+        counts = self._normalise_counts(raw_result.get_counts())
+
+        return ExecutionResult(
+            counts=counts,
+            backend=self.config.device_name,
+            execution_time_ms=wall_time_ms,
+            shots=shots,
+            raw_result=raw_result,
+            metadata={
+                "handle": self._current_handle,
+                "device_name": self.config.device_name,
+                "optimisation_level": self.config.optimisation_level,
+                "wall_time_ms": wall_time_ms,
+            },
+        )
+
+    @staticmethod
+    def _normalise_counts(raw_counts: dict[Any, Any]) -> dict[str, int]:
+        """Convert pytket count keys into Marqov bitstring counts."""
+        counts: dict[str, int] = {}
+        for outcome, count in dict(raw_counts).items():
+            if isinstance(outcome, str):
+                bitstring = outcome
+            else:
+                values = outcome.tolist() if hasattr(outcome, "tolist") else outcome
+                bitstring = "".join(str(int(bit)) for bit in values)
+            counts[bitstring] = int(count)
+        return counts
+
+    async def cancel(self, job_id: str) -> bool:
+        """Cancel a running Quantinuum job by ResultHandle string."""
+        try:
+            from pytket.backends import ResultHandle
+
+            backend = await self._get_backend()
+            handle = ResultHandle.from_str(job_id)
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, partial(backend.cancel, handle))
+            return True
+        except Exception:
+            return False
+
+    async def get_device_status(self) -> str:
+        """Get raw Quantinuum device state."""
+        try:
+            from pytket.extensions.quantinuum import QuantinuumBackend
+        except ImportError:
+            raise ImportError(
+                "pytket-quantinuum is required for QuantinuumExecutor. "
+                "Install with: pip install marqov[quantinuum]"
+            )
+
+        kwargs: dict[str, Any] = {}
+        if self.config.api_handler is not None:
+            kwargs["api_handler"] = self.config.api_handler
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            partial(QuantinuumBackend.device_state, self.config.device_name, **kwargs),
+        )
+
+    async def is_device_available(self) -> bool:
+        """Check whether the configured Quantinuum device is online."""
+        status = await self.get_status()
+        return status.status == "online"
+
+    async def get_status(self) -> DeviceStatus:
+        """Map Quantinuum device state to the shared DeviceStatus shape."""
+        try:
+            raw_status = (await self.get_device_status()).lower()
+            status = self._STATUS_MAP.get(raw_status, "maintenance")
+            return DeviceStatus(status=status, queue_depth=None, queue_time_seconds=None)
+        except Exception:
+            return DeviceStatus(status="maintenance", queue_depth=None, queue_time_seconds=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ cirq = [
 pennylane = [
     "pennylane>=0.35.0",
 ]
+pytket = [
+    "pytket>=1.0.0",
+    "pytket-qiskit>=0.50.0",
+]
 openqasm = [
     "qiskit>=1.0.0",
     "qiskit-qasm3-import>=0.5.0",
@@ -61,6 +65,8 @@ all = [
     "qiskit-qasm3-import>=0.5.0",
     "cirq-core>=1.0.0",
     "pennylane>=0.35.0",
+    "pytket>=1.0.0",
+    "pytket-qiskit>=0.50.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,11 @@ pytket = [
     "pytket>=1.0.0",
     "pytket-qiskit>=0.50.0",
 ]
+quantinuum = [
+    "pytket>=1.0.0",
+    "pytket-qiskit>=0.50.0",
+    "pytket-quantinuum>=0.59.0",
+]
 openqasm = [
     "qiskit>=1.0.0",
     "qiskit-qasm3-import>=0.5.0",
@@ -67,6 +72,7 @@ all = [
     "pennylane>=0.35.0",
     "pytket>=1.0.0",
     "pytket-qiskit>=0.50.0",
+    "pytket-quantinuum>=0.59.0",
 ]
 
 [project.scripts]

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -211,6 +211,126 @@ class TestFromQiskit:
         assert np.isclose(np.abs(amps[3]) ** 2, 0.5, atol=0.01)
 
 
+class TestToPytket:
+    """Tests for Circuit.to_pytket()."""
+
+    @staticmethod
+    def _remove_stubbed_optional_modules() -> None:
+        """Remove conftest stubs so optional real deps can be imported."""
+        import sys
+
+        real_optional_prefixes = ("qiskit", "pydantic")
+        for name, module in list(sys.modules.items()):
+            if name in real_optional_prefixes or name.startswith(
+                tuple(f"{prefix}." for prefix in real_optional_prefixes)
+            ):
+                if getattr(module, "__spec__", None) is None:
+                    del sys.modules[name]
+
+    @staticmethod
+    def _set_pytket_config_home(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        """Keep pytket config writes inside pytest's temp directory."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    @staticmethod
+    def _stub_qf_elements(circuit: Circuit, names: list[str]) -> None:
+        """Replace QuantumFlow elements with named stubs for converter validation."""
+
+        class _GateStub:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+        circuit._qf._elements = [_GateStub(name) for name in names]
+
+    def test_roundtrip_through_qiskit_bridge(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+    ) -> None:
+        """pytket bridge output converts back to an equivalent Qiskit circuit."""
+        import math
+
+        import numpy as np
+
+        self._set_pytket_config_home(monkeypatch, tmp_path)
+        self._remove_stubbed_optional_modules()
+        pytest.importorskip("pytket.extensions.qiskit")
+        pytest.importorskip("qiskit.quantum_info")
+
+        from pytket.extensions.qiskit import tk_to_qiskit
+        from qiskit import QuantumCircuit
+        from qiskit.quantum_info import Operator
+
+        qiskit_circuit = QuantumCircuit(3)
+        qiskit_circuit.h(0)
+        qiskit_circuit.x(1)
+        qiskit_circuit.y(2)
+        qiskit_circuit.z(0)
+        qiskit_circuit.s(1)
+        qiskit_circuit.t(2)
+        qiskit_circuit.rx(math.pi / 3, 0)
+        qiskit_circuit.ry(math.pi / 5, 1)
+        qiskit_circuit.rz(math.pi / 7, 2)
+        qiskit_circuit.cx(0, 1)
+        qiskit_circuit.cz(1, 2)
+        qiskit_circuit.swap(0, 2)
+
+        circuit = Circuit()
+        self._stub_qf_elements(
+            circuit,
+            ["H", "X", "Y", "Z", "S", "T", "Rx", "Ry", "Rz", "CNot", "CZ", "Swap"],
+        )
+        monkeypatch.setattr(circuit, "to_qiskit", lambda: qiskit_circuit)
+
+        converted = circuit.to_pytket()
+        roundtripped = tk_to_qiskit(converted)
+
+        assert np.allclose(
+            Operator(qiskit_circuit).data,
+            Operator(roundtripped).data,
+            atol=1e-10,
+        )
+
+    def test_bell_pair_matches_known_pytket_circuit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+    ) -> None:
+        """Bell pair conversion matches a hand-written pytket circuit."""
+        self._set_pytket_config_home(monkeypatch, tmp_path)
+        self._remove_stubbed_optional_modules()
+        pytest.importorskip("pytket")
+        pytest.importorskip("pytket.extensions.qiskit")
+
+        from pytket.circuit import Circuit as PytketCircuit
+        from qiskit import QuantumCircuit
+
+        qiskit_circuit = QuantumCircuit(2)
+        qiskit_circuit.h(0)
+        qiskit_circuit.cx(0, 1)
+
+        circuit = Circuit()
+        self._stub_qf_elements(circuit, ["H", "CNot"])
+        monkeypatch.setattr(circuit, "to_qiskit", lambda: qiskit_circuit)
+
+        converted = circuit.to_pytket()
+        expected = PytketCircuit(2).H(0).CX(0, 1)
+
+        assert converted.get_commands() == expected.get_commands()
+
+    def test_unsupported_gate_raises_not_implemented(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Noncanonical internal gates fail with a clear NotImplementedError."""
+        circuit = Circuit()
+        self._stub_qf_elements(circuit, ["CCNot"])
+        monkeypatch.setattr(circuit, "to_qiskit", lambda: pytest.fail("guard should run first"))
+
+        with pytest.raises(NotImplementedError, match="CCNot"):
+            circuit.to_pytket()
+
+
 class TestFromCirq:
     """Tests for Circuit.from_cirq()."""
 

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -7,11 +7,13 @@ import pytest
 from marqov.circuits import Circuit, bell_state
 from marqov.executors import (
     AzureQuantumExecutor,
-    BaseExecutor,
     BraketExecutor,
     ExecutionResult,
+    ExecutorFactory,
     IBMExecutor,
     LocalExecutor,
+    QuantinuumExecutor,
+    QuantinuumExecutorConfig,
 )
 from marqov.executors.azure import AzureQuantumExecutorConfig
 from marqov.executors.braket import BraketExecutorConfig, _extract_region_from_arn
@@ -431,6 +433,161 @@ class TestAzureQuantumExecutor:
     #     result = await executor.execute(circuit, shots=100)
     #     assert "00" in result.counts or "11" in result.counts
     #     assert result.shots == 100
+
+
+class TestQuantinuumExecutorConfig:
+    """Tests for QuantinuumExecutorConfig."""
+
+    def test_config_defaults(self) -> None:
+        """Config has sensible defaults."""
+        config = QuantinuumExecutorConfig(device_name="H2-1E")
+        assert config.device_name == "H2-1E"
+        assert config.label == "marqov"
+        assert config.simulator == "state-vector"
+        assert config.machine_debug is False
+        assert config.optimisation_level == 2
+        assert config.timeout_seconds is None
+
+
+class TestQuantinuumExecutor:
+    """Tests for QuantinuumExecutor with mocked pytket-quantinuum backend."""
+
+    @pytest.fixture
+    def mock_quantinuum(self) -> dict[str, MagicMock]:
+        """Create mock Quantinuum backend, handle, and result."""
+        mock_result = MagicMock()
+        mock_result.get_counts.return_value = {(0, 0): 512, (1, 1): 488}
+
+        mock_handle = MagicMock()
+        mock_handle.__str__.return_value = "quantinuum-handle-123"
+
+        mock_compiled = MagicMock(name="compiled_circuit")
+
+        mock_backend = MagicMock()
+        mock_backend.get_compiled_circuit.return_value = mock_compiled
+        mock_backend.process_circuit.return_value = mock_handle
+        mock_backend.get_result.return_value = mock_result
+
+        return {
+            "backend": mock_backend,
+            "compiled": mock_compiled,
+            "handle": mock_handle,
+            "result": mock_result,
+        }
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_normalised_result(self, mock_quantinuum: dict[str, MagicMock]) -> None:
+        """Execute compiles, submits, retrieves, and normalises Quantinuum counts."""
+        config = QuantinuumExecutorConfig(device_name="H2-1E", machine_debug=True)
+        executor = QuantinuumExecutor(config)
+        circuit = Circuit().h(0).cnot(0, 1)
+        mock_tket_circuit = MagicMock()
+        mock_tket_circuit.n_bits = 0
+
+        with patch.object(executor, "_get_backend", new_callable=AsyncMock) as get_backend:
+            get_backend.return_value = mock_quantinuum["backend"]
+            with patch.object(circuit, "to_pytket", return_value=mock_tket_circuit):
+                result = await executor.execute(circuit, shots=1000)
+
+        mock_tket_circuit.measure_all.assert_called_once()
+        mock_quantinuum["backend"].get_compiled_circuit.assert_called_once_with(
+            mock_tket_circuit,
+            optimisation_level=2,
+        )
+        mock_quantinuum["backend"].process_circuit.assert_called_once_with(
+            mock_quantinuum["compiled"],
+            n_shots=1000,
+        )
+        mock_quantinuum["backend"].get_result.assert_called_once_with(mock_quantinuum["handle"])
+
+        assert isinstance(result, ExecutionResult)
+        assert result.counts == {"00": 512, "11": 488}
+        assert result.backend == "H2-1E"
+        assert result.shots == 1000
+        assert result.metadata["handle"] == "quantinuum-handle-123"
+        assert result.metadata["optimisation_level"] == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_preserves_existing_measurements(
+        self,
+        mock_quantinuum: dict[str, MagicMock],
+    ) -> None:
+        """Circuits with classical bits are not measured a second time."""
+        executor = QuantinuumExecutor(QuantinuumExecutorConfig(device_name="H2-1E"))
+        circuit = Circuit().h(0)
+        mock_tket_circuit = MagicMock()
+        mock_tket_circuit.n_bits = 1
+
+        with patch.object(executor, "_get_backend", new_callable=AsyncMock) as get_backend:
+            get_backend.return_value = mock_quantinuum["backend"]
+            with patch.object(circuit, "to_pytket", return_value=mock_tket_circuit):
+                await executor.execute(circuit, shots=10)
+
+        mock_tket_circuit.measure_all.assert_not_called()
+
+    def test_normalise_counts_accepts_string_keys(self) -> None:
+        """String keys from backends are preserved."""
+        counts = QuantinuumExecutor._normalise_counts({"00": 4, "11": 6})
+        assert counts == {"00": 4, "11": 6}
+
+    @pytest.mark.asyncio
+    async def test_get_status_maps_online(self) -> None:
+        """Available Quantinuum device states map to online."""
+        executor = QuantinuumExecutor(QuantinuumExecutorConfig(device_name="H2-1E"))
+        with patch.object(executor, "get_device_status", new_callable=AsyncMock, return_value="online"):
+            status = await executor.get_status()
+
+        assert status.status == "online"
+        assert status.queue_depth is None
+
+    @pytest.mark.asyncio
+    async def test_get_status_maps_offline(self) -> None:
+        """Unavailable Quantinuum device states map to offline."""
+        executor = QuantinuumExecutor(QuantinuumExecutorConfig(device_name="H2-1E"))
+        with patch.object(executor, "get_device_status", new_callable=AsyncMock, return_value="unavailable"):
+            status = await executor.get_status()
+
+        assert status.status == "offline"
+
+    @pytest.mark.asyncio
+    async def test_get_status_error_returns_maintenance(self) -> None:
+        """API failures map to maintenance."""
+        executor = QuantinuumExecutor(QuantinuumExecutorConfig(device_name="H2-1E"))
+        with patch.object(
+            executor,
+            "get_device_status",
+            new_callable=AsyncMock,
+            side_effect=Exception("API error"),
+        ):
+            status = await executor.get_status()
+
+        assert status.status == "maintenance"
+        assert status.queue_depth is None
+
+
+class TestQuantinuumExecutorFactory:
+    """Tests for Quantinuum ExecutorFactory registration."""
+
+    def test_factory_creates_quantinuum_executor(self) -> None:
+        """Factory supports provider string 'Quantinuum'."""
+        executor = ExecutorFactory.create_executor(
+            "H2-1E",
+            {
+                "provider": "Quantinuum",
+                "device_name": "H2-1E",
+                "label": "unit-test",
+                "machine_debug": True,
+            },
+        )
+
+        assert isinstance(executor, QuantinuumExecutor)
+        assert executor.config.device_name == "H2-1E"
+        assert executor.config.label == "unit-test"
+        assert executor.config.machine_debug is True
+
+    def test_quantinuum_provider_is_supported(self) -> None:
+        """Supported provider list includes Quantinuum."""
+        assert ExecutorFactory.is_provider_supported("Quantinuum") is True
 
 
 class TestSmartCircuitErrors:


### PR DESCRIPTION
## Summary

Adds a `QuantinuumExecutor` and `QuantinuumExecutorConfig` using `pytket-quantinuum`, registered through `ExecutorFactory` with provider string `"Quantinuum"`.

This also includes the `Circuit.to_pytket()` conversion path needed by the executor because the prerequisite converter issue has not merged yet.

Closes #6

## Type of change

- [ ] Bug fix
- [x] New executor
- [x] Circuit format converter
- [ ] Documentation
- [ ] Other (describe):

## Testing

- [ ] I ran `pytest tests/ -v` and tests pass
- [ ] For new executors: tested against local simulator or QVM (describe below)
- [x] For circuit converters: roundtrip test passes with known-correct reference circuit

**Test details:**

Focused local checks:

- `.venv/bin/python -m pytest tests/test_executors.py::TestQuantinuumExecutorConfig tests/test_executors.py::TestQuantinuumExecutor tests/test_executors.py::TestQuantinuumExecutorFactory -q` - 9 passed
- `.venv/bin/python -m pytest tests/test_circuits.py::TestToPytket -q` - 3 passed
- `.venv/bin/python -m ruff check marqov/executors/quantinuum.py marqov/executors/factory.py marqov/executors/__init__.py marqov/circuits.py tests/test_executors.py tests/test_circuits.py` - passed

The executor tests use a mocked `pytket-quantinuum` backend, matching the issue's acceptance criteria. I did not run a hardware smoke test.

## Checklist

- [x] No hardcoded credentials or API keys
- [x] Handles the canonical gate set from `CONTRIBUTING.md §1` (if adding a circuit converter)

**For new executors only:**
- [x] Registered in `ExecutorFactory` per `CONTRIBUTING.md §3`
- [x] `get_status()` returns device-level availability (`"online"/"offline"/"maintenance"`), not job-level status

## AI disclosure

Codex assisted with implementation, test planning, and local validation for this contribution. The commit messages include the disclosure footer:

`Assisted-by: GPT-5 Codex via Codex`
