### PR TITLE
feat(benchmarks): unified multi-backend benchmark suite (#5)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,24 +147,54 @@ check both containers are running with `docker ps`.
 
 ## §5 — Running Benchmarks
 
+`benchmarks/suite.py` runs a fixed set of reference circuits — Bell, 3-qubit
+GHZ, and a deterministic depth-5 random circuit — against any configured
+executor and prints a comparison table. It works out of the box with
+`LocalExecutor`, so no credentials are required:
+
 ```bash
-python benchmarks/suite.py --executor local --shots 1000
+python benchmarks/suite.py --executor local --shots 1000 --seed 1234
 ```
 
 Output format — one row per (backend × circuit) combination:
 
-| backend | circuit   | shots | exec_time_ms | top_3_outcomes         |
-|---------|-----------|-------|--------------|------------------------|
-| local   | bell      | 1000  | 12.3         | {"00": 503, "11": 497} |
-| local   | ghz       | 1000  | 18.1         | {"000": 998, "111": 2} |
-| local   | random_d5 | 1000  | 24.7         | {"010": 312, ...}      |
+| backend | circuit   | shots | exec_time_ms | top_3_outcomes                       |
+|---------|-----------|-------|--------------|--------------------------------------|
+| local   | bell      | 1000  | 0.4          | {"11": 502, "00": 498}               |
+| local   | ghz       | 1000  | 0.4          | {"111": 524, "000": 476}             |
+| local   | random_d5 | 1000  | 0.4          | {"010": 262, "100": 254, "110": 243} |
 
 Columns:
 - `backend`: executor name
 - `circuit`: circuit name (`bell`, `ghz`, `random_d5`)
 - `shots`: number of shots
-- `exec_time_ms`: wall time in milliseconds
-- `top_3_outcomes`: counts dict of top 3 measurement outcomes
+- `exec_time_ms`: wall time in milliseconds (varies per run and machine)
+- `top_3_outcomes`: counts of the 3 most frequent measurement outcomes, ordered
+  by count descending
 
-On executor error: the suite skips that backend, logs the error to stderr, and
-continues — it does not abort.
+The measurement outcomes above are reproducible for a fixed `--seed` (it seeds
+both the random circuit and the local sampler); `exec_time_ms` is wall time and
+will differ on your machine.
+
+**Error handling.** If a backend errors on any circuit, the suite skips that
+*entire* backend (it emits no partial rows for it), logs the backend and the
+failing circuit to stderr, and continues with the next backend — it never
+aborts. If every backend fails the command exits non-zero, so CI can flag a
+fully broken run.
+
+**Benchmarking other backends.** The CLI only constructs the zero-credential
+`local` executor, but `run_suite()` is executor-agnostic — pass a mapping of
+name → `BaseExecutor` to benchmark cloud backends programmatically:
+
+```python
+import asyncio
+from benchmarks.suite import run_suite, format_table
+from marqov.executors import ExecutorFactory, LocalExecutor
+
+executors = {
+    "local": LocalExecutor(),
+    "sv1": ExecutorFactory.create_executor("sv1", braket_config),
+}
+rows = asyncio.run(run_suite(executors, shots=1000))
+print(format_table(rows))
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,10 @@ The measurement outcomes above are reproducible for a fixed `--seed` (it seeds
 both the random circuit and the local sampler); `exec_time_ms` is wall time and
 will differ on your machine.
 
+**Scope.** The suite compares execution time and outcome distribution only.
+Shot-fidelity and queue-overhead metrics are out of scope for this harness;
+device-level queue status is available separately via `BaseExecutor.get_status()`.
+
 **Error handling.** If a backend errors on any circuit, the suite skips that
 *entire* backend (it emits no partial rows for it), logs the backend and the
 failing circuit to stderr, and continues with the next backend — it never

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Marqov benchmark scripts and the unified multi-backend benchmark suite."""

--- a/benchmarks/suite.py
+++ b/benchmarks/suite.py
@@ -216,6 +216,9 @@ def format_table(rows: Sequence[BenchmarkRow]) -> str:
 
 def _build_executor(name: str, seed: int) -> BaseExecutor:
     """Create a single executor for a CLI ``--executor`` name."""
+    # Only ``local`` is wired here. Richer backends need provider config (ARNs,
+    # tokens, S3 buckets) that a zero-arg CLI can't supply, so they go through
+    # run_suite() with a caller-built BaseExecutor rather than ExecutorFactory.
     if name == "local":
         return LocalExecutor(LocalExecutorConfig(seed=seed))
     raise ValueError(

--- a/benchmarks/suite.py
+++ b/benchmarks/suite.py
@@ -1,0 +1,291 @@
+"""Unified multi-backend benchmark harness.
+
+Runs a fixed set of reference circuits (Bell, 3-qubit GHZ, and a deterministic
+depth-5 random circuit) against any configured executor and prints a comparison
+table in the CONTRIBUTING.md §5 column format.
+
+Works out of the box with ``LocalExecutor`` — no credentials required::
+
+    python benchmarks/suite.py --executor local --shots 1000
+
+``run_suite()`` is executor-agnostic: pass any mapping of name -> ``BaseExecutor``
+to benchmark cloud backends programmatically.
+
+    from benchmarks.suite import run_suite, format_table
+    from marqov.executors import ExecutorFactory
+
+    executors = {
+        "local": LocalExecutor(),
+        "sv1": ExecutorFactory.create_executor("sv1", braket_config),
+    }
+    rows = await run_suite(executors, shots=1000)
+    print(format_table(rows))
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import random
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import TextIO
+
+from marqov.circuits import Circuit, bell_state, ghz_state
+from marqov.executors.base import BaseExecutor
+from marqov.executors.local import LocalExecutor, LocalExecutorConfig
+
+# Column order is fixed by CONTRIBUTING.md §5 and must not change.
+TABLE_COLUMNS: tuple[str, ...] = (
+    "backend",
+    "circuit",
+    "shots",
+    "exec_time_ms",
+    "top_3_outcomes",
+)
+
+DEFAULT_SHOTS = 1000
+DEFAULT_SEED = 1234
+
+# Single-qubit gates for the random benchmark circuit. Restricted to the
+# canonical gate set (CONTRIBUTING.md §1) so every backend can run it.
+_RANDOM_SINGLE_QUBIT_GATES: tuple[str, ...] = ("h", "x", "y", "z", "s", "t")
+_RANDOM_QUBITS = 3
+_RANDOM_DEPTH = 5
+
+
+@dataclass(frozen=True)
+class BenchmarkRow:
+    """One rendered row of the benchmark comparison table."""
+
+    backend: str
+    circuit: str
+    shots: int
+    exec_time_ms: float
+    top_3_outcomes: dict[str, int]
+
+
+def random_depth5_circuit(seed: int = DEFAULT_SEED) -> Circuit:
+    """Build a deterministic pseudo-random 3-qubit, depth-5 circuit.
+
+    Each of the five layers applies one random single-qubit gate to a random
+    qubit followed by a CNOT between two distinct random qubits. Seeding makes
+    the circuit identical across runs, which keeps the suite usable for
+    regression testing.
+
+    Args:
+        seed: Seed for the pseudo-random generator.
+
+    Returns:
+        A reproducible Circuit using only canonical gates.
+    """
+    rng = random.Random(seed)
+    circuit = Circuit()
+    for _ in range(_RANDOM_DEPTH):
+        gate = rng.choice(_RANDOM_SINGLE_QUBIT_GATES)
+        getattr(circuit, gate)(rng.randrange(_RANDOM_QUBITS))
+        control = rng.randrange(_RANDOM_QUBITS)
+        # Offset by 1..n-1 (mod n) so control and target are always distinct.
+        target = (control + rng.randrange(1, _RANDOM_QUBITS)) % _RANDOM_QUBITS
+        circuit.cnot(control, target)
+    return circuit
+
+
+def default_circuits(seed: int = DEFAULT_SEED) -> dict[str, Circuit]:
+    """Return the standard benchmark circuits keyed by name.
+
+    Args:
+        seed: Seed for the random depth-5 circuit.
+
+    Returns:
+        Ordered mapping of circuit name -> Circuit (bell, ghz, random_d5).
+    """
+    return {
+        "bell": bell_state(),
+        "ghz": ghz_state(3),
+        "random_d5": random_depth5_circuit(seed),
+    }
+
+
+def top_outcomes(counts: Mapping[str, int], limit: int = 3) -> dict[str, int]:
+    """Return the most frequent measurement outcomes.
+
+    Outcomes are ordered by count descending, with bitstring ascending as a
+    deterministic tie-breaker. The returned dict's insertion order carries this
+    ranking and must be preserved when serialising — do not sort JSON keys.
+
+    Args:
+        counts: Measurement outcome counts.
+        limit: Maximum number of outcomes to return.
+
+    Returns:
+        Ordered dict of the top ``limit`` outcomes.
+    """
+    ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    return dict(ranked[:limit])
+
+
+async def run_suite(
+    executors: Mapping[str, BaseExecutor],
+    shots: int = DEFAULT_SHOTS,
+    circuits: Mapping[str, Circuit] | None = None,
+    stderr: TextIO | None = None,
+) -> list[BenchmarkRow]:
+    """Benchmark every circuit against every executor.
+
+    Each backend is treated atomically: if any circuit raises, the whole backend
+    is skipped, the failure is logged to stderr (naming the backend and the
+    circuit that failed), and the suite continues with the next backend — it
+    never aborts.
+
+    Args:
+        executors: Ordered mapping of backend name -> executor.
+        shots: Number of measurement shots per circuit.
+        circuits: Circuits to run; defaults to the standard suite.
+        stderr: Stream for skip messages; defaults to ``sys.stderr``.
+
+    Returns:
+        One BenchmarkRow per (backend, circuit) that completed successfully.
+    """
+    error_stream = stderr if stderr is not None else sys.stderr
+    benchmark_circuits = circuits if circuits is not None else default_circuits()
+    rows: list[BenchmarkRow] = []
+
+    for backend, executor in executors.items():
+        backend_rows: list[BenchmarkRow] = []
+        in_flight: str | None = None
+        try:
+            for circuit_name, circuit in benchmark_circuits.items():
+                in_flight = circuit_name
+                result = await executor.execute(circuit, shots=shots)
+                backend_rows.append(
+                    BenchmarkRow(
+                        backend=backend,
+                        circuit=circuit_name,
+                        shots=result.shots,
+                        exec_time_ms=result.execution_time_ms,
+                        top_3_outcomes=top_outcomes(result.counts),
+                    )
+                )
+        except Exception as exc:
+            # Atomic skip: discard any partial rows for this backend and move on.
+            print(f"skipping {backend} (failed on {in_flight}): {exc}", file=error_stream)
+            continue
+        rows.extend(backend_rows)
+
+    return rows
+
+
+def format_table(rows: Sequence[BenchmarkRow]) -> str:
+    """Render rows as a GitHub-flavoured markdown table (CONTRIBUTING.md §5).
+
+    Columns are padded to a common width and wrapped in pipes with a separator
+    row, matching the documented format exactly. Empty ``rows`` still yields a
+    well-formed header and separator rather than crashing.
+
+    Args:
+        rows: Benchmark rows to render.
+
+    Returns:
+        The markdown table as a string (no trailing newline).
+    """
+    cells = [
+        (
+            row.backend,
+            row.circuit,
+            str(row.shots),
+            f"{row.exec_time_ms:.1f}",
+            json.dumps(row.top_3_outcomes),
+        )
+        for row in rows
+    ]
+
+    widths: list[int] = []
+    for index, column in enumerate(TABLE_COLUMNS):
+        column_cells = [len(cell[index]) for cell in cells]
+        widths.append(max(len(column), *column_cells) if column_cells else len(column))
+
+    def render(values: Sequence[str]) -> str:
+        return "| " + " | ".join(value.ljust(widths[i]) for i, value in enumerate(values)) + " |"
+
+    separator = "|" + "|".join("-" * (width + 2) for width in widths) + "|"
+    return "\n".join([render(TABLE_COLUMNS), separator, *(render(cell) for cell in cells)])
+
+
+def _build_executor(name: str, seed: int) -> BaseExecutor:
+    """Create a single executor for a CLI ``--executor`` name."""
+    if name == "local":
+        return LocalExecutor(LocalExecutorConfig(seed=seed))
+    raise ValueError(
+        f"Unsupported executor '{name}'. The CLI supports: local. "
+        f"To benchmark other backends, call run_suite() with any BaseExecutor."
+    )
+
+
+def build_executors(names: Sequence[str], seed: int) -> dict[str, BaseExecutor]:
+    """Create executors for the given CLI names, preserving order and de-duping.
+
+    Args:
+        names: Executor names from the CLI.
+        seed: Seed forwarded to executors that support reproducibility.
+
+    Returns:
+        Ordered mapping of name -> executor.
+    """
+    executors: dict[str, BaseExecutor] = {}
+    for name in names:
+        if name not in executors:
+            executors[name] = _build_executor(name, seed)
+    return executors
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Run Marqov's multi-backend benchmark suite.")
+    parser.add_argument(
+        "--executor",
+        action="append",
+        default=None,
+        help="Executor to benchmark (repeatable). Defaults to 'local'.",
+    )
+    parser.add_argument("--shots", type=int, default=DEFAULT_SHOTS, help="Shots per circuit.")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help="Seed for the random circuit and local sampler (reproducible runs).",
+    )
+    return parser.parse_args(argv)
+
+
+async def async_main(argv: Sequence[str] | None = None) -> int:
+    """Async CLI entry point. Returns a process exit code."""
+    args = parse_args(argv)
+    if args.shots <= 0:
+        raise ValueError("--shots must be a positive integer")
+
+    names = args.executor or ["local"]
+    executors = build_executors(names, args.seed)
+    rows = await run_suite(executors, shots=args.shots, circuits=default_circuits(args.seed))
+    print(format_table(rows))
+    # Non-zero only when every backend failed, so CI can flag a fully broken run.
+    return 0 if rows else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point. Returns a process exit code.
+
+    Invalid arguments (unknown executor, non-positive shots) are reported to
+    stderr and produce exit code 2 rather than an uncaught traceback.
+    """
+    try:
+        return asyncio.run(async_main(argv))
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -1,0 +1,314 @@
+"""Tests for the unified multi-backend benchmark suite (``benchmarks/suite.py``)."""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+import pytest
+
+from benchmarks.suite import (
+    BenchmarkRow,
+    build_executors,
+    default_circuits,
+    format_table,
+    main,
+    random_depth5_circuit,
+    run_suite,
+    top_outcomes,
+)
+from marqov.circuits import Circuit
+from marqov.executors.base import BaseExecutor, ExecutionResult
+from marqov.executors.local import LocalExecutor, LocalExecutorConfig
+
+
+class _FixedExecutor(BaseExecutor):
+    """Executor that returns fixed counts — for deterministic table assertions."""
+
+    def __init__(self, counts: dict[str, int]) -> None:
+        self._counts = counts
+
+    async def execute(self, circuit: Circuit, shots: int = 1000, **kwargs: Any) -> ExecutionResult:
+        return ExecutionResult(
+            counts=dict(self._counts),
+            backend="fixed",
+            execution_time_ms=12.34,
+            shots=shots,
+        )
+
+
+class _FailOnNthExecutor(BaseExecutor):
+    """Executor that raises on its N-th ``execute`` call and succeeds otherwise.
+
+    Used to verify that a backend which fails partway through is skipped
+    *atomically* (no partial rows survive).
+    """
+
+    def __init__(self, fail_on_call: int) -> None:
+        self._fail_on_call = fail_on_call
+        self._calls = 0
+
+    async def execute(self, circuit: Circuit, shots: int = 1000, **kwargs: Any) -> ExecutionResult:
+        self._calls += 1
+        if self._calls == self._fail_on_call:
+            raise RuntimeError("backend unavailable")
+        return ExecutionResult(
+            counts={"00": shots}, backend="flaky", execution_time_ms=1.0, shots=shots
+        )
+
+
+# --------------------------------------------------------------------------- #
+# top_outcomes
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("counts", "expected"),
+    [
+        # Ordered by count descending, then bitstring ascending; limited to 3.
+        ({"00": 5, "11": 2, "01": 3, "10": 1}, {"00": 5, "01": 3, "11": 2}),
+        # Ties broken by bitstring ascending.
+        ({"10": 4, "00": 4, "11": 3}, {"00": 4, "10": 4, "11": 3}),
+        # The count-descending order must win even when the top key sorts last —
+        # this is the case a naive json.dumps(sort_keys=True) would corrupt.
+        ({"11": 600, "00": 400}, {"11": 600, "00": 400}),
+        # Fewer than the limit, and empty.
+        ({"0": 7}, {"0": 7}),
+        ({}, {}),
+    ],
+)
+def test_top_outcomes(counts: dict[str, int], expected: dict[str, int]) -> None:
+    """top_outcomes ranks by count (desc) then bitstring (asc), capped at 3."""
+    result = top_outcomes(counts)
+    assert result == expected
+    # dict equality ignores order, so assert the ranking order explicitly too.
+    assert list(result.items()) == list(expected.items())
+
+
+# --------------------------------------------------------------------------- #
+# format_table — exact CONTRIBUTING.md §5 column format
+# --------------------------------------------------------------------------- #
+
+
+def test_format_table_matches_contributing_section5() -> None:
+    """A single row renders as the exact markdown table documented in §5."""
+    table = format_table(
+        [
+            BenchmarkRow(
+                backend="local",
+                circuit="bell",
+                shots=1000,
+                exec_time_ms=12.34,
+                top_3_outcomes={"00": 503, "11": 497},
+            )
+        ]
+    )
+
+    assert table.splitlines() == [
+        "| backend | circuit | shots | exec_time_ms | top_3_outcomes         |",
+        "|---------|---------|-------|--------------|------------------------|",
+        '| local   | bell    | 1000  | 12.3         | {"00": 503, "11": 497} |',
+    ]
+
+
+def test_format_table_preserves_count_descending_outcome_order() -> None:
+    """The rendered JSON keeps count-descending order (no sort_keys corruption)."""
+    table = format_table(
+        [BenchmarkRow("local", "bell", 1000, 1.0, top_outcomes({"11": 600, "00": 400}))]
+    )
+    assert '{"11": 600, "00": 400}' in table
+
+
+def test_format_table_empty_rows_is_wellformed() -> None:
+    """Rendering with no rows yields just the header + separator, never crashes."""
+    lines = format_table([]).splitlines()
+    assert lines == [
+        "| backend | circuit | shots | exec_time_ms | top_3_outcomes |",
+        "|---------|---------|-------|--------------|----------------|",
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# run_suite — end-to-end with the real LocalExecutor (no credentials)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_run_suite_local_end_to_end() -> None:
+    """The full suite runs against a real LocalExecutor with no credentials.
+
+    The assertions pin physics invariants of the sampling + aggregation pipeline
+    (total conservation, the support of Bell/GHZ, a roughly balanced split) so a
+    numerically-wrong regression — e.g. counts silently halved — is caught, not
+    just the structural shape.
+    """
+    shots = 200
+    rows = await run_suite(
+        {"local": LocalExecutor(LocalExecutorConfig(seed=0))},
+        shots=shots,
+        circuits=default_circuits(seed=0),
+    )
+
+    assert [row.circuit for row in rows] == ["bell", "ghz", "random_d5"]
+    assert all(row.backend == "local" for row in rows)
+    assert all(row.shots == shots for row in rows)
+    assert all(row.exec_time_ms >= 0.0 for row in rows)
+
+    by_circuit = {row.circuit: row.top_3_outcomes for row in rows}
+
+    # Bell and GHZ each have exactly two outcomes, so top_3 captures *all* counts:
+    # the sum must equal shots exactly (catches a halving / dropped-shot bug) and
+    # the split must stay roughly balanced (catches a collapsed distribution).
+    for name, support in (("bell", {"00", "11"}), ("ghz", {"000", "111"})):
+        outcomes = by_circuit[name]
+        assert set(outcomes) <= support
+        assert sum(outcomes.values()) == shots
+        assert all(0.3 * shots < count < 0.7 * shots for count in outcomes.values())
+
+    # random_d5 may have more than three outcomes, so top_3 can sum below shots —
+    # but never above it, and at least one outcome must have been observed.
+    random_d5 = by_circuit["random_d5"]
+    assert len(random_d5) <= 3
+    assert 0 < sum(random_d5.values()) <= shots
+
+
+@pytest.mark.asyncio
+async def test_run_suite_outcomes_are_pinned_for_seed() -> None:
+    """Exact-value regression guard for the suite's reproducibility promise.
+
+    With both the circuit and the sampler seeded to 0 the whole pipeline is
+    deterministic, so the exact counts are pinned. This flags any drift in
+    circuit construction, simulation, sampling, or aggregation. The values are
+    tied to the locked numpy (<2.4) and quantumflow (v1.4.0) versions; re-baseline
+    them deliberately if those pins change.
+    """
+    rows = await run_suite(
+        {"local": LocalExecutor(LocalExecutorConfig(seed=0))},
+        shots=200,
+        circuits=default_circuits(seed=0),
+    )
+
+    assert {row.circuit: row.top_3_outcomes for row in rows} == {
+        "bell": {"11": 112, "00": 88},
+        "ghz": {"111": 105, "000": 95},
+        "random_d5": {"001": 109, "000": 91},
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_suite_is_reproducible_with_seed() -> None:
+    """Identical seeds yield identical outcome rows — usable for regression tests."""
+    circuits = default_circuits(seed=0)
+    first = await run_suite(
+        {"local": LocalExecutor(LocalExecutorConfig(seed=0))}, shots=500, circuits=circuits
+    )
+    second = await run_suite(
+        {"local": LocalExecutor(LocalExecutorConfig(seed=0))}, shots=500, circuits=circuits
+    )
+    assert [r.top_3_outcomes for r in first] == [r.top_3_outcomes for r in second]
+
+
+# --------------------------------------------------------------------------- #
+# run_suite — skip-and-log error handling (atomic per backend)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_run_suite_skips_and_logs_failing_backend() -> None:
+    """A backend that always fails is logged to stderr and produces no rows."""
+    stderr = io.StringIO()
+    rows = await run_suite(
+        {
+            "broken": _FailOnNthExecutor(fail_on_call=1),
+            "local": LocalExecutor(LocalExecutorConfig(seed=0)),
+        },
+        shots=50,
+        stderr=stderr,
+    )
+
+    assert {row.backend for row in rows} == {"local"}
+    assert "skipping broken (failed on bell)" in stderr.getvalue()
+    assert "backend unavailable" in stderr.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_run_suite_skips_whole_backend_atomically() -> None:
+    """A backend that fails on its 2nd circuit contributes *zero* rows (atomic)."""
+    stderr = io.StringIO()
+    rows = await run_suite(
+        {
+            "flaky": _FailOnNthExecutor(fail_on_call=2),  # passes bell, fails ghz
+            "local": LocalExecutor(LocalExecutorConfig(seed=0)),
+        },
+        shots=50,
+        stderr=stderr,
+    )
+
+    # No partial 'flaky' row leaks through despite bell having succeeded.
+    assert all(row.backend != "flaky" for row in rows)
+    assert [row.circuit for row in rows] == ["bell", "ghz", "random_d5"]
+    assert "skipping flaky (failed on ghz)" in stderr.getvalue()
+
+
+# --------------------------------------------------------------------------- #
+# random_depth5_circuit
+# --------------------------------------------------------------------------- #
+
+
+def test_random_depth5_circuit_is_deterministic() -> None:
+    """The same seed always produces the same circuit; different seeds differ."""
+    assert random_depth5_circuit(7).to_dict() == random_depth5_circuit(7).to_dict()
+    assert random_depth5_circuit(7).to_dict() != random_depth5_circuit(8).to_dict()
+
+
+def test_random_depth5_circuit_uses_canonical_gates_on_three_qubits() -> None:
+    """The random circuit stays within 3 qubits and the canonical gate set."""
+    # QuantumFlow op names the generator may emit (single-qubit gates + CNOT).
+    allowed = {"H", "X", "Y", "Z", "S", "T", "CNot"}
+    circuit = random_depth5_circuit(0)
+    for gate in circuit.to_dict()["gates"]:
+        assert gate["gate"] in allowed
+        assert all(0 <= qubit < 3 for qubit in gate["qubits"])
+
+
+# --------------------------------------------------------------------------- #
+# build_executors + CLI
+# --------------------------------------------------------------------------- #
+
+
+def test_build_executors_dedupes_local() -> None:
+    """Repeated names collapse to a single ordered entry."""
+    executors = build_executors(["local", "local"], seed=0)
+    assert list(executors) == ["local"]
+    assert isinstance(executors["local"], LocalExecutor)
+
+
+def test_build_executors_rejects_unknown_name() -> None:
+    """An unknown executor name raises a helpful error."""
+    with pytest.raises(ValueError, match="Unsupported executor 'rigetti'"):
+        build_executors(["rigetti"], seed=0)
+
+
+def test_cli_main_runs_local_end_to_end(capsys: pytest.CaptureFixture[str]) -> None:
+    """`main --executor local` prints the table and exits 0."""
+    exit_code = main(["--executor", "local", "--shots", "50", "--seed", "0"])
+    assert exit_code == 0
+
+    out_lines = capsys.readouterr().out.splitlines()
+    assert out_lines[0].startswith("| backend | circuit")
+    data_rows = [line for line in out_lines if line.startswith("| local")]
+    assert len(data_rows) == 3
+
+
+def test_cli_main_rejects_nonpositive_shots(capsys: pytest.CaptureFixture[str]) -> None:
+    """`--shots 0` exits 2 with a clean stderr message, not a traceback."""
+    exit_code = main(["--executor", "local", "--shots", "0"])
+    assert exit_code == 2
+    assert "--shots must be a positive integer" in capsys.readouterr().err
+
+
+def test_cli_main_rejects_unknown_executor(capsys: pytest.CaptureFixture[str]) -> None:
+    """An unknown `--executor` exits 2 with a helpful stderr message."""
+    exit_code = main(["--executor", "bogus"])
+    assert exit_code == 2
+    assert "Unsupported executor 'bogus'" in capsys.readouterr().err

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -57,6 +57,25 @@ class _FailOnNthExecutor(BaseExecutor):
         )
 
 
+class _ClampedShotsExecutor(BaseExecutor):
+    """Executor that runs fewer shots than requested — like a shot-capped backend.
+
+    The table must report ``result.shots`` (what actually ran), not the requested
+    value, so a clamped run is never silently misreported.
+    """
+
+    def __init__(self, actual_shots: int) -> None:
+        self._actual_shots = actual_shots
+
+    async def execute(self, circuit: Circuit, shots: int = 1000, **kwargs: Any) -> ExecutionResult:
+        return ExecutionResult(
+            counts={"00": self._actual_shots},
+            backend="clamped",
+            execution_time_ms=1.0,
+            shots=self._actual_shots,
+        )
+
+
 # --------------------------------------------------------------------------- #
 # top_outcomes
 # --------------------------------------------------------------------------- #
@@ -208,6 +227,21 @@ async def test_run_suite_is_reproducible_with_seed() -> None:
     assert [r.top_3_outcomes for r in first] == [r.top_3_outcomes for r in second]
 
 
+@pytest.mark.asyncio
+async def test_run_suite_records_executor_shots_not_request() -> None:
+    """The shots column reflects what the backend actually ran, not what was asked.
+
+    Real hardware clamps shot counts, so the row must carry ``result.shots`` —
+    recording the requested value instead would silently misreport a capped run.
+    """
+    rows = await run_suite(
+        {"clamped": _ClampedShotsExecutor(actual_shots=64)},
+        shots=1000,
+        circuits={"bell": Circuit()},
+    )
+    assert [row.shots for row in rows] == [64]
+
+
 # --------------------------------------------------------------------------- #
 # run_suite — skip-and-log error handling (atomic per backend)
 # --------------------------------------------------------------------------- #
@@ -312,3 +346,21 @@ def test_cli_main_rejects_unknown_executor(capsys: pytest.CaptureFixture[str]) -
     exit_code = main(["--executor", "bogus"])
     assert exit_code == 2
     assert "Unsupported executor 'bogus'" in capsys.readouterr().err
+
+
+def test_cli_main_exits_1_when_all_backends_fail(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When every backend fails, the CLI exits non-zero so CI can flag a broken run.
+
+    The shipped CLI only builds the always-succeeding ``local`` executor, so the
+    all-fail path (``return 0 if rows else 1``) is driven here by substituting a
+    failing backend.
+    """
+    monkeypatch.setattr(
+        "benchmarks.suite.build_executors",
+        lambda names, seed: {"broken": _FailOnNthExecutor(fail_on_call=1)},
+    )
+    exit_code = main(["--executor", "broken", "--shots", "50"])
+    assert exit_code == 1
+    assert "skipping broken" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Closes #5.

Adds `benchmarks/suite.py` — a unified harness that runs a fixed set of reference
circuits (Bell, 3-qubit GHZ, deterministic depth-5 random) against any configured
executor and prints the comparison table documented in CONTRIBUTING.md §5.

- **Zero credentials out of the box** — `python benchmarks/suite.py --executor local --shots 1000 --seed 1234`.
- **Executor-agnostic core** — `run_suite()` accepts any `name → BaseExecutor` mapping,
  so cloud backends can be benchmarked programmatically; the CLI wires only the
  zero-credential `local` executor.
- **Exact §5 output** — bordered markdown table; JSON outcomes preserved in
  count-descending order (no `sort_keys`, which would corrupt the ranking).
- **Atomic, per-backend error handling** — if any circuit raises, the *whole* backend
  is skipped (no partial rows leak), the backend and failing circuit are logged to
  stderr, and the run continues. Exits non-zero only when *every* backend fails, so CI
  can flag a fully broken run.
- **Reproducible** — `--seed` seeds both the random circuit and the local sampler;
  exact outcome counts are pinned in tests against the locked numpy / quantumflow versions.

## Review methodology

Before submission this branch was subjected to an adversarial multi-agent review. A set
of independent reviewer agents each examined the implementation from a distinct,
non-overlapping angle:

1. **Acceptance-criteria conformance** — every requirement in issue #5 and
   CONTRIBUTING.md §5 verified at the terminal, including a byte-for-byte check of the
   rendered table against the documented format.
2. **Adversarial input / edge-case fuzzing** — malformed CLI arguments, degenerate
   executors (empty counts, NaN/inf timings, tied outcomes), and determinism verified
   across independent processes.
3. **Code-quality and house-style audit** — consistency with the SDK's conventions,
   `ruff` and `mypy --strict` conformance, and idiom review against the surrounding code.
4. **Mutation testing of the test suite** — production lines were deliberately broken to
   confirm a test fails. Six of eight mutations were caught by the pre-existing tests;
   the two survivors revealed documented-but-undefended contracts.

The follow-up commit closes those two gaps:

- The "all backends fail → non-zero exit" CLI contract (previously, hardcoding a `0`
  exit passed every test).
- The `shots` column records `result.shots` — what the backend actually ran — rather
  than the requested value, so a shot-capped hardware run is never silently misreported.

It also adds a CONTRIBUTING.md §5 scope note (shot-fidelity and queue-overhead
comparisons are out of scope; device queue status is exposed separately via
`BaseExecutor.get_status()`) and a comment explaining why `_build_executor` does not
route through `ExecutorFactory`.

## Type of change

- [x] Other (describe): **benchmark tooling + documentation**

## Testing

- [x] I ran `pytest tests/ -v` and tests pass — **340 passed, 13 skipped**
- [x] Benchmark suite: 22 tests pass; verified end-to-end against the real
      `LocalExecutor` (no credentials). `ruff` and `mypy --strict` clean.

**Test details:** parametrised `top_outcomes` ranking/tie-break cases, byte-for-byte §5
format match, atomic skip-and-log (including failure on a *later* circuit, proving no
partial rows leak), seeded reproducibility across independent runs, a pinned exact-count
regression guard, and the two contract tests above. Each newly added test was
mutation-verified to fail when its target line is broken.

## Checklist

- [x] No hardcoded credentials or API keys
- [x] Handles the canonical gate set from `CONTRIBUTING.md §1` — the random circuit is
      restricted to `H, X, Y, Z, S, T, CNOT`, asserted by a test.

---

🤖 Reviewed and hardened with [Claude Code](https://claude.com/claude-code)
