### PR TITLE
feat(benchmarks): add atomic unified executor suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,8 +147,20 @@ check both containers are running with `docker ps`.
 
 ## §5 — Running Benchmarks
 
+The unified suite runs Bell, three-qubit GHZ, and deterministic random depth-5
+circuits. The local executor works without credentials:
+
 ```bash
 python benchmarks/suite.py --executor local --shots 1000
+```
+
+Configured executors can be supplied programmatically:
+
+```python
+from benchmarks.suite import format_table, run_suite
+
+rows = await run_suite({"my-backend": executor}, shots=1000)
+print(format_table(rows))
 ```
 
 Output format — one row per (backend × circuit) combination:
@@ -166,5 +178,5 @@ Columns:
 - `exec_time_ms`: wall time in milliseconds
 - `top_3_outcomes`: counts dict of top 3 measurement outcomes
 
-On executor error: the suite skips that backend, logs the error to stderr, and
-continues — it does not abort.
+On executor error: the suite discards any partial rows for that backend, logs
+the error to stderr, and continues — it does not abort.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Executor-agnostic benchmark utilities."""

--- a/benchmarks/suite.py
+++ b/benchmarks/suite.py
@@ -1,0 +1,153 @@
+"""Run a small, executor-agnostic circuit benchmark suite."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import random
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from marqov.circuits import Circuit
+from marqov.executors.base import BaseExecutor
+from marqov.executors.local import LocalExecutor, LocalExecutorConfig
+
+
+@dataclass(frozen=True)
+class BenchmarkRow:
+    """Result from one executor and circuit combination."""
+
+    backend: str
+    circuit: str
+    shots: int
+    exec_time_ms: float
+    top_3_outcomes: dict[str, int]
+
+
+def build_circuits(seed: int = 0) -> dict[str, Circuit]:
+    """Build the standard Bell, GHZ, and depth-five random circuits."""
+    rng = random.Random(seed)
+    random_circuit = Circuit()
+    single_qubit_gates = (random_circuit.h, random_circuit.x, random_circuit.y)
+    for _ in range(5):
+        for qubit in range(3):
+            rng.choice(single_qubit_gates)(qubit)
+        control = rng.randrange(3)
+        target = (control + rng.choice((1, 2))) % 3
+        random_circuit.cnot(control, target)
+
+    return {
+        "bell": Circuit().h(0).cnot(0, 1),
+        "ghz": Circuit().h(0).cnot(0, 1).cnot(1, 2),
+        "random_d5": random_circuit,
+    }
+
+
+def top_outcomes(counts: Mapping[str, int], limit: int = 3) -> dict[str, int]:
+    """Return the most frequent outcomes with deterministic tie-breaking."""
+    return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:limit])
+
+
+async def run_suite(
+    executors: Mapping[str, BaseExecutor],
+    shots: int = 1000,
+    circuits: Mapping[str, Circuit] | None = None,
+    stderr: TextIO = sys.stderr,
+) -> list[BenchmarkRow]:
+    """Run every circuit on each executor, skipping backends that fail."""
+    benchmark_circuits = circuits or build_circuits()
+    rows: list[BenchmarkRow] = []
+
+    for backend, executor in executors.items():
+        backend_rows: list[BenchmarkRow] = []
+        try:
+            for circuit_name, circuit in benchmark_circuits.items():
+                result = await executor.execute(circuit, shots=shots)
+                backend_rows.append(
+                    BenchmarkRow(
+                        backend=backend,
+                        circuit=circuit_name,
+                        shots=result.shots,
+                        exec_time_ms=result.execution_time_ms,
+                        top_3_outcomes=top_outcomes(result.counts),
+                    )
+                )
+        except Exception as exc:
+            print(f"Skipping backend {backend}: {exc}", file=stderr)
+            continue
+        rows.extend(backend_rows)
+
+    return rows
+
+
+def format_table(rows: Sequence[BenchmarkRow]) -> str:
+    """Format benchmark rows using the documented column layout."""
+    headers = ("backend", "circuit", "shots", "exec_time_ms", "top_3_outcomes")
+    values = [
+        (
+            row.backend,
+            row.circuit,
+            str(row.shots),
+            f"{row.exec_time_ms:.1f}",
+            json.dumps(row.top_3_outcomes, sort_keys=True),
+        )
+        for row in rows
+    ]
+    widths = [
+        max(len(headers[index]), *(len(row[index]) for row in values))
+        for index in range(len(headers))
+    ]
+
+    def format_row(row: Sequence[str]) -> str:
+        return " | ".join(value.ljust(width) for value, width in zip(row, widths)).rstrip()
+
+    separator = " | ".join("-" * width for width in widths)
+    return "\n".join([format_row(headers), separator, *(format_row(row) for row in values)])
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--executor",
+        action="append",
+        choices=("local",),
+        default=None,
+        help="Executor to benchmark; repeat to select multiple executors.",
+    )
+    parser.add_argument("--shots", type=int, default=1000, help="Shots per circuit.")
+    parser.add_argument(
+        "--seed", type=int, default=0, help="Random circuit and local sampler seed."
+    )
+    return parser.parse_args(argv)
+
+
+async def async_main(argv: Sequence[str] | None = None) -> int:
+    """Run the command-line benchmark suite."""
+    args = parse_args(argv)
+    if args.shots <= 0:
+        raise ValueError("--shots must be positive")
+
+    executor_names = args.executor or ["local"]
+    executors = {
+        name: LocalExecutor(LocalExecutorConfig(seed=args.seed)) for name in executor_names
+    }
+    rows = await run_suite(executors, shots=args.shots, circuits=build_circuits(args.seed))
+    print(format_table(rows))
+    return 0 if rows else 1
+
+
+def main() -> int:
+    """Run the benchmark suite CLI."""
+    return asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -1,0 +1,85 @@
+"""Tests for the unified executor benchmark suite."""
+
+from io import StringIO
+
+import pytest
+
+from benchmarks.suite import BenchmarkRow, build_circuits, format_table, run_suite, top_outcomes
+from marqov.circuits import Circuit
+from marqov.executors.base import BaseExecutor, ExecutionResult
+from marqov.executors.local import LocalExecutor, LocalExecutorConfig
+
+
+class FailingExecutor(BaseExecutor):
+    """Executor that always fails, used to verify skip-and-log behavior."""
+
+    async def execute(
+        self, circuit: Circuit, shots: int = 1000, **kwargs: object
+    ) -> ExecutionResult:
+        raise RuntimeError("backend unavailable")
+
+
+@pytest.mark.parametrize(
+    ("name", "num_qubits"),
+    [("bell", 2), ("ghz", 3), ("random_d5", 3)],
+)
+def test_build_circuits(name: str, num_qubits: int) -> None:
+    """The suite contains all documented circuits with the expected width."""
+    circuit = build_circuits()[name]
+    assert len(circuit.simulate().qubits) == num_qubits
+
+
+def test_top_outcomes_limits_and_sorts_counts() -> None:
+    """Only the three most common outcomes are returned."""
+    assert top_outcomes({"11": 2, "00": 4, "10": 3, "01": 2}) == {
+        "00": 4,
+        "10": 3,
+        "01": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_suite_with_local_executor() -> None:
+    """The complete suite runs without credentials on the local executor."""
+    rows = await run_suite(
+        {"local": LocalExecutor(LocalExecutorConfig(seed=0))},
+        shots=100,
+    )
+
+    assert [row.circuit for row in rows] == ["bell", "ghz", "random_d5"]
+    assert all(row.backend == "local" for row in rows)
+    assert all(row.shots == 100 for row in rows)
+    assert all(sum(row.top_3_outcomes.values()) <= 100 for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_run_suite_skips_and_logs_failing_backend() -> None:
+    """A failed backend is logged and does not abort remaining backends."""
+    stderr = StringIO()
+    rows = await run_suite(
+        {
+            "broken": FailingExecutor(),
+            "local": LocalExecutor(LocalExecutorConfig(seed=0)),
+        },
+        shots=10,
+        circuits={"bell": build_circuits()["bell"]},
+        stderr=stderr,
+    )
+
+    assert [row.backend for row in rows] == ["local"]
+    assert "Skipping backend broken: backend unavailable" in stderr.getvalue()
+
+
+def test_format_table_uses_documented_columns() -> None:
+    """Table output exactly uses the documented five-column layout."""
+    table = format_table([BenchmarkRow("local", "bell", 1000, 12.34, {"00": 503, "11": 497})])
+    assert table.splitlines()[0].split(" | ") == [
+        "backend",
+        "circuit",
+        "shots",
+        "exec_time_ms",
+        "top_3_outcomes",
+    ]
+    assert "local" in table
+    assert "12.3" in table
+    assert '{"00": 503, "11": 497}' in table


### PR DESCRIPTION
Closes #5.

## Summary
- add an executor-agnostic `benchmarks/suite.py` for Bell, three-qubit GHZ, and deterministic random depth-5 circuits
- run out of the box with `LocalExecutor`, while accepting arbitrary configured executors through `run_suite()`
- output the exact five documented columns with deterministic top-three outcome ordering
- treat backend execution atomically: on any circuit error, discard partial rows for that backend, log to stderr, skip it, and continue with the next backend
- document CLI and programmatic usage in `CONTRIBUTING.md` and add parametrized/error-path tests

## Verification
- `python benchmarks/suite.py --executor local --shots 100` (runs end-to-end without credentials)
- `python -m pytest tests/test_benchmark_suite.py -q` (`7 passed`)
- `ruff check benchmarks/suite.py tests/test_benchmark_suite.py`
- `ruff format --check benchmarks/suite.py tests/test_benchmark_suite.py`
- `git diff --check`

## Repository-wide notes
- The full test suite currently reports 55 failures caused by optional `qiskit`, `cirq`, and `pennylane` extras not being installed by the `dev` extra.
- Repository-wide Ruff currently reports 153 pre-existing errors outside this change.
- Strict mypy follows imports into existing modules and reports 89 pre-existing errors outside this change.

## AI disclosure
This contribution was developed with OpenAI Codex assistance. I reviewed the implementation, ran the commands listed above, and explicitly tested the real zero-credential `LocalExecutor` path and backend-level skip behavior.