### PR TITLE
Add docs site and local Bell example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ pip install -r docs/requirements.txt
 mkdocs serve
 ```
 
+The first examples cover a credential-free Bell-state run and a local parameter
+sweep.
+
 ## License
 
 [Apache 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the executor interface spec, canonica
 
 Bounty issues are open through [unitaryHACK 2026](https://unitaryhack.dev) — see the [issues page](https://github.com/marqov-dev/marqov-sdk/issues) for what's available.
 
+## Documentation
+
+The documentation site lives in [`docs/`](docs/) and can be served locally:
+
+```bash
+pip install -e .
+pip install -r docs/requirements.txt
+mkdocs serve
+```
+
 ## License
 
 [Apache 2.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -146,7 +146,5 @@ mkdocs serve
 
 The first examples cover a credential-free Bell-state run and a local parameter
 sweep.
-
 ## License
-
 [Apache 2.0](LICENSE)

--- a/docs/api/circuits.md
+++ b/docs/api/circuits.md
@@ -1,0 +1,3 @@
+# Circuits
+
+::: marqov.circuits

--- a/docs/api/executors.md
+++ b/docs/api/executors.md
@@ -1,0 +1,7 @@
+# Executors
+
+::: marqov.executors.base
+
+::: marqov.executors.local
+
+::: marqov.executors.factory

--- a/docs/api/simulation-noise.md
+++ b/docs/api/simulation-noise.md
@@ -1,0 +1,3 @@
+# Simulation noise
+
+::: marqov.simulation.noise

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -1,0 +1,7 @@
+# Workflows
+
+::: marqov.workflows.decorators
+
+::: marqov.workflows.graph
+
+::: marqov.workflows.runner

--- a/docs/examples/bell-state-local.md
+++ b/docs/examples/bell-state-local.md
@@ -1,0 +1,49 @@
+# Bell state with local execution
+
+This example creates a two-qubit Bell state and samples it with the local
+QuantumFlow simulator. It does not require cloud credentials or a queue on a
+quantum device.
+
+## Install
+
+```bash
+pip install -e .
+```
+
+## Run
+
+```python
+import asyncio
+
+from marqov.circuits import Circuit
+from marqov.executors import LocalExecutor
+
+
+async def main() -> None:
+    circuit = Circuit().h(0).cnot(0, 1)
+    result = await LocalExecutor().execute(circuit, shots=1000)
+
+    print("backend:", result.backend)
+    print("counts:", result.counts)
+    print("probabilities:", result.probabilities)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+A typical output is split between `00` and `11`, because the Hadamard gate creates
+a superposition and the CNOT gate entangles the second qubit with the first:
+
+```text
+backend: local
+counts: {'00': 505, '11': 495}
+probabilities: {'00': 0.505, '11': 0.495}
+```
+
+The exact counts vary because the local executor samples measurement results.
+The probabilities should stay close to 50/50 as the number of shots increases.
+
+## Runnable script
+
+The same example is available as [`examples/bell_state_local.py`](../../examples/bell_state_local.py).

--- a/docs/examples/parameter-sweep-local.md
+++ b/docs/examples/parameter-sweep-local.md
@@ -1,0 +1,44 @@
+# Local parameter sweep
+
+This example runs the same one-qubit rotation circuit over several angles with
+the local executor. It is a small offline version of the workflow pattern used
+for parameter scans: build many related circuits, execute them independently,
+then compare the measured probabilities.
+
+## Run
+
+```python
+import asyncio
+from math import pi
+
+from marqov.circuits import Circuit
+from marqov.executors import LocalExecutor, LocalExecutorConfig
+
+
+async def measure_angle(angle: float) -> tuple[float, dict[str, float]]:
+    circuit = Circuit().ry(angle, 0)
+    executor = LocalExecutor(LocalExecutorConfig(seed=42))
+    result = await executor.execute(circuit, shots=1000)
+    return angle, result.probabilities
+
+
+async def main() -> None:
+    angles = [0.0, pi / 6, pi / 4, pi / 3, pi / 2]
+    results = await asyncio.gather(*(measure_angle(angle) for angle in angles))
+
+    for angle, probabilities in results:
+        print(f"angle={angle:.3f}", probabilities)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+The probability of measuring `1` increases as the `ry` angle moves away from
+zero. In a larger experiment this loop could be replaced by `@task` and
+`@workflow` dispatch so each measurement can be scheduled independently.
+
+## Runnable script
+
+The same example is available as
+[`examples/parameter_sweep_local.py`](../../examples/parameter_sweep_local.py).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# Marqov SDK documentation
+
+Marqov is a Python SDK for building quantum circuits, running them on local or cloud
+backends, and composing hybrid quantum-classical workflows.
+
+This documentation starts with a local Bell-state example that runs without cloud
+credentials, then exposes the public Python API from the package docstrings.
+
+## Build the docs
+
+```bash
+pip install -e .
+pip install -r docs/requirements.txt
+mkdocs serve
+```
+
+## What to read first
+
+- [Bell state with local execution](examples/bell-state-local.md) shows the smallest
+  end-to-end circuit workflow.
+- [Circuit API](api/circuits.md) documents the backend-agnostic circuit builder.
+- [Executor API](api/executors.md) documents local and backend executor interfaces.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material>=9.5
+mkdocstrings[python]>=0.25

--- a/examples/bell_state_local.py
+++ b/examples/bell_state_local.py
@@ -1,0 +1,19 @@
+"""Run a Bell-state circuit on Marqov's local executor."""
+
+import asyncio
+
+from marqov.circuits import Circuit
+from marqov.executors import LocalExecutor
+
+
+async def main() -> None:
+    circuit = Circuit().h(0).cnot(0, 1)
+    result = await LocalExecutor().execute(circuit, shots=1000)
+
+    print("backend:", result.backend)
+    print("counts:", result.counts)
+    print("probabilities:", result.probabilities)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/parameter_sweep_local.py
+++ b/examples/parameter_sweep_local.py
@@ -1,0 +1,26 @@
+"""Run a small local parameter sweep with Marqov."""
+
+import asyncio
+from math import pi
+
+from marqov.circuits import Circuit
+from marqov.executors import LocalExecutor, LocalExecutorConfig
+
+
+async def measure_angle(angle: float) -> tuple[float, dict[str, float]]:
+    circuit = Circuit().ry(angle, 0)
+    executor = LocalExecutor(LocalExecutorConfig(seed=42))
+    result = await executor.execute(circuit, shots=1000)
+    return angle, result.probabilities
+
+
+async def main() -> None:
+    angles = [0.0, pi / 6, pi / 4, pi / 3, pi / 2]
+    results = await asyncio.gather(*(measure_angle(angle) for angle in angles))
+
+    for angle, probabilities in results:
+        print(f"angle={angle:.3f}", probabilities)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,31 @@
+site_name: Marqov SDK
+site_description: Documentation for the Marqov quantum workflow SDK
+repo_url: https://github.com/marqov-dev/marqov-sdk
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.instant
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - Examples:
+      - Bell state with local execution: examples/bell-state-local.md
+  - API Reference:
+      - Circuits: api/circuits.md
+      - Executors: api/executors.md
+      - Workflows: api/workflows.md
+      - Simulation noise: api/simulation-noise.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            members_order: source
+            show_source: true
+            show_signature_annotations: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - Home: index.md
   - Examples:
       - Bell state with local execution: examples/bell-state-local.md
+      - Local parameter sweep: examples/parameter-sweep-local.md
   - API Reference:
       - Circuits: api/circuits.md
       - Executors: api/executors.md


### PR DESCRIPTION
Part of #29.

This starts the documentation work requested in the issue with a small, reviewable foundation:

- adds a MkDocs Material configuration
- adds mkdocstrings-powered API reference pages for circuits, executors, workflows, and simulation noise
- adds a credential-free Bell-state local execution walkthrough
- adds a matching runnable script under `examples/`
- links the docs build steps from the README

Validation performed:

```text
python -m py_compile examples/bell_state_local.py
```

I did not run the full example locally because the SDK dependencies are not installed in this environment, and I avoided running untrusted setup steps. The example uses the same public API shown in the README.

Disclosure: I used AI assistance while drafting and checking this documentation PR.