### PR TITLE
feature: add Circuit.from_pyquil() import  (Closes #4)

### DIFF
--- a/marqov/circuits.py
+++ b/marqov/circuits.py
@@ -293,6 +293,20 @@ class Circuit:
         circuit._qf = qf.braket_to_circuit(braket_circuit)
         return circuit
 
+    @classmethod
+    def from_pyquil(cls, program: pyquil.Program) -> "Circuit":
+        """Import from existing PyQuil program.
+
+        Args:
+            pyquil_program: PyQuil Program to import.
+
+        Returns:
+            New Circuit instance.
+        """  
+        circuit = cls()
+        circuit._qf = qf.pyquil_to_circuit(program)
+        return circuit
+        
     # Qiskit gate name -> Circuit fluent method mapping.
     # Used by from_qiskit() to convert decomposed Qiskit circuits.
     _QISKIT_GATE_MAP: dict[str, str] = {
@@ -512,6 +526,7 @@ class Circuit:
                 gate_type = type(op.gate).__name__ if op.gate else type(op).__name__
                 try:
                     import sentry_sdk
+
                     sentry_sdk.capture_message(
                         f"Circuit.from_cirq(): unmappable gate '{gate_type}'",
                         level="warning",
@@ -630,6 +645,7 @@ class Circuit:
                 # Decomposition failed — log to Sentry and raise.
                 try:
                     import sentry_sdk
+
                     sentry_sdk.capture_message(
                         f"Circuit.from_pennylane(): unmappable gate '{name}'",
                         level="warning",
@@ -695,11 +711,13 @@ class Circuit:
             gate_name = op.name
             qubits = list(op.qubits)
             params = list(op.params) if hasattr(op, "params") and op.params else []
-            gates.append({
-                "gate": gate_name,
-                "qubits": qubits,
-                "params": params,
-            })
+            gates.append(
+                {
+                    "gate": gate_name,
+                    "qubits": qubits,
+                    "params": params,
+                }
+            )
         return {"gates": gates}
 
     @classmethod

--- a/marqov/circuits.py
+++ b/marqov/circuits.py
@@ -293,20 +293,89 @@ class Circuit:
         circuit._qf = qf.braket_to_circuit(braket_circuit)
         return circuit
 
+    # PyQuil gate name -> Circuit fluent method mapping.
+    # Used by from_pyquil() to convert decomposed PyQuil circuits.
+    _PYQUIL_GATE_MAP: dict[str, str] = {
+        "H": "h",
+        "X": "x",
+        "Y": "y",
+        "Z": "z",
+        "S": "s",
+        "T": "t",
+        "RX": "rx",
+        "RY": "ry",
+        "RZ": "rz",
+        "CNOT": "cnot",
+        "CZ": "cz",
+        "SWAP": "swap",
+    }
+
+    # Gates that take rotation angle parameters.
+    _PYQUIL_ROTATION_GATES: set[str] = {"RX", "RY", "RZ"}
+
     @classmethod
     def from_pyquil(cls, program: pyquil.Program) -> "Circuit":
         """Import from existing PyQuil program.
+
+        Requires PyQuil to be installed (``pip install marqov[pyquil]``).
 
         Args:
             pyquil_program: PyQuil Program to import.
 
         Returns:
             New Circuit instance.
-        """  
+
+        Raises:
+            ImportError: If PyQuil is not installed.
+            TypeError: If the input is not a PyQuil Program.
+            NotImplementedError: If a gate cannot be mapped after decomposition.
+        """
+
+        try:
+            from pyquil import Program
+            from pyquil.quilbase import Gate, Declare, Halt, Measurement, Pragma
+
+        except ImportError:
+            raise ImportError(
+                "PyQuil is required for Circuit.from_pyquil(). "
+                "Install with: pip install marqov[pyquil]"
+            )
+
+        if not isinstance(program, Program):
+            raise TypeError(
+                f"Expected a PyQuil Program, got {type(program).__name__}"
+            )
+
         circuit = cls()
-        circuit._qf = qf.pyquil_to_circuit(program)
+
+        for instruction in program.instructions:
+
+            if isinstance(instruction, (Declare, Halt, Measurement, Pragma)):
+                continue
+            if not isinstance(instruction, Gate):
+                raise NotImplementedError(
+                    f"Unsupported instruction '{type(instruction).__name__}' in PyQuil program. "
+                )
+
+            name = instruction.name
+
+            if name not in cls._PYQUIL_GATE_MAP:
+                raise NotImplementedError(
+                    f"Unsupported gate '{name}' in PyQuil program. "
+                    f"Supported gates: {', '.join(sorted(cls._PYQUIL_GATE_MAP))}"
+                )
+
+            qubits = [q.index for q in instruction.qubits]
+            method_name = cls._PYQUIL_GATE_MAP[name]
+
+            if name in cls._PYQUIL_ROTATION_GATES:
+                getattr(circuit, method_name)(float(instruction.params[0]), qubits[0])
+            elif len(qubits) == 1:
+                getattr(circuit, method_name)(qubits[0])
+            else:
+                getattr(circuit, method_name)(qubits[0], qubits[1])
         return circuit
-        
+
     # Qiskit gate name -> Circuit fluent method mapping.
     # Used by from_qiskit() to convert decomposed Qiskit circuits.
     _QISKIT_GATE_MAP: dict[str, str] = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ pennylane = [
     "pennylane>=0.35.0",
 ]
 pyquil = [
-    "pyquil>=4.0.0",
+    "pyquil>=4.0.0,<4.17",
 ]
 openqasm = [
     "qiskit>=1.0.0",
@@ -64,6 +64,7 @@ all = [
     "qiskit-qasm3-import>=0.5.0",
     "cirq-core>=1.0.0",
     "pennylane>=0.35.0",
+    "pyquil>=4.0.0,<4.17",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,10 @@ pennylane = [
     "pennylane>=0.35.0",
 ]
 pyquil = [
-    "pyquil>=4.0.0,<4.17",
+    # pyquil 4.x requires Python <3.13 and quil <0.18 (see CONTRIBUTING.md setup)
+    "pyquil>=4.16,<4.17",
+    "quil>=0.15.3,<0.18",
+    "qcs-sdk-python>=0.20.1,<0.22",
 ]
 openqasm = [
     "qiskit>=1.0.0",
@@ -64,7 +67,9 @@ all = [
     "qiskit-qasm3-import>=0.5.0",
     "cirq-core>=1.0.0",
     "pennylane>=0.35.0",
-    "pyquil>=4.0.0,<4.17",
+    "pyquil>=4.16,<4.17",
+    "quil>=0.15.3,<0.18",
+    "qcs-sdk-python>=0.20.1,<0.22",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ cirq = [
 pennylane = [
     "pennylane>=0.35.0",
 ]
+pyquil = [
+    "pyquil>=4.0.0",
+]
 openqasm = [
     "qiskit>=1.0.0",
     "qiskit-qasm3-import>=0.5.0",

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -111,6 +111,27 @@ class TestBackendConversion:
         imported = Circuit.from_braket(braket_circuit)
         assert imported.num_qubits == original.num_qubits
 
+class TestFromPyquil:
+    """Tests for Circuit.from_pyquil()."""
+
+    def test_from_pyquil_roundtrip(self) -> None:
+        """Import from PyQuil preserves circuit structure."""
+        original = Circuit().h(0).cnot(0, 1)
+        pyquil_program = original.to_pyquil()
+        imported = Circuit.from_pyquil(pyquil_program)
+        assert imported.num_qubits == original.num_qubits
+    
+    def test_from_pyquil_swap_roundtrip(self) -> None:
+        """Import from PyQuil preserves swap gate."""
+        import numpy as np
+
+        original = Circuit().swap(0, 1)
+        imported = Circuit.from_pyquil(original.to_pyquil())
+
+        orig_amps = original.simulate().tensor.flatten()
+        imported_amps = imported.simulate().tensor.flatten()
+        assert np.allclose(np.abs(orig_amps), np.abs(imported_amps))
+
 
 class TestFromQiskit:
     """Tests for Circuit.from_qiskit()."""

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -116,10 +116,15 @@ class TestFromPyquil:
 
     def test_from_pyquil_roundtrip(self) -> None:
         """Import from PyQuil preserves circuit structure."""
-        original = Circuit().h(0).cnot(0, 1)
+        import numpy as np
+
+        original = bell_state()
         pyquil_program = original.to_pyquil()
         imported = Circuit.from_pyquil(pyquil_program)
-        assert imported.num_qubits == original.num_qubits
+
+        orig_amps = original.simulate().tensor.flatten()
+        imported_amps = imported.simulate().tensor.flatten()
+        assert np.allclose(np.abs(orig_amps), np.abs(imported_amps))
     
     def test_from_pyquil_swap_roundtrip(self) -> None:
         """Import from PyQuil preserves swap gate."""


### PR DESCRIPTION
## Summary

This PR resolves issues #4 implementing the equivalent of `from_qiskit()` for pyquil by adding a method `Circuit.from_pyquil()`

## Type of change

Changes were introduced in `marqov\circuits.py`

The implementation was written by looking at the structure of from_qiskit(), though using different dictionary for 
```   
 _PYQUIL_GATE_MAP: dict[str, str] = {
        "H": "h",
        "X": "x",
        "Y": "y",
        "Z": "z",
        "S": "s",
        "T": "t",
        "RX": "rx",
        "RY": "ry",
        "RZ": "rz",
        "CNOT": "cnot",
        "CZ": "cz",
        "SWAP": "swap",
    }
```

Finally, pyquil was added in pyproject.toml

```
pyquil = 
    "pyquil>=4.16,<4.17",
    "quil>=0.15.3,<0.18",
    "qcs-sdk-python>=0.20.1,<0.22",
]
```

- [x ] Circuit format converter


## Testing

- [ x] I ran `pytest tests/ -v` and tests pass
- [ x] For circuit converters: roundtrip test passes with known-correct reference circuit

**Test details:**

Tested roudtrip `circuit → to_pyquil() → from_pyquil() → circuit` via
`def test_from_pyquil_swap_roundtrip()` and ` def test_from_pyquil_roundtrip()`
To check run:

```bash
 python -m pytest tests/test_circuits.py::TestFromPyquil -v
```

## Checklist

- [x ] No hardcoded credentials or API keys
- [x ] Handles the canonical gate set from `CONTRIBUTING.md §1` (if adding a circuit converter)

**Note**: Please note I used Cursor for debugging. In particular, I had initially installed Python 3.13, which was breaking my tests, and I was able to identify that I needed Python version 3.12.
