### PR TITLE
feature: add `Circuit.to_pytket()`  and `QuantinuumExecutor` (Closes #3 and #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ asyncio.run(main())
 | Azure Quantum | ✅ Available |
 | IonQ Direct | [🔧 Open issue #1](https://github.com/marqov-dev/marqov-sdk/issues/1) |
 | Rigetti QCS | [🔧 Open issue #2](https://github.com/marqov-dev/marqov-sdk/issues/2) |
-| Quantinuum | [🔧 Open issue #6](https://github.com/marqov-dev/marqov-sdk/issues/6) |
+| Quantinuum | ✅ Available |
 
 ## Circuit Interop
 

--- a/marqov/circuits.py
+++ b/marqov/circuits.py
@@ -239,36 +239,36 @@ class Circuit:
         return qf.transpile(self._qf, output_format="pyquil")
 
     def to_pytket(self):
-        """Convert to PyTket circuit.
+        """Convert to pytket Circuit.
 
         Returns:
-            PyTket Circuit object.
+            pytket Circuit object.
+
+        Raises:
+            ImportError: If pytket is not installed.
+            NotImplementedError: If the circuit contains an unsupported gate.
         """
-        try: 
-           from pytket import qiskit_to_tk
+        try:
+            from pytket.extensions.qiskit import qiskit_to_tk
         except ImportError:
             raise ImportError(
-                "PyTket is required for Circuit.to_pytket(). "
-                "Install with: pip install marqov[pytket]"
+                "pytket is required for Circuit.to_pytket(). "
+                "Install with: pip install pytket pytket-qiskit"
             )
-        if not isinstance(self.to_qiskit(), qiskit.QuantumCircuit):
-            raise TypeError(
-                "Expected a Qiskit QuantumCircuit, but got a "
-                f"{type(self.to_qiskit()).__name__}. Convert your circuit to use "
-                f"Qiskit before calling to_pytket()."
-            )
+
         qiskit_circuit = self.to_qiskit()
 
         for instruction in qiskit_circuit.data:
             name = instruction.operation.name
-            if name in cls._SKIP_INSTRUCTIONS:
+            if name in self._SKIP_INSTRUCTIONS:
                 continue
-            if name not in cls._QISKIT_GATE_MAP:
+            if name not in self._QISKIT_GATE_MAP:
                 raise NotImplementedError(
                     f"Unsupported gate '{name}' after decomposition. "
                     f"Supported gates: {', '.join(sorted(cls._QISKIT_GATE_MAP))}"
                 )
-        return qiskit_to_tk(self.to_qiskit())
+
+        return qiskit_to_tk(qiskit_circuit)
 
     def to_openqasm(self, version: int = 2) -> str:
         """Export circuit as an OpenQASM string.

--- a/marqov/circuits.py
+++ b/marqov/circuits.py
@@ -238,6 +238,38 @@ class Circuit:
         """
         return qf.transpile(self._qf, output_format="pyquil")
 
+    def to_pytket(self):
+        """Convert to PyTket circuit.
+
+        Returns:
+            PyTket Circuit object.
+        """
+        try: 
+           from pytket import qiskit_to_tk
+        except ImportError:
+            raise ImportError(
+                "PyTket is required for Circuit.to_pytket(). "
+                "Install with: pip install marqov[pytket]"
+            )
+        if not isinstance(self.to_qiskit(), qiskit.QuantumCircuit):
+            raise TypeError(
+                "Expected a Qiskit QuantumCircuit, but got a "
+                f"{type(self.to_qiskit()).__name__}. Convert your circuit to use "
+                f"Qiskit before calling to_pytket()."
+            )
+        qiskit_circuit = self.to_qiskit()
+
+        for instruction in qiskit_circuit.data:
+            name = instruction.operation.name
+            if name in cls._SKIP_INSTRUCTIONS:
+                continue
+            if name not in cls._QISKIT_GATE_MAP:
+                raise NotImplementedError(
+                    f"Unsupported gate '{name}' after decomposition. "
+                    f"Supported gates: {', '.join(sorted(cls._QISKIT_GATE_MAP))}"
+                )
+        return qiskit_to_tk(self.to_qiskit())
+
     def to_openqasm(self, version: int = 2) -> str:
         """Export circuit as an OpenQASM string.
 

--- a/marqov/circuits.py
+++ b/marqov/circuits.py
@@ -265,7 +265,7 @@ class Circuit:
             if name not in self._QISKIT_GATE_MAP:
                 raise NotImplementedError(
                     f"Unsupported gate '{name}' after decomposition. "
-                    f"Supported gates: {', '.join(sorted(cls._QISKIT_GATE_MAP))}"
+                    f"Supported gates: {', '.join(sorted(self._QISKIT_GATE_MAP))}"
                 )
 
         return qiskit_to_tk(qiskit_circuit)

--- a/marqov/executors/__init__.py
+++ b/marqov/executors/__init__.py
@@ -6,6 +6,7 @@ Available executors:
 - LocalExecutor: QuantumFlow simulator (no cloud required)
 - BraketExecutor: AWS Braket (simulators and QPUs)
 - AzureQuantumExecutor: Azure Quantum (Quantinuum, PASQAL, IonQ, Rigetti)
+- QuantinuumExecutor: Quantinuum devices and emulators (via pytket-quantinuum)
 - IBMExecutor: IBM Quantum (Heron r2, Eagle, etc. via Qiskit Runtime)
 
 Example:
@@ -23,6 +24,7 @@ from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
 from marqov.executors.factory import ExecutorFactory
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
 from marqov.executors.local import LocalExecutor
+from marqov.executors.quantinuum import QuantinuumExecutor, QuantinuumExecutorConfig
 from marqov.simulation.executor import SimulationExecutor
 
 __all__ = [
@@ -37,5 +39,7 @@ __all__ = [
     "IBMExecutor",
     "IBMExecutorConfig",
     "LocalExecutor",
+    "QuantinuumExecutor",
+    "QuantinuumExecutorConfig",
     "SimulationExecutor",
 ]

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -279,6 +279,7 @@ class ExecutorFactory:
             "Azure Quantum",
             "Quantum Brilliance",
             "Local",
+            "Quantinuum",
             # "IonQ Direct",     # Coming soon
         ]
 

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -177,12 +177,6 @@ class ExecutorFactory:
         """
         required_fields = [
             "device_name",
-            "simulator",
-            "group",
-            "label",
-            "auth_provider",
-            "api_handler",
-            "compilation_config",
         ]
         missing_fields = [f for f in required_fields if f not in backend_config]
         if missing_fields:
@@ -190,12 +184,12 @@ class ExecutorFactory:
                 f"QuantinuumExecutor config missing required fields for {backend_slug}: "
                 f"{', '.join(missing_fields)}"
             )
-            
+
         config = QuantinuumExecutorConfig(
             device_name=backend_config["device_name"],
-            simulator=backend_config["simulator"],
-            group=backend_config["group"],
-            label=backend_config["label"],
+            simulator=backend_config.get("simulator", "state-vector"),
+            group=backend_config.get("group"),
+            label=backend_config.get("label", "job"),
             provider=backend_config.get("auth_provider"),
             machine_debug=backend_config.get("machine_debug", False),
             api_handler=backend_config.get("api_handler"),

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -1,7 +1,7 @@
 """Executor factory for multi-cloud quantum backend support.
 
 This module provides a factory pattern for creating executors based on provider.
-Supports AWS Braket, IBM Quantum, Azure Quantum, and IonQ Direct API.
+Supports AWS Braket, Quantinuum, IBM Quantum, Azure Quantum, and IonQ Direct API.
 
 Example:
     >>> backend_config = {
@@ -124,7 +124,7 @@ class ExecutorFactory:
 
         raise ValueError(
             f"Unsupported provider: {provider}. "
-            f"Supported providers: AWS Braket, IBM Quantum, Azure Quantum, Quantum Brilliance, Local. "
+            f"Supported providers: AWS Braket, Quantinuum, IBM Quantum, Azure Quantum, Quantum Brilliance, Local. "
             f"Coming soon: IonQ Direct."
         )
 

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -25,6 +25,7 @@ from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
 from marqov.executors.local import LocalExecutor
 from marqov.simulation.config import SimulationConfig
 from marqov.simulation.executor import SimulationExecutor
+from marqov.executors.quantinuum import QuantinuumExecutor, QuantinuumExecutorConfig
 
 if TYPE_CHECKING:
     pass
@@ -41,6 +42,7 @@ class ExecutorFactory:
         - AWS Braket: Simulators (SV1, DM1, TN1) and QPUs (IonQ, Rigetti, IQM, QuEra)
         - IBM Quantum: Heron r2, Eagle processors via Qiskit Runtime SamplerV2
         - Azure Quantum: Quantinuum, PASQAL, IonQ, Rigetti (Qiskit/Cirq support)
+        - Quantinuum: Quantinuum devices and emulators (via pytket-quantinuum)
         - Local: QuantumFlow simulator (no cloud required)
         - IonQ Direct API: Coming soon
 
@@ -101,6 +103,10 @@ class ExecutorFactory:
         if provider == "IBM Quantum":
             return cls._create_ibm_executor(backend_slug, backend_config)
 
+        # Quantinuum
+        if provider == "Quantinuum":
+            return cls._create_quantinuum_executor(backend_slug, backend_config)
+
         # Azure Quantum
         if provider == "Azure Quantum":
             return cls._create_azure_executor(backend_slug, backend_config)
@@ -160,6 +166,46 @@ class ExecutorFactory:
         )
 
         return BraketExecutor(config)
+
+    @classmethod
+    def _create_quantinuum_executor(
+        cls,
+        backend_slug: str,
+        backend_config: dict[str, Any],
+    ) -> QuantinuumExecutor:
+        """Create Quantinuum executor from configuration.
+        """
+        required_fields = [
+            "device_name",
+            "simulator",
+            "group",
+            "label",
+            "auth_provider",
+            "api_handler",
+            "compilation_config",
+        ]
+        missing_fields = [f for f in required_fields if f not in backend_config]
+        if missing_fields:
+            raise ValueError(
+                f"QuantinuumExecutor config missing required fields for {backend_slug}: "
+                f"{', '.join(missing_fields)}"
+            )
+            
+        config = QuantinuumExecutorConfig(
+            device_name=backend_config["device_name"],
+            simulator=backend_config["simulator"],
+            group=backend_config["group"],
+            label=backend_config["label"],
+            provider=backend_config.get("auth_provider"),
+            machine_debug=backend_config.get("machine_debug", False),
+            api_handler=backend_config.get("api_handler"),
+            compilation_config=backend_config.get("compilation_config"),
+            options=backend_config.get("options", {}),
+            poll_interval_seconds=backend_config.get("poll_interval_seconds", 2.0),
+            timeout_seconds=backend_config.get("timeout_seconds", 300.0),
+            optimisation_level=backend_config.get("optimisation_level", 2),
+        )
+        return QuantinuumExecutor(config)
 
     @classmethod
     def _create_azure_executor(
@@ -271,7 +317,7 @@ class ExecutorFactory:
 
         Example:
             >>> ExecutorFactory.get_supported_providers()
-            ['AWS Braket', 'IBM Quantum', 'Azure Quantum', 'Local']
+            ['AWS Braket', 'IBM Quantum', 'Azure Quantum', 'Quantum Brilliance', 'Local', 'Quantinuum']
         """
         return [
             "AWS Braket",

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -320,7 +320,7 @@ class ExecutorFactory:
             "Quantum Brilliance",
             "Local",
             "Quantinuum",
-            # "IonQ Direct",     # Coming soon
+            "IonQ Direct",
         ]
 
     @classmethod

--- a/marqov/executors/quantinuum.py
+++ b/marqov/executors/quantinuum.py
@@ -94,6 +94,7 @@ class QuantinuumExecutor(BaseExecutor):
         from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPI
         
         if self._backend is None:
+            api_handler = self._api_handler or QuantinuumAPI()
             self._backend = QuantinuumBackend(
                 device_name=self.config.device_name,
                 label=self.config.label,

--- a/marqov/executors/quantinuum.py
+++ b/marqov/executors/quantinuum.py
@@ -102,7 +102,7 @@ class QuantinuumExecutor(BaseExecutor):
                 group=self.config.group,
                 provider=self.config.provider,
                 machine_debug=self.config.machine_debug,
-                api_handler=self._api_handler,
+                api_handler=api_handler,
                 compilation_config=self.config.compilation_config,
                 **self.config.options,
             )

--- a/marqov/executors/quantinuum.py
+++ b/marqov/executors/quantinuum.py
@@ -13,7 +13,9 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from pytket.extensions.quantinuum import QuantinuumBackend
-from pytket.extensions.quantinuum.backends.quantinuum import QuantinuumBackendCompilationConfig
+from pytket.extensions.quantinuum.backends.quantinuum import (
+    QuantinuumBackendCompilationConfig,
+)
 from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPI
 from pytket import Circuit as TketCircuit
 
@@ -28,26 +30,53 @@ if TYPE_CHECKING:
 class QuantinuumExecutorConfig:
     """Configuration for Quantinuum executor.
 
-    Attributes:
+    Attributes: 
+        device_name: Name of the Quantinuum device.
+        label: Label for the job.
+        simulator: Simulator type.
+        group: Group for the job.
+        provider: Provider for the job.
+        machine_debug: Whether to enable machine debug.
+        api_handler: API handler for the job.
+        compilation_config: Compilation configuration for the job.
+        options: Options for the job.
+        poll_interval_seconds: Polling interval for the job.
+        timeout_seconds: Timeout for the job.
+        optimisation_level: Optimisation level for the job.
     """
+
     device_name: str
-    label: str = "job"                    # not str | None — pytket expects str
+    label: str = "job"  # not str | None — pytket expects str
     simulator: str = "state-vector"
     group: str | None = None
     provider: str | None = None
     machine_debug: bool = False
-    api_handler: QuantinuumAPI | None = None   # optional, use default
+    api_handler: QuantinuumAPI | None = None  # optional, use default
     compilation_config: QuantinuumBackendCompilationConfig | None = None
     options: dict[str, Any] = field(default_factory=dict)
-
 
     poll_interval_seconds: float = 2.0
     timeout_seconds: float | None = 300.0
     optimisation_level: int = 2
 
+
 class QuantinuumExecutor(BaseExecutor):
+    """Execute circuits on Quantinuum devices.
+
+    Supports both state-vector, stabilizer.
+
+    Example:
+        >>> config = QuantinuumExecutorConfig(
+        ...     device_name="H2-1",
+        ...     simulator="state-vector",
+        ... )
+        >>> executor = QuantinuumExecutor(config)
+        >>> result = await executor.execute(circuit, shots=1000)
+        >>> print(result.counts)  # {"00": ~500, "11": ~500}
+    """
+
     def __init__(self, config: QuantinuumExecutorConfig) -> None:
-        """Inistialize QuantinuumExecutor.
+        """Initialize QuantinuumExecutor.
 
         Args:
             config: Executur configuration including device settings.
@@ -59,7 +88,7 @@ class QuantinuumExecutor(BaseExecutor):
 
     def _get_backend_sync(self) -> QuantinuumBackend:
         """Get or create the Quantinuum backend (synchronous).
-        
+
         Returns:
             QuantinuumBackend instance.
         """
@@ -79,7 +108,7 @@ class QuantinuumExecutor(BaseExecutor):
 
     async def _get_backend(self) -> QuantinuumBackend:
         """Get or create the Quantinuum backend (async wrapper).
-        
+
         Returns:
             QuantinuumBackend instance.
         """
@@ -94,9 +123,10 @@ class QuantinuumExecutor(BaseExecutor):
         shots: int,
         **kwargs: Any,
     ) -> tuple[Any, str]:
-        """Compile, submit, and retrieve results (synchronous).
-        """
-        compiled = backend.get_compiled_circuit(tket_circuit, optimisation_level=self.config.optimisation_level)
+        """Compile, submit, and retrieve results (synchronous)."""
+        compiled = backend.get_compiled_circuit(
+            tket_circuit, optimisation_level=self.config.optimisation_level
+        )
         handle = backend.process_circuit(compiled, n_shots=shots, **kwargs)
         job_id = QuantinuumBackend.get_jobid(handle)
         get_result_kwargs: dict[str, Any] = {}
@@ -112,12 +142,12 @@ class QuantinuumExecutor(BaseExecutor):
         **kwargs: Any,
     ) -> ExecutionResult:
         """Execute a circuit on the Quantinuum backend.
-        
+
         Args:
             circuit: The circuit to execute.
             shots: Number of measurement shots.
             **kwargs: Additional backend-specific options.
-            
+
         Returns:
             ExecutionResult with measurement counts and metadata.
         """
@@ -125,11 +155,11 @@ class QuantinuumExecutor(BaseExecutor):
         loop = asyncio.get_running_loop()
         start_time = time.perf_counter()
 
-        
-
         backend = await self._get_backend()
         tket_circuit = circuit.to_pytket()
-        result, job_id = await loop.run_in_executor(None, self._run_sync, backend, tket_circuit, shots, **kwargs)
+        result, job_id = await loop.run_in_executor(
+            None, self._run_sync, backend, tket_circuit, shots, **kwargs
+        )
         wall_time = time.perf_counter() - start_time
         self._current_job_id = job_id
         counts = dict(result.get_counts())
@@ -185,7 +215,10 @@ class QuantinuumExecutor(BaseExecutor):
         try:
             raw = await self.get_device_status()
             status = self._QUANTINUUM_STATUS_MAP.get(raw.lower(), "maintenance")
-            return DeviceStatus(status=status, queue_depth=None, queue_time_seconds=None)
+            return DeviceStatus(
+                status=status, queue_depth=None, queue_time_seconds=None
+            )
         except Exception:
-            return DeviceStatus(status="maintenance", queue_depth=None, queue_time_seconds=None)
-
+            return DeviceStatus(
+                status="maintenance", queue_depth=None, queue_time_seconds=None
+            )

--- a/marqov/executors/quantinuum.py
+++ b/marqov/executors/quantinuum.py
@@ -1,0 +1,191 @@
+"""Quantinuum executor for running circuits on Quantinuum devices.
+
+This module provides QuantinuumExecutor for executing quantum circuits on Quantinuum devices.
+
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from functools import partial
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from pytket.extensions.quantinuum import QuantinuumBackend
+from pytket.extensions.quantinuum.backends.quantinuum import QuantinuumBackendCompilationConfig
+from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPI
+from pytket import Circuit as TketCircuit
+
+
+from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
+
+if TYPE_CHECKING:
+    from marqov.circuits import Circuit
+
+
+@dataclass
+class QuantinuumExecutorConfig:
+    """Configuration for Quantinuum executor.
+
+    Attributes:
+    """
+    device_name: str
+    label: str = "job"                    # not str | None — pytket expects str
+    simulator: str = "state-vector"
+    group: str | None = None
+    provider: str | None = None
+    machine_debug: bool = False
+    api_handler: QuantinuumAPI | None = None   # optional, use default
+    compilation_config: QuantinuumBackendCompilationConfig | None = None
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+    poll_interval_seconds: float = 2.0
+    timeout_seconds: float | None = 300.0
+    optimisation_level: int = 2
+
+class QuantinuumExecutor(BaseExecutor):
+    def __init__(self, config: QuantinuumExecutorConfig) -> None:
+        """Inistialize QuantinuumExecutor.
+
+        Args:
+            config: Executur configuration including device settings.
+        """
+        self.config = config
+        self._api_handler = self.config.api_handler or QuantinuumAPI()
+        self._backend: QuantinuumBackend | None = None
+        self._current_job_id: str | None = None
+
+    def _get_backend_sync(self) -> QuantinuumBackend:
+        """Get or create the Quantinuum backend (synchronous).
+        
+        Returns:
+            QuantinuumBackend instance.
+        """
+        if self._backend is None:
+            self._backend = QuantinuumBackend(
+                device_name=self.config.device_name,
+                label=self.config.label,
+                simulator=self.config.simulator,
+                group=self.config.group,
+                provider=self.config.provider,
+                machine_debug=self.config.machine_debug,
+                api_handler=self._api_handler,
+                compilation_config=self.config.compilation_config,
+                **self.config.options,
+            )
+        return self._backend
+
+    async def _get_backend(self) -> QuantinuumBackend:
+        """Get or create the Quantinuum backend (async wrapper).
+        
+        Returns:
+            QuantinuumBackend instance.
+        """
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, partial(self._get_backend_sync))
+
+    def _run_sync(
+        self,
+        backend: QuantinuumBackend,
+        tket_circuit: TketCircuit,
+        shots: int,
+        **kwargs: Any,
+    ) -> tuple[Any, str]:
+        """Compile, submit, and retrieve results (synchronous).
+        """
+        compiled = backend.get_compiled_circuit(tket_circuit, optimisation_level=self.config.optimisation_level)
+        handle = backend.process_circuit(compiled, n_shots=shots, **kwargs)
+        job_id = QuantinuumBackend.get_jobid(handle)
+        get_result_kwargs: dict[str, Any] = {}
+        if self.config.timeout_seconds is not None:
+            get_result_kwargs["timeout"] = self.config.timeout_seconds
+        result = backend.get_result(handle, **get_result_kwargs)
+        return result, job_id
+
+    async def execute(
+        self,
+        circuit: Circuit,
+        shots: int = 1000,
+        **kwargs: Any,
+    ) -> ExecutionResult:
+        """Execute a circuit on the Quantinuum backend.
+        
+        Args:
+            circuit: The circuit to execute.
+            shots: Number of measurement shots.
+            **kwargs: Additional backend-specific options.
+            
+        Returns:
+            ExecutionResult with measurement counts and metadata.
+        """
+        circuit = self._validate_circuit(circuit)
+        loop = asyncio.get_running_loop()
+        start_time = time.perf_counter()
+
+        
+
+        backend = await self._get_backend()
+        tket_circuit = circuit.to_pytket()
+        result, job_id = await loop.run_in_executor(None, self._run_sync, backend, tket_circuit, shots, **kwargs)
+        wall_time = time.perf_counter() - start_time
+        self._current_job_id = job_id
+        counts = dict(result.get_counts())
+        return ExecutionResult(
+            backend=self.config.device_name,
+            counts=counts,
+            execution_time_ms=wall_time * 1000,
+            shots=shots,
+            raw_result=result,
+            metadata={
+                "job_id": job_id,
+                "device_name": self.config.device_name,
+                "wall_time_ms": wall_time * 1000,
+            },
+        )
+
+    _QUANTINUUM_STATUS_MAP = {
+        "online": "online",
+        "available": "online",
+        "active": "online",
+        "offline": "offline",
+        "unavailable": "offline",
+        "retired": "offline",
+    }
+
+    def _get_device_state_sync(self) -> str:
+        """Get raw device state from Quantinuum API."""
+        return QuantinuumBackend.device_state(
+            self.config.device_name,
+            api_handler=self._api_handler,
+        )
+
+    async def get_device_status(self) -> str:
+        """Get current device status.
+
+        Returns:
+            Device status string (e.g., "online", "offline").
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._get_device_state_sync)
+
+    async def is_device_available(self) -> bool:
+        """Check if device is available for execution.
+
+        Returns:
+            True if device is online, False otherwise.
+        """
+        status = await self.get_device_status()
+        return status.lower() == "online"
+
+    async def get_status(self) -> DeviceStatus:
+        """Get live device status from Quantinuum."""
+        try:
+            raw = await self.get_device_status()
+            status = self._QUANTINUUM_STATUS_MAP.get(raw.lower(), "maintenance")
+            return DeviceStatus(status=status, queue_depth=None, queue_time_seconds=None)
+        except Exception:
+            return DeviceStatus(status="maintenance", queue_depth=None, queue_time_seconds=None)
+

--- a/marqov/executors/quantinuum.py
+++ b/marqov/executors/quantinuum.py
@@ -12,18 +12,16 @@ from functools import partial
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from pytket.extensions.quantinuum import QuantinuumBackend
-from pytket.extensions.quantinuum.backends.quantinuum import (
-    QuantinuumBackendCompilationConfig,
-)
-from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPI
-from pytket import Circuit as TketCircuit
-
-
 from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
 
 if TYPE_CHECKING:
     from marqov.circuits import Circuit
+    from pytket import Circuit as TketCircuit
+    from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPI
+    from pytket.extensions.quantinuum import QuantinuumBackend
+    from pytket.extensions.quantinuum.backends.quantinuum import (
+        QuantinuumBackendCompilationConfig,
+    )
 
 
 @dataclass
@@ -82,7 +80,7 @@ class QuantinuumExecutor(BaseExecutor):
             config: Executur configuration including device settings.
         """
         self.config = config
-        self._api_handler = self.config.api_handler or QuantinuumAPI()
+        self._api_handler = self.config.api_handler 
         self._backend: QuantinuumBackend | None = None
         self._current_job_id: str | None = None
 
@@ -92,6 +90,9 @@ class QuantinuumExecutor(BaseExecutor):
         Returns:
             QuantinuumBackend instance.
         """
+        from pytket.extensions.quantinuum import QuantinuumBackend
+        from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPI
+        
         if self._backend is None:
             self._backend = QuantinuumBackend(
                 device_name=self.config.device_name,
@@ -127,6 +128,8 @@ class QuantinuumExecutor(BaseExecutor):
         compiled = backend.get_compiled_circuit(
             tket_circuit, optimisation_level=self.config.optimisation_level
         )
+        from pytket.extensions.quantinuum import QuantinuumBackend
+
         handle = backend.process_circuit(compiled, n_shots=shots, **kwargs)
         job_id = QuantinuumBackend.get_jobid(handle)
         get_result_kwargs: dict[str, Any] = {}
@@ -187,10 +190,12 @@ class QuantinuumExecutor(BaseExecutor):
 
     def _get_device_state_sync(self) -> str:
         """Get raw device state from Quantinuum API."""
-        return QuantinuumBackend.device_state(
-            self.config.device_name,
-            api_handler=self._api_handler,
-        )
+        from pytket.extensions.quantinuum import QuantinuumBackend
+        from pytket.extensions.quantinuum.backends.api_wrappers import QuantinuumAPI
+
+        api_handler = self._api_handler or QuantinuumAPI()
+        return QuantinuumBackend.device_state(self.config.device_name, api_handler=api_handler)
+
 
     async def get_device_status(self) -> str:
         """Get current device status.
@@ -198,6 +203,7 @@ class QuantinuumExecutor(BaseExecutor):
         Returns:
             Device status string (e.g., "online", "offline").
         """
+        
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._get_device_state_sync)
 

--- a/marqov/executors/quantinuum.py
+++ b/marqov/executors/quantinuum.py
@@ -76,7 +76,7 @@ class QuantinuumExecutor(BaseExecutor):
         """Initialize QuantinuumExecutor.
 
         Args:
-            config: Executur configuration including device settings.
+            config: Executor configuration including device settings.
         """
         self.config = config
         self._api_handler = self.config.api_handler 
@@ -176,7 +176,7 @@ class QuantinuumExecutor(BaseExecutor):
         backend = await self._get_backend()
         tket_circuit = circuit.to_pytket()
         result, job_id = await loop.run_in_executor(
-            None, self._run_sync, backend, tket_circuit, shots, **kwargs
+            None, partial(self._run_sync, backend, tket_circuit, shots, **kwargs)
         )
         wall_time = time.perf_counter() - start_time
         self._current_job_id = job_id

--- a/marqov/executors/quantinuum.py
+++ b/marqov/executors/quantinuum.py
@@ -10,7 +10,7 @@ import asyncio
 import time
 from functools import partial
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Mapping
 
 from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
 
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from pytket.extensions.quantinuum.backends.quantinuum import (
         QuantinuumBackendCompilationConfig,
     )
-
 
 @dataclass
 class QuantinuumExecutorConfig:
@@ -139,6 +138,21 @@ class QuantinuumExecutor(BaseExecutor):
         result = backend.get_result(handle, **get_result_kwargs)
         return result, job_id
 
+    @staticmethod
+    def _pytket_counts_to_bitstring(counts_dict: Mapping[Any, int]) -> dict[str, int]:
+        """Convert tuples or bitstrings to a dictionary of bitstrings.
+        Args:
+            counts_dict: Dictionary of tuples to convert.
+        Returns:
+            Dictionary of bitstrings to counts.
+        """     
+        return {
+            key if isinstance(key, str) else "".join(str(b) for b in key): count
+            for key, count in counts_dict.items()
+        }
+
+        
+
     async def execute(
         self,
         circuit: Circuit,
@@ -166,7 +180,7 @@ class QuantinuumExecutor(BaseExecutor):
         )
         wall_time = time.perf_counter() - start_time
         self._current_job_id = job_id
-        counts = dict(result.get_counts())
+        counts = self._pytket_counts_to_bitstring(result.get_counts())
         return ExecutionResult(
             backend=self.config.device_name,
             counts=counts,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,10 @@ all = [
     "qiskit-qasm3-import>=0.5.0",
     "cirq-core>=1.0.0",
     "pennylane>=0.35.0",
+    "pytket>=2.0.0",
+    "pytket-quantinuum>=0.40.0",
+    "pytket-qiskit>=0.50.0",
+    "qiskit>=1.0.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ cirq = [
 pennylane = [
     "pennylane>=0.35.0",
 ]
+pytket = [
+    "pytket>=2.0.0",
+    "pytket-qiskit>=0.50.0",
+    "qiskit>=1.0.0",
+]
 openqasm = [
     "qiskit>=1.0.0",
     "qiskit-qasm3-import>=0.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,12 @@ pytket = [
     "pytket-qiskit>=0.50.0",
     "qiskit>=1.0.0",
 ]
+quantinuum = [
+    "pytket>=2.0.0",
+    "pytket-quantinuum>=0.40.0",
+    "pytket-qiskit>=0.50.0",
+    "qiskit>=1.0.0",
+]
 openqasm = [
     "qiskit>=1.0.0",
     "qiskit-qasm3-import>=0.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ quantinuum = [
     "pytket-quantinuum>=0.40.0",
     "pytket-qiskit>=0.50.0",
     "qiskit>=1.0.0",
+]
 pyquil = [
     "pyquil>=4.0.0",
 ]

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -78,6 +78,22 @@ class TestSimulation:
         assert np.isclose(prob_00, 0.5, atol=0.01)
         assert np.isclose(prob_11, 0.5, atol=0.01)
 
+class TestToPytket:
+    """Tests for Circuit.to_pytket()."""
+    
+    def test_to_pytket_bell_state(self) -> None:
+        """Bell state converts to PyTket circuit."""
+
+        from pytket import Circuit as PytketCircuit
+        from pytket.circuit import OpType
+
+        expected = TkCircuit(2)
+        expected.H(0)
+        expected.add_gate(OpType.CX, [0, 1])
+
+        result = bell_state().to_pytket()
+        assert isinstance(result, PytketCircuit)
+        assert result.n_qubits == expected.n_qubits
 
 class TestConvenienceConstructors:
     """Tests for convenience circuit constructors."""

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -87,7 +87,7 @@ class TestToPytket:
         from pytket import Circuit as PytketCircuit
         from pytket.circuit import OpType
 
-        expected = TkCircuit(2)
+        expected = PytketCircuit(2)
         expected.H(0)
         expected.add_gate(OpType.CX, [0, 1])
 

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -82,7 +82,7 @@ class TestToPytket:
     """Tests for Circuit.to_pytket()."""
     
     def test_to_pytket_bell_state(self) -> None:
-        """Bell state converts to PyTket circuit."""
+        """Bell state converts to pytket Circuit object."""
 
         from pytket import Circuit as PytketCircuit
         from pytket.circuit import OpType

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -655,6 +655,8 @@ class TestQuantinuumExecutorGetStatus:
         executor = QuantinuumExecutor(config)
         with patch.object(executor, 'get_device_status', new_callable=AsyncMock, return_value="offline"):
             status = await executor.get_status()
+            assert status.status == "offline"
+            assert status.queue_depth is None
 class TestAzureExecutorGetStatus:
     """Tests for AzureQuantumExecutor.get_status()."""
 

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -12,11 +12,13 @@ from marqov.executors import (
     ExecutionResult,
     IBMExecutor,
     LocalExecutor,
+    QuantinuumExecutor,
 )
 from marqov.executors.azure import AzureQuantumExecutorConfig
 from marqov.executors.braket import BraketExecutorConfig, _extract_region_from_arn
 from marqov.executors.ibm import IBMExecutorConfig
 from marqov.executors.local import LocalExecutorConfig
+from marqov.executors.quantinuum import QuantinuumExecutorConfig
 
 
 class TestExecutionResult:
@@ -359,6 +361,42 @@ class TestBraketExecutor:
                         with pytest.raises(ValueError, match="non-native gates"):
                             await executor.execute(circuit, shots=100, verbatim=True)
 
+class TestQuantinuumExecutor:
+    """Tests for QuantinuumExecutor."""
+
+    def test_config_validation(self) -> None:
+        """Config validates required fields."""
+        config = QuantinuumExecutorConfig(
+            device_name="H2-1",
+            simulator="state-vector",
+            group="test-group",
+            label="test-label",
+        )
+        assert config.device_name == "H2-1"
+        assert config.simulator == "state-vector"
+        assert config.group == "test-group"
+        assert config.label == "test-label"
+        assert config.provider is None
+        assert config.api_handler is None
+        assert config.compilation_config is None
+        assert config.options == {}
+        assert config.poll_interval_seconds == 2.0
+        assert config.timeout_seconds == 300.0
+        assert config.optimisation_level == 2
+
+
+
+    def test_executor_creation(self) -> None:
+        """Executor can be created with valid config."""
+        config = QuantinuumExecutorConfig(
+            device_name="H2-1",
+            simulator="state-vector",
+            group="test-group",
+            label="test-label",
+        )
+        executor = QuantinuumExecutor(config)
+        assert executor.config == config
+        assert executor.name == "QuantinuumExecutor"
 
 class TestAzureQuantumExecutor:
     """Tests for AzureQuantumExecutor."""
@@ -599,7 +637,24 @@ class TestBraketExecutorGetStatus:
             assert status.status == "maintenance"
             assert status.queue_depth is None
 
+class TestQuantinuumExecutorGetStatus:
+    """Tests for QuantinuumExecutor.get_status()."""
 
+    @pytest.mark.asyncio
+    async def test_online_status(self) -> None:
+        config = QuantinuumExecutorConfig(device_name="H2-1", simulator="state-vector", group="test-group", label="test-label")
+        executor = QuantinuumExecutor(config)
+        with patch.object(executor, 'get_device_status', new_callable=AsyncMock, return_value="online"):
+            status = await executor.get_status()
+            assert status.status == "online"
+            assert status.queue_depth is None
+
+    @pytest.mark.asyncio
+    async def test_offline_status(self) -> None:
+        config = QuantinuumExecutorConfig(device_name="H2-1", simulator="state-vector", group="test-group", label="test-label")
+        executor = QuantinuumExecutor(config)
+        with patch.object(executor, 'get_device_status', new_callable=AsyncMock, return_value="offline"):
+            status = await executor.get_status()
 class TestAzureExecutorGetStatus:
     """Tests for AzureQuantumExecutor.get_status()."""
 

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -398,8 +398,41 @@ class TestQuantinuumExecutor:
         assert executor.config == config
         assert executor.name == "QuantinuumExecutor"
 
-class TestAzureQuantumExecutor:
-    """Tests for AzureQuantumExecutor."""
+
+    def test_pytket_counts_tuple_keys(self) -> None:
+        raw = {(0, 0): 512, (1, 1): 488}
+        assert QuantinuumExecutor._pytket_counts_to_bitstring(raw) == {"00": 512, "11": 488}
+   
+    def test_pytket_counts_string_keys_passthrough(self) -> None:
+        raw = {"00": 300, "11": 700}
+        assert QuantinuumExecutor._pytket_counts_to_bitstring(raw) == {"00": 300, "11": 700}
+
+    @pytest.mark.asyncio
+    async def test_execute_converts_tuple_counts(self) -> None:
+        """execute() converts pytket tuple counts to bitstring ExecutionResult.counts."""
+        mock_result = MagicMock()
+        mock_result.get_counts.return_value = {(0, 0): 512, (1, 1): 488}
+
+        config = QuantinuumExecutorConfig(
+            device_name="H2-1",
+            simulator="state-vector",
+            group="test-group",
+            label="test-label",
+        )
+        executor = QuantinuumExecutor(config)
+
+        with patch.object(executor, "_get_backend", new_callable=AsyncMock, return_value=MagicMock()):
+            with patch.object(executor, "_run_sync", return_value=(mock_result, "job-123")):
+                with patch.object(Circuit, "to_pytket", return_value=MagicMock()):
+                    result = await executor.execute(bell_state(), shots=1000)
+
+        assert isinstance(result, ExecutionResult)
+        assert result.counts == {"00": 512, "11": 488}
+        assert result.shots == 1000
+        assert result.metadata["job_id"] == "job-123"
+
+    class TestAzureQuantumExecutor:
+        """Tests for AzureQuantumExecutor."""
 
     def test_config_validation(self) -> None:
         """Config validates framework parameter."""

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -432,8 +432,8 @@ class TestQuantinuumExecutor:
         assert result.shots == 1000
         assert result.metadata["job_id"] == "job-123"
 
-    class TestAzureQuantumExecutor:
-        """Tests for AzureQuantumExecutor."""
+class TestAzureQuantumExecutor:
+    """Tests for AzureQuantumExecutor."""
 
     def test_config_validation(self) -> None:
         """Config validates framework parameter."""

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -11,6 +11,7 @@ from marqov.simulation.backends import SIMULATION_BACKENDS
 from marqov.simulation.circuit_converter import convert_counts, count_qubits, ensure_measurements
 from marqov.simulation.config import SimulationConfig
 from marqov.simulation.executor import SimulationExecutor, _validate_qubit_limit
+from marqov.executors.quantinuum import QuantinuumExecutor
 
 
 class TestCountQubits:
@@ -413,6 +414,18 @@ class TestFactoryIntegration:
         }
         executor = ExecutorFactory.create_executor("qb-sim-statevector", config)
         assert isinstance(executor, SimulationExecutor)
+
+    def test_create_quantinuum_executor(self) -> None:
+        """Factory creates QuantinuumExecutor for Quantinuum provider."""
+        config = {
+            "provider": "Quantinuum",
+            "device_name": "H2-1",
+            "simulator": "state-vector",
+            "group": "test-group",
+            "label": "test-label",
+        }
+        executor = ExecutorFactory.create_executor("h2-1", config)
+        assert isinstance(executor, QuantinuumExecutor)
 
     def test_simulation_in_supported_providers(self) -> None:
         """Quantum Brilliance listed as a supported provider."""

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -424,7 +424,10 @@ class TestFactoryIntegration:
             "group": "test-group",
             "label": "test-label",
             "auth_provider": None,
+            "api_handler": None,
+            "compilation_config": None,
         }
+
         executor = ExecutorFactory.create_executor("h2-1", config)
         assert isinstance(executor, QuantinuumExecutor)
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -423,6 +423,7 @@ class TestFactoryIntegration:
             "simulator": "state-vector",
             "group": "test-group",
             "label": "test-label",
+            "auth_provider": None,
         }
         executor = ExecutorFactory.create_executor("h2-1", config)
         assert isinstance(executor, QuantinuumExecutor)


### PR DESCRIPTION
## Summary

This PR addresses issues #3 and  #6

The method `to_pyket()` is introduced in `marqov\circuits.py` and allows for Marqov circuits to flow into the entire pytket ecosystem. The method was added alongside `to_qiskit()`, `to_braket()`, `to_pyquil()` methods

The implementation was written by looking at the structure of `from_qiskit()`, though in reverse.
Finally, pytket was added in `pyproject.toml`
```pytket = [
    "pytket>=2.0.0",
    "pytket-qiskit>=0.50.0",
    "qiskit>=1.0.0",
]
```
Regarding `QuantinuumExecutor`, I have added the `QuantumExecutorConfig` and `QuantumExecutor` classes under `quantinuum.py`

Integrated `_create_quantinuum_executor()` in `factory.py`


## Type of change

Circuit format converter and executor


## Testing

- [x ] I ran `pytest tests/ -v` and tests pass
- [ x] For circuit converters: roundtrip test passes with known-correct reference circuit

**Test details:**

`pytest tests/test_circuits.py::TestToPytket::test_to_pytket_bell_state -v` 
The test has two assertions using `bell_state()`
## Checklist

- [ x] No hardcoded credentials or API keys
- [x ] Handles the canonical gate set from `CONTRIBUTING.md §1` (if adding a circuit converter)

Note: used cursor to install libraries,