### PR TITLE
feat(circuits): add Circuit.from_pyquil import

### DIFF
--- a/marqov/circuits.py
+++ b/marqov/circuits.py
@@ -18,6 +18,7 @@ import quantumflow as qf
 
 if TYPE_CHECKING:
     from braket.circuits import Circuit as BraketCircuit
+    from pyquil import Program as PyQuilProgram
 
 
 class Circuit:
@@ -319,6 +320,28 @@ class Circuit:
     # Non-gate instructions to skip silently.
     _SKIP_INSTRUCTIONS: set[str] = {"barrier", "measure", "reset", "delay"}
 
+    # PyQuil gate name -> Circuit fluent method mapping.
+    _PYQUIL_GATE_MAP: dict[str, str] = {
+        "H": "h",
+        "X": "x",
+        "Y": "y",
+        "Z": "z",
+        "S": "s",
+        "T": "t",
+        "RX": "rx",
+        "RY": "ry",
+        "RZ": "rz",
+        "CNOT": "cnot",
+        "CZ": "cz",
+        "SWAP": "swap",
+    }
+
+    _PYQUIL_ROTATION_GATES: set[str] = {"RX", "RY", "RZ"}
+
+    # Classical declarations and measurement instructions do not affect the
+    # unitary circuit representation imported by this SDK.
+    _PYQUIL_SKIP_INSTRUCTIONS: set[str] = {"Declare", "Measurement"}
+
     @classmethod
     def from_qiskit(cls, qiskit_circuit) -> "Circuit":
         """Import from a Qiskit QuantumCircuit.
@@ -379,6 +402,101 @@ class Circuit:
 
             if name in cls._ROTATION_GATES:
                 angle = float(instruction.operation.params[0])
+                getattr(circuit, method_name)(angle, qubits[0])
+            elif len(qubits) == 1:
+                getattr(circuit, method_name)(qubits[0])
+            else:
+                getattr(circuit, method_name)(qubits[0], qubits[1])
+
+        return circuit
+
+    @classmethod
+    def _pyquil_qubit_index(cls, qubit) -> int:
+        """Return the integer index for a PyQuil qubit operand."""
+        if isinstance(qubit, int):
+            return qubit
+
+        index = getattr(qubit, "index", None)
+        if isinstance(index, int):
+            return index
+
+        raise TypeError(
+            "Circuit.from_pyquil() requires concrete integer qubits, but found "
+            f"{type(qubit).__name__}. Compile or relabel the program to concrete "
+            "Qubit indices before calling from_pyquil()."
+        )
+
+    @classmethod
+    def _pyquil_float_param(cls, value) -> float:
+        """Return a real-valued PyQuil gate parameter."""
+        if isinstance(value, complex):
+            if value.imag != 0:
+                raise TypeError(
+                    "Circuit.from_pyquil() only supports real-valued rotation "
+                    f"parameters, but found {value!r}."
+                )
+            return float(value.real)
+
+        return float(value)
+
+    @classmethod
+    def from_pyquil(cls, program: "PyQuilProgram") -> "Circuit":
+        """Import from a PyQuil Program.
+
+        Known gates in the Marqov canonical gate set are mapped directly.
+        Classical declarations and measurements are skipped. Quil-native gates
+        outside the canonical set raise ``NotImplementedError`` so callers can
+        decompose them explicitly before importing.
+
+        Requires PyQuil to be installed (``pip install marqov[pyquil]``).
+
+        Args:
+            program: A PyQuil ``Program`` instance.
+
+        Returns:
+            New Circuit instance.
+
+        Raises:
+            ImportError: If PyQuil is not installed.
+            TypeError: If the input is not a PyQuil Program or uses non-integer qubits.
+            NotImplementedError: If a Quil instruction cannot be mapped.
+        """
+        try:
+            from pyquil import Program
+            from pyquil.quilbase import Gate
+        except ImportError:
+            raise ImportError(
+                "PyQuil is required for Circuit.from_pyquil(). "
+                "Install with: pip install marqov[pyquil]"
+            )
+
+        if not isinstance(program, Program):
+            raise TypeError(f"Expected a PyQuil Program, got {type(program).__name__}")
+
+        circuit = cls()
+
+        for instruction in program.instructions:
+            if not isinstance(instruction, Gate):
+                instruction_type = type(instruction).__name__
+                if instruction_type in cls._PYQUIL_SKIP_INSTRUCTIONS:
+                    continue
+                raise NotImplementedError(
+                    f"Unsupported PyQuil instruction '{instruction_type}'. "
+                    "Only canonical gates plus declarations and measurements are supported."
+                )
+
+            name = instruction.name.upper()
+            if name not in cls._PYQUIL_GATE_MAP:
+                raise NotImplementedError(
+                    f"Unsupported PyQuil gate '{name}'. Supported gates: "
+                    f"{', '.join(sorted(cls._PYQUIL_GATE_MAP))}"
+                )
+
+            qubits = [cls._pyquil_qubit_index(qubit) for qubit in instruction.qubits]
+            method_name = cls._PYQUIL_GATE_MAP[name]
+
+            if name in cls._PYQUIL_ROTATION_GATES:
+                angle = cls._pyquil_float_param(instruction.params[0])
                 getattr(circuit, method_name)(angle, qubits[0])
             elif len(qubits) == 1:
                 getattr(circuit, method_name)(qubits[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ cirq = [
 pennylane = [
     "pennylane>=0.35.0",
 ]
+pyquil = [
+    "pyquil>=4.0.0",
+]
 openqasm = [
     "qiskit>=1.0.0",
     "qiskit-qasm3-import>=0.5.0",
@@ -61,6 +64,7 @@ all = [
     "qiskit-qasm3-import>=0.5.0",
     "cirq-core>=1.0.0",
     "pennylane>=0.35.0",
+    "pyquil>=4.0.0",
 ]
 
 [project.scripts]

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -211,6 +211,132 @@ class TestFromQiskit:
         assert np.isclose(np.abs(amps[3]) ** 2, 0.5, atol=0.01)
 
 
+class TestFromPyQuil:
+    """Tests for Circuit.from_pyquil()."""
+
+    def _use_real_quantumflow(self, monkeypatch) -> None:
+        """Use the installed QuantumFlow package for roundtrip tests."""
+        import importlib
+        import sys
+
+        import marqov.circuits as circuits_module
+
+        for module_name in list(sys.modules):
+            if module_name == "quantumflow" or module_name.startswith("quantumflow."):
+                monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+        try:
+            real_quantumflow = importlib.import_module("quantumflow")
+        except Exception as exc:
+            pytest.skip(f"real quantumflow unavailable: {exc}")
+
+        monkeypatch.setattr(circuits_module, "qf", real_quantumflow)
+
+    def _record_gate_calls(self, monkeypatch):
+        """Patch fluent gate methods to record from_pyquil() mappings."""
+        calls = []
+
+        for method_name in ("h", "x", "y", "z", "s", "t", "rx", "ry", "rz", "cnot", "cz", "swap"):
+
+            def recorder(self, *args, method_name=method_name):
+                calls.append((method_name, args))
+                return self
+
+            monkeypatch.setattr(Circuit, method_name, recorder)
+
+        return calls
+
+    def test_bell_state_roundtrip(self, monkeypatch) -> None:
+        """Bell state survives Circuit -> PyQuil -> Circuit roundtrip."""
+        import numpy as np
+        from pyquil import Program
+
+        self._use_real_quantumflow(monkeypatch)
+
+        original = bell_state()
+        pyquil_program = original.to_pyquil()
+        assert isinstance(pyquil_program, Program)
+
+        imported = Circuit.from_pyquil(pyquil_program)
+        orig_amps = original.simulate().tensor.flatten()
+        imported_amps = imported.simulate().tensor.flatten()
+
+        assert imported.num_qubits == original.num_qubits
+        assert np.allclose(np.abs(orig_amps), np.abs(imported_amps))
+
+    def test_canonical_gate_program_import(self, monkeypatch) -> None:
+        """Canonical PyQuil gates map to Marqov Circuit methods."""
+        import math
+        from pyquil import Program
+        from pyquil.gates import CNOT, CZ, H, RX, RY, RZ, S, SWAP, T, X, Y, Z
+
+        calls = self._record_gate_calls(monkeypatch)
+        program = Program(
+            H(0),
+            X(1),
+            Y(2),
+            Z(3),
+            S(4),
+            T(5),
+            RX(math.pi / 3, 0),
+            RY(math.pi / 5, 1),
+            RZ(math.pi / 7, 2),
+            CNOT(0, 1),
+            CZ(1, 2),
+            SWAP(3, 4),
+        )
+
+        Circuit.from_pyquil(program)
+
+        assert calls == [
+            ("h", (0,)),
+            ("x", (1,)),
+            ("y", (2,)),
+            ("z", (3,)),
+            ("s", (4,)),
+            ("t", (5,)),
+            ("rx", (math.pi / 3, 0)),
+            ("ry", (math.pi / 5, 1)),
+            ("rz", (math.pi / 7, 2)),
+            ("cnot", (0, 1)),
+            ("cz", (1, 2)),
+            ("swap", (3, 4)),
+        ]
+
+    def test_native_pyquil_bell_pair(self, monkeypatch) -> None:
+        """A hand-written PyQuil Bell pair maps to H and CNOT."""
+        from pyquil import Program
+        from pyquil.gates import CNOT, H
+
+        calls = self._record_gate_calls(monkeypatch)
+        Circuit.from_pyquil(Program(H(0), CNOT(0, 1)))
+
+        assert calls == [("h", (0,)), ("cnot", (0, 1))]
+
+    def test_native_pyquil_swap(self, monkeypatch) -> None:
+        """Native PyQuil SWAP is supported directly."""
+        from pyquil import Program
+        from pyquil.gates import SWAP, X
+
+        calls = self._record_gate_calls(monkeypatch)
+        Circuit.from_pyquil(Program(X(0), SWAP(0, 1)))
+
+        assert calls == [("x", (0,)), ("swap", (0, 1))]
+
+    def test_unsupported_gate_raises_not_implemented(self) -> None:
+        """Quil-native gates outside the canonical set are rejected clearly."""
+        from pyquil import Program
+        from pyquil.gates import CCNOT
+
+        with pytest.raises(NotImplementedError, match="CCNOT"):
+            Circuit.from_pyquil(Program(CCNOT(0, 1, 2)))
+
+    def test_type_error_on_wrong_input(self) -> None:
+        """TypeError raised for non-Program input."""
+        with pytest.raises(TypeError, match="Expected a PyQuil Program"):
+            Circuit.from_pyquil("not a program")
+
+
 class TestFromCirq:
     """Tests for Circuit.from_cirq()."""
 


### PR DESCRIPTION
Closes #4.

## Summary
- add `Circuit.from_pyquil()` for importing concrete `pyquil.Program` instances
- map the canonical Marqov gate set including rotations, CNOT/CZ, and native SWAP
- reject unsupported Quil-native gates with `NotImplementedError`
- add an optional `pyquil` extra and include it in `all`

## Tests
- `.venv312/bin/python -m pytest tests/test_circuits.py::TestFromPyQuil -q` -> 6 passed, 18 warnings
- `.venv312/bin/python -m ruff check marqov/circuits.py tests/test_circuits.py pyproject.toml` -> All checks passed
- `.venv/bin/python -m py_compile marqov/circuits.py tests/test_circuits.py` -> passed
- `git diff --check` -> clean

AI disclosure: this PR was implemented with assistance from OpenAI Codex.