### PR TITLE
feat(executors): add IonQ Direct API executor (closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ async def main():
 asyncio.run(main())
 ```
 
+Or run directly on IonQ hardware via the native REST API (no AWS account needed):
+
+```python
+executor = ExecutorFactory.create_executor("qpu.aria-1", {
+    "provider": "IonQ Direct",
+    "api_key": "your-ionq-api-key",  # or set IONQ_API_KEY
+})
+result = await executor.execute(circuit, shots=1000)
+```
+
 ## Supported Backends
 
 | Backend | Status |
@@ -97,7 +107,7 @@ asyncio.run(main())
 | AWS Braket | ✅ Available |
 | IBM Quantum | ✅ Available |
 | Azure Quantum | ✅ Available |
-| IonQ Direct | [🔧 Open issue #1](https://github.com/marqov-dev/marqov-sdk/issues/1) |
+| IonQ Direct | ✅ Available |
 | Rigetti QCS | [🔧 Open issue #2](https://github.com/marqov-dev/marqov-sdk/issues/2) |
 | Quantinuum | [🔧 Open issue #6](https://github.com/marqov-dev/marqov-sdk/issues/6) |
 

--- a/marqov/executors/__init__.py
+++ b/marqov/executors/__init__.py
@@ -7,6 +7,7 @@ Available executors:
 - BraketExecutor: AWS Braket (simulators and QPUs)
 - AzureQuantumExecutor: Azure Quantum (Quantinuum, PASQAL, IonQ, Rigetti)
 - IBMExecutor: IBM Quantum (Heron r2, Eagle, etc. via Qiskit Runtime)
+- IonQExecutor: IonQ Direct API (native REST, no Braket intermediary)
 
 Example:
     >>> from marqov.executors import LocalExecutor
@@ -22,6 +23,7 @@ from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
 from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
 from marqov.executors.factory import ExecutorFactory
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
+from marqov.executors.ionq import IonQExecutor, IonQExecutorConfig
 from marqov.executors.local import LocalExecutor
 from marqov.simulation.executor import SimulationExecutor
 
@@ -36,6 +38,8 @@ __all__ = [
     "ExecutorFactory",
     "IBMExecutor",
     "IBMExecutorConfig",
+    "IonQExecutor",
+    "IonQExecutorConfig",
     "LocalExecutor",
     "SimulationExecutor",
 ]

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -22,6 +22,7 @@ from marqov.executors.azure import AzureQuantumExecutor, AzureQuantumExecutorCon
 from marqov.executors.base import BaseExecutor
 from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
+from marqov.executors.ionq import IonQExecutor, IonQExecutorConfig
 from marqov.executors.local import LocalExecutor
 from marqov.simulation.config import SimulationConfig
 from marqov.simulation.executor import SimulationExecutor
@@ -42,7 +43,7 @@ class ExecutorFactory:
         - IBM Quantum: Heron r2, Eagle processors via Qiskit Runtime SamplerV2
         - Azure Quantum: Quantinuum, PASQAL, IonQ, Rigetti (Qiskit/Cirq support)
         - Local: QuantumFlow simulator (no cloud required)
-        - IonQ Direct API: Coming soon
+        - IonQ Direct: Native IonQ REST API (no AWS/Braket intermediary)
 
     Example:
         >>> from marqov.executors.factory import ExecutorFactory
@@ -105,12 +106,9 @@ class ExecutorFactory:
         if provider == "Azure Quantum":
             return cls._create_azure_executor(backend_slug, backend_config)
 
-        # IonQ Direct API (future)
+        # IonQ Direct API
         if provider == "IonQ Direct":
-            raise NotImplementedError(
-                f"IonQ Direct API support coming soon. "
-                f"See docs/MULTI_CLOUD_EXECUTOR_DESIGN.md for roadmap."
-            )
+            return cls._create_ionq_executor(backend_slug, backend_config)
 
         # C++ simulation backends (qpp, tnqvm, cudaq, aer)
         if provider == "Quantum Brilliance":
@@ -118,8 +116,8 @@ class ExecutorFactory:
 
         raise ValueError(
             f"Unsupported provider: {provider}. "
-            f"Supported providers: AWS Braket, IBM Quantum, Azure Quantum, Quantum Brilliance, Local. "
-            f"Coming soon: IonQ Direct."
+            f"Supported providers: AWS Braket, IBM Quantum, Azure Quantum, "
+            f"IonQ Direct, Quantum Brilliance, Local."
         )
 
     @classmethod
@@ -245,6 +243,37 @@ class ExecutorFactory:
         return IBMExecutor(config)
 
     @classmethod
+    def _create_ionq_executor(
+        cls,
+        backend_slug: str,
+        backend_config: dict[str, Any],
+    ) -> IonQExecutor:
+        """Create an IonQ Direct API executor from configuration.
+
+        The IonQ API key may be supplied via config or the IONQ_API_KEY
+        environment variable, so no field is strictly required here.
+
+        Args:
+            backend_slug: Backend slug used as the IonQ target if not given
+                (e.g. "simulator", "qpu.aria-1").
+            backend_config: Configuration with optional target, api_key,
+                base_url, noise_model, and polling options.
+
+        Returns:
+            Configured IonQExecutor instance.
+        """
+        config = IonQExecutorConfig(
+            target=backend_config.get("target", backend_slug),
+            api_key=backend_config.get("api_key"),
+            base_url=backend_config.get("base_url", "https://api.ionq.co/v0.3"),
+            poll_interval_seconds=backend_config.get("poll_interval_seconds", 1.0),
+            timeout_seconds=backend_config.get("timeout_seconds"),
+            noise_model=backend_config.get("noise_model"),
+        )
+
+        return IonQExecutor(config)
+
+    @classmethod
     def _create_simulation_executor(
         cls,
         backend_slug: str,
@@ -271,15 +300,15 @@ class ExecutorFactory:
 
         Example:
             >>> ExecutorFactory.get_supported_providers()
-            ['AWS Braket', 'IBM Quantum', 'Azure Quantum', 'Local']
+            ['AWS Braket', 'IBM Quantum', 'Azure Quantum', 'IonQ Direct', ...]
         """
         return [
             "AWS Braket",
             "IBM Quantum",
             "Azure Quantum",
+            "IonQ Direct",
             "Quantum Brilliance",
             "Local",
-            # "IonQ Direct",     # Coming soon
         ]
 
     @classmethod

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -262,14 +262,17 @@ class ExecutorFactory:
         Returns:
             Configured IonQExecutor instance.
         """
-        config = IonQExecutorConfig(
-            target=backend_config.get("target", backend_slug),
-            api_key=backend_config.get("api_key"),
-            base_url=backend_config.get("base_url", "https://api.ionq.co/v0.3"),
-            poll_interval_seconds=backend_config.get("poll_interval_seconds", 1.0),
-            timeout_seconds=backend_config.get("timeout_seconds"),
-            noise_model=backend_config.get("noise_model"),
-        )
+        # Only forward keys present in backend_config and rely on
+        # IonQExecutorConfig's own defaults otherwise, so factory and dataclass
+        # defaults can't drift apart. The target falls back to the backend slug.
+        config_kwargs: dict[str, Any] = {
+            "target": backend_config.get("target", backend_slug),
+        }
+        for key in ("api_key", "base_url", "poll_interval_seconds", "timeout_seconds", "noise_model"):
+            if key in backend_config:
+                config_kwargs[key] = backend_config[key]
+
+        config = IonQExecutorConfig(**config_kwargs)
 
         return IonQExecutor(config)
 

--- a/marqov/executors/ionq.py
+++ b/marqov/executors/ionq.py
@@ -106,25 +106,37 @@ class IonQExecutor(BaseExecutor):
 
         Args:
             config: Executor configuration including target and credentials.
-            session: Optional pre-built HTTP session (``requests.Session`` or a test
-                double exposing ``request(method, url, **kwargs)``). If None, a
-                ``requests.Session`` is created lazily.
+            session: Optional HTTP session/transport exposing
+                ``request(method, url, **kwargs)`` (e.g. ``requests.Session`` or a
+                test double). If None, each request uses a fresh ``requests`` call,
+                which keeps the executor safe to share across concurrent coroutines
+                (``requests.Session`` is not guaranteed thread-safe).
         """
         self.config = config
         self._session = session
         self._current_job_id: str | None = None
 
-    def _get_session_sync(self) -> Any:
-        """Get or lazily create the HTTP session (synchronous).
+    def _do_request(self, method: str, url: str, **kwargs: Any) -> Any:
+        """Perform a single synchronous HTTP request.
+
+        Uses the injected session if provided, otherwise a fresh ``requests`` call
+        per invocation. Avoiding a shared, cached session means concurrent calls
+        (each run in a worker thread via ``run_in_executor``) don't race on a single
+        non-thread-safe ``requests.Session``.
+
+        Args:
+            method: HTTP method.
+            url: Fully-qualified request URL.
+            **kwargs: Extra arguments forwarded to the transport.
 
         Returns:
-            An HTTP session exposing a ``request(method, url, **kwargs)`` method.
+            The HTTP response object.
         """
-        if self._session is None:
-            import requests
+        if self._session is not None:
+            return self._session.request(method, url, **kwargs)
+        import requests
 
-            self._session = requests.Session()
-        return self._session
+        return requests.request(method, url, **kwargs)
 
     def _auth_headers(self) -> dict[str, str]:
         """Build IonQ authorization headers.
@@ -200,11 +212,6 @@ class IonQExecutor(BaseExecutor):
 
         IonQ returns a sparse histogram mapping big-endian state indices (as
         strings) to probabilities, where the leftmost bit corresponds to qubit 0.
-
-        Args:
-            histogram: Mapping of state index strings to probabilities.
-            shots: Number of shots, used to scale probabilities to counts.
-            num_qubits: Number of qubits, used to zero-pad bitstrings.
 
         Counts are allocated with the largest-remainder (Hamilton) method so the
         totals sum exactly to ``shots`` — naive per-bin rounding can drift above or
@@ -363,7 +370,6 @@ class IonQExecutor(BaseExecutor):
             The parsed JSON response body.
         """
         loop = asyncio.get_running_loop()
-        session = await loop.run_in_executor(None, self._get_session_sync)
         url = f"{self.config.base_url}{path}"
 
         # Merge any caller-provided headers with auth headers so they don't collide
@@ -371,7 +377,7 @@ class IonQExecutor(BaseExecutor):
         headers = {**kwargs.pop("headers", {}), **self._auth_headers()}
 
         def _call() -> dict[str, Any]:
-            response = session.request(
+            response = self._do_request(
                 method, url, headers=headers, timeout=_HTTP_TIMEOUT_SECONDS, **kwargs
             )
             response.raise_for_status()

--- a/marqov/executors/ionq.py
+++ b/marqov/executors/ionq.py
@@ -163,6 +163,34 @@ class IonQExecutor(BaseExecutor):
         return qasm, qiskit_circuit.num_qubits
 
     @staticmethod
+    def _extract_histogram(payload: dict[str, Any]) -> dict[str, float]:
+        """Extract the probability histogram from a results response.
+
+        The IonQ results endpoint may return the histogram directly
+        (``{"0": 0.5, ...}``) or wrapped (``{"histogram": {...}}`` or
+        ``{"data": {"histogram": {...}}}``, and sometimes under ``probabilities``).
+        This normalizes those shapes to the bare ``{state_index: probability}`` map.
+
+        Args:
+            payload: The parsed JSON results response.
+
+        Returns:
+            The probability histogram mapping.
+        """
+        data = payload.get("data")
+        if isinstance(data, dict) and isinstance(data.get("histogram"), dict):
+            nested: dict[str, float] = data["histogram"]
+            return nested
+        if isinstance(payload.get("histogram"), dict):
+            wrapped: dict[str, float] = payload["histogram"]
+            return wrapped
+        if isinstance(payload.get("probabilities"), dict):
+            probabilities: dict[str, float] = payload["probabilities"]
+            return probabilities
+        # Assume the payload is already a bare histogram mapping.
+        return payload
+
+    @staticmethod
     def _histogram_to_counts(
         histogram: dict[str, float],
         shots: int,
@@ -283,15 +311,19 @@ class IonQExecutor(BaseExecutor):
 
         histogram = job.get("data", {}).get("histogram")
         if histogram is None:
-            histogram = await self._request("GET", f"/jobs/{job_id}/results")
+            results = await self._request("GET", f"/jobs/{job_id}/results")
+            histogram = self._extract_histogram(results)
 
         counts = self._histogram_to_counts(histogram, shots, num_qubits)
 
-        execution_time_ms = job.get("execution_time")
+        # Prefer IonQ's reported execution time; fall back to measured wall time.
+        # Use an explicit None check so a valid 0 is preserved (not treated as missing).
+        reported_time = job.get("execution_time")
+        execution_time_ms = reported_time if reported_time is not None else wall_time * 1000
         return ExecutionResult(
             counts=counts,
             backend=self.config.target,
-            execution_time_ms=execution_time_ms if execution_time_ms else wall_time * 1000,
+            execution_time_ms=execution_time_ms,
             shots=shots,
             raw_result=job,
             metadata={
@@ -333,7 +365,10 @@ class IonQExecutor(BaseExecutor):
         loop = asyncio.get_running_loop()
         session = await loop.run_in_executor(None, self._get_session_sync)
         url = f"{self.config.base_url}{path}"
-        headers = self._auth_headers()
+
+        # Merge any caller-provided headers with auth headers so they don't collide
+        # with the explicit headers= argument below (auth takes precedence).
+        headers = {**kwargs.pop("headers", {}), **self._auth_headers()}
 
         def _call() -> dict[str, Any]:
             response = session.request(
@@ -371,7 +406,10 @@ class IonQExecutor(BaseExecutor):
             raw_status = str(backend.get("status", "")).lower()
             status = self._IONQ_STATUS_MAP.get(raw_status, "maintenance")
 
-            queue_depth = backend.get("queue_depth") or backend.get("jobs_queued")
+            # Explicit None check so a valid queue_depth of 0 is not discarded.
+            queue_depth = backend.get("queue_depth")
+            if queue_depth is None:
+                queue_depth = backend.get("jobs_queued")
             avg_queue = backend.get("average_queue_time")
             queue_time_seconds = int(avg_queue) if avg_queue is not None else None
 

--- a/marqov/executors/ionq.py
+++ b/marqov/executors/ionq.py
@@ -178,14 +178,52 @@ class IonQExecutor(BaseExecutor):
             shots: Number of shots, used to scale probabilities to counts.
             num_qubits: Number of qubits, used to zero-pad bitstrings.
 
+        Counts are allocated with the largest-remainder (Hamilton) method so the
+        totals sum exactly to ``shots`` — naive per-bin rounding can drift above or
+        below ``shots`` and break downstream "total == shots" assumptions.
+
+        Args:
+            histogram: Mapping of state index strings to probabilities.
+            shots: Number of shots, used to scale probabilities to counts.
+            num_qubits: Number of qubits, used to zero-pad bitstrings.
+
         Returns:
-            Mapping of bitstrings to integer counts.
+            Mapping of bitstrings to integer counts that sum to ``shots``.
         """
+        if not histogram:
+            return {}
+
+        # Floor each bin and remember its fractional remainder.
         counts: dict[str, int] = {}
+        remainders: dict[str, float] = {}
+        allocated = 0
         for index, probability in histogram.items():
             bitstring = format(int(index), f"0{num_qubits}b")
-            counts[bitstring] = round(float(probability) * shots)
-        return counts
+            exact = float(probability) * shots
+            base = int(exact)  # floor (probabilities are non-negative)
+            counts[bitstring] = base
+            remainders[bitstring] = exact - base
+            allocated += base
+
+        # Distribute (or reclaim) the leftover shots so the total equals `shots`.
+        leftover = shots - allocated
+        if leftover > 0:
+            # Hand extra shots to the largest fractional remainders first.
+            ordered = sorted(remainders, key=lambda b: remainders[b], reverse=True)
+            for i in range(leftover):
+                counts[ordered[i % len(ordered)]] += 1
+        elif leftover < 0:
+            # Reclaim over-allocated shots from the smallest remainders first.
+            ordered = sorted(remainders, key=lambda b: remainders[b])
+            i = 0
+            while leftover < 0 and i < len(ordered) * (-leftover + 1):
+                bitstring = ordered[i % len(ordered)]
+                if counts[bitstring] > 0:
+                    counts[bitstring] -= 1
+                    leftover += 1
+                i += 1
+
+        return {bitstring: count for bitstring, count in counts.items() if count > 0}
 
     async def execute(
         self,

--- a/marqov/executors/ionq.py
+++ b/marqov/executors/ionq.py
@@ -1,0 +1,346 @@
+"""IonQ Direct API executor for running circuits on IonQ hardware.
+
+This module provides IonQExecutor for executing quantum circuits directly against
+IonQ's REST API (https://api.ionq.co), bypassing the AWS Braket intermediary.
+Talking to IonQ directly shortens the round-trip, surfaces richer error messages,
+and exposes IonQ-specific features (e.g. simulator noise models) without requiring
+an AWS account or S3 bucket.
+
+Circuits are converted with ``circuit.to_qiskit()`` and dumped to OpenQASM, then
+submitted using IonQ's ``qasm`` input format.
+
+Note on the official ``ionq`` client:
+    The official ``ionq`` Python client is intentionally not used. Its only release
+    (``0.0.0a15``) pins ``pydantic<2``, which conflicts with marqov's core
+    ``pydantic>=2`` requirement, making ``marqov[ionq]`` impossible to install while
+    that client is a dependency. We therefore call IonQ's REST API directly with
+    ``requests`` (the same HTTP library the official client uses under the hood).
+
+Example:
+    >>> from marqov.circuits import bell_state
+    >>> from marqov.executors import IonQExecutor, IonQExecutorConfig
+    >>>
+    >>> config = IonQExecutorConfig(target="simulator", api_key="your-ionq-key")
+    >>> executor = IonQExecutor(config)
+    >>> result = await executor.execute(bell_state(), shots=1000)
+    >>> print(result.counts)  # {"00": ~500, "11": ~500}
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
+
+if TYPE_CHECKING:
+    from marqov.circuits import Circuit
+
+# Job statuses that mean the job has finished successfully.
+_SUCCESS_STATUSES = frozenset({"completed"})
+# Job statuses that mean the job has finished without usable results.
+_FAILURE_STATUSES = frozenset({"failed", "canceled", "cancelled"})
+
+# Per-request HTTP timeout (seconds). Overall job completion is bounded separately
+# by IonQExecutorConfig.timeout_seconds around polling.
+_HTTP_TIMEOUT_SECONDS = 30
+
+
+@dataclass
+class IonQExecutorConfig:
+    """Configuration for the IonQ Direct API executor.
+
+    Attributes:
+        target: IonQ backend target (e.g. "simulator", "qpu.aria-1",
+            "qpu.forte-1").
+        api_key: IonQ API key. If None, falls back to the ``IONQ_API_KEY``
+            environment variable at request time.
+        base_url: Base URL for the IonQ REST API.
+        poll_interval_seconds: Polling interval while waiting for a job to finish.
+        timeout_seconds: Maximum time to wait for job completion. None for no
+            timeout.
+        noise_model: Optional simulator noise model (e.g. "aria-1", "forte-1").
+            Only applied when ``target`` is the simulator.
+    """
+
+    target: str = "simulator"
+    api_key: str | None = None
+    base_url: str = "https://api.ionq.co/v0.3"
+    poll_interval_seconds: float = 1.0
+    timeout_seconds: float | None = None
+    noise_model: str | None = None
+
+
+class IonQExecutor(BaseExecutor):
+    """Execute circuits on IonQ hardware via IonQ's direct REST API.
+
+    Converts circuits with ``to_qiskit()`` and submits them as OpenQASM, polls for
+    completion, and converts IonQ's probability histogram into measurement counts.
+    An HTTP session may be injected for testing without network access or credentials.
+
+    Example:
+        >>> config = IonQExecutorConfig(
+        ...     target="qpu.aria-1",
+        ...     api_key="your-ionq-key",
+        ... )
+        >>> executor = IonQExecutor(config)
+        >>> if (await executor.get_status()).status == "online":
+        ...     result = await executor.execute(circuit, shots=1000)
+    """
+
+    # IonQ backend availability → standard DeviceStatus state.
+    _IONQ_STATUS_MAP = {
+        "available": "online",
+        "running": "online",
+        "unavailable": "offline",
+        "offline": "offline",
+        "reserved": "maintenance",
+        "calibrating": "maintenance",
+    }
+
+    def __init__(self, config: IonQExecutorConfig, *, session: Any = None) -> None:
+        """Initialize IonQExecutor.
+
+        Args:
+            config: Executor configuration including target and credentials.
+            session: Optional pre-built HTTP session (``requests.Session`` or a test
+                double exposing ``request(method, url, **kwargs)``). If None, a
+                ``requests.Session`` is created lazily.
+        """
+        self.config = config
+        self._session = session
+        self._current_job_id: str | None = None
+
+    def _get_session_sync(self) -> Any:
+        """Get or lazily create the HTTP session (synchronous).
+
+        Returns:
+            An HTTP session exposing a ``request(method, url, **kwargs)`` method.
+        """
+        if self._session is None:
+            import requests
+
+            self._session = requests.Session()
+        return self._session
+
+    def _auth_headers(self) -> dict[str, str]:
+        """Build IonQ authorization headers.
+
+        Returns:
+            Headers dict with the IonQ API key.
+
+        Raises:
+            ValueError: If no API key is available from config or environment.
+        """
+        api_key = self.config.api_key or os.environ.get("IONQ_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "IonQ API key not found. Set it via IonQExecutorConfig(api_key=...) "
+                "or the IONQ_API_KEY environment variable."
+            )
+        return {"Authorization": f"apiKey {api_key}"}
+
+    @staticmethod
+    def _circuit_to_qasm(circuit: Circuit) -> tuple[str, int]:
+        """Convert a Marqov circuit to OpenQASM via the Qiskit path.
+
+        This implements the explicit ``to_qiskit()`` → QASM conversion: the circuit
+        is first converted to a Qiskit ``QuantumCircuit`` and then dumped to QASM 2.0.
+
+        Args:
+            circuit: The Marqov circuit to convert.
+
+        Returns:
+            A tuple of (QASM string, number of qubits).
+        """
+        from qiskit import qasm2  # type: ignore[import-untyped]
+
+        qiskit_circuit = circuit.to_qiskit()  # type: ignore[no-untyped-call]
+        qasm: str = qasm2.dumps(qiskit_circuit)
+        return qasm, qiskit_circuit.num_qubits
+
+    @staticmethod
+    def _histogram_to_counts(
+        histogram: dict[str, float],
+        shots: int,
+        num_qubits: int,
+    ) -> dict[str, int]:
+        """Convert an IonQ probability histogram into measurement counts.
+
+        IonQ returns a sparse histogram mapping big-endian state indices (as
+        strings) to probabilities, where the leftmost bit corresponds to qubit 0.
+
+        Args:
+            histogram: Mapping of state index strings to probabilities.
+            shots: Number of shots, used to scale probabilities to counts.
+            num_qubits: Number of qubits, used to zero-pad bitstrings.
+
+        Returns:
+            Mapping of bitstrings to integer counts.
+        """
+        counts: dict[str, int] = {}
+        for index, probability in histogram.items():
+            bitstring = format(int(index), f"0{num_qubits}b")
+            counts[bitstring] = round(float(probability) * shots)
+        return counts
+
+    async def execute(
+        self,
+        circuit: Circuit,
+        shots: int = 1000,
+        **kwargs: Any,
+    ) -> ExecutionResult:
+        """Execute a circuit on an IonQ backend via the direct REST API.
+
+        Args:
+            circuit: The quantum circuit to execute.
+            shots: Number of measurement shots.
+            **kwargs: Additional backend-specific options (currently unused).
+
+        Returns:
+            ExecutionResult with measurement counts and metadata.
+
+        Raises:
+            RuntimeError: If the job fails or is canceled by IonQ.
+            ValueError: If no API key is available.
+            TimeoutError: If the job does not finish within ``timeout_seconds``.
+        """
+        circuit = self._validate_circuit(circuit)
+
+        start_time = time.perf_counter()
+
+        qasm, num_qubits = self._circuit_to_qasm(circuit)
+
+        payload: dict[str, Any] = {
+            "target": self.config.target,
+            "shots": shots,
+            "input": {"format": "qasm", "data": qasm},
+        }
+        if self.config.noise_model and self.config.target == "simulator":
+            payload["noise"] = {"model": self.config.noise_model}
+
+        # Submit the job and record its id for cancellation/tracking.
+        submit_response = await self._request("POST", "/jobs", json=payload)
+        job_id = submit_response["id"]
+        self._current_job_id = job_id
+
+        # Poll until the job reaches a terminal state.
+        if self.config.timeout_seconds is not None:
+            job = await asyncio.wait_for(
+                self._poll_until_done(job_id),
+                timeout=self.config.timeout_seconds,
+            )
+        else:
+            job = await self._poll_until_done(job_id)
+
+        wall_time = time.perf_counter() - start_time
+
+        status = job.get("status")
+        if status in _FAILURE_STATUSES:
+            message = job.get("failure", {}).get("error") or f"job {status}"
+            raise RuntimeError(f"IonQ job {job_id} {status}: {message}")
+
+        histogram = job.get("data", {}).get("histogram")
+        if histogram is None:
+            histogram = await self._request("GET", f"/jobs/{job_id}/results")
+
+        counts = self._histogram_to_counts(histogram, shots, num_qubits)
+
+        execution_time_ms = job.get("execution_time")
+        return ExecutionResult(
+            counts=counts,
+            backend=self.config.target,
+            execution_time_ms=execution_time_ms if execution_time_ms else wall_time * 1000,
+            shots=shots,
+            raw_result=job,
+            metadata={
+                "job_id": job_id,
+                "target": self.config.target,
+                "provider": "ionq",
+                "noise_model": self.config.noise_model,
+                "wall_time_ms": wall_time * 1000,
+            },
+        )
+
+    async def _poll_until_done(self, job_id: str) -> dict[str, Any]:
+        """Poll a job until it reaches a terminal state.
+
+        Args:
+            job_id: The IonQ job id to poll.
+
+        Returns:
+            The terminal job object.
+        """
+        while True:
+            job = await self._request("GET", f"/jobs/{job_id}")
+            status = job.get("status")
+            if status in _SUCCESS_STATUSES or status in _FAILURE_STATUSES:
+                return job
+            await asyncio.sleep(self.config.poll_interval_seconds)
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        """Make an authenticated request to the IonQ API (off the event loop).
+
+        Args:
+            method: HTTP method ("GET", "POST", "PUT").
+            path: API path relative to ``base_url`` (e.g. "/jobs").
+            **kwargs: Extra arguments forwarded to the HTTP session (e.g. ``json``).
+
+        Returns:
+            The parsed JSON response body.
+        """
+        loop = asyncio.get_running_loop()
+        session = await loop.run_in_executor(None, self._get_session_sync)
+        url = f"{self.config.base_url}{path}"
+        headers = self._auth_headers()
+
+        def _call() -> dict[str, Any]:
+            response = session.request(
+                method, url, headers=headers, timeout=_HTTP_TIMEOUT_SECONDS, **kwargs
+            )
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+            return data
+
+        return await loop.run_in_executor(None, _call)
+
+    async def cancel(self, job_id: str) -> bool:
+        """Cancel a running IonQ job.
+
+        Args:
+            job_id: The job id to cancel.
+
+        Returns:
+            True if cancellation succeeded, False otherwise.
+        """
+        try:
+            await self._request("PUT", f"/jobs/{job_id}/status/cancel")
+            return True
+        except Exception:
+            return False
+
+    async def get_status(self) -> DeviceStatus:
+        """Get live device status from the IonQ API.
+
+        Maps IonQ backend availability to the standard DeviceStatus states.
+        Returns "maintenance" on any error so callers can degrade gracefully.
+        """
+        try:
+            backend = await self._request("GET", f"/backends/{self.config.target}")
+            raw_status = str(backend.get("status", "")).lower()
+            status = self._IONQ_STATUS_MAP.get(raw_status, "maintenance")
+
+            queue_depth = backend.get("queue_depth") or backend.get("jobs_queued")
+            avg_queue = backend.get("average_queue_time")
+            queue_time_seconds = int(avg_queue) if avg_queue is not None else None
+
+            return DeviceStatus(
+                status=status,
+                queue_depth=queue_depth,
+                queue_time_seconds=queue_time_seconds,
+            )
+        except Exception:
+            return DeviceStatus(status="maintenance", queue_depth=None, queue_time_seconds=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,12 +55,17 @@ azure = [
     "qiskit>=1.0.0",
     "cirq>=1.0.0",
 ]
+ionq = [
+    "requests>=2.31.0",
+    "qiskit>=1.0.0",
+]
 all = [
     "qiskit>=1.0.0",
     "qiskit-ibm-runtime>=0.20.0",
     "qiskit-qasm3-import>=0.5.0",
     "cirq-core>=1.0.0",
     "pennylane>=0.35.0",
+    "requests>=2.31.0",
 ]
 
 [project.scripts]

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -7,10 +7,11 @@ import pytest
 from marqov.circuits import Circuit, bell_state
 from marqov.executors import (
     AzureQuantumExecutor,
-    BaseExecutor,
     BraketExecutor,
     ExecutionResult,
+    ExecutorFactory,
     IBMExecutor,
+    IonQExecutor,
     LocalExecutor,
 )
 from marqov.executors.azure import AzureQuantumExecutorConfig
@@ -698,3 +699,36 @@ class TestIBMExecutorGetStatus:
             assert status.status == "online"
             assert status.queue_depth is None
             assert status.queue_time_seconds is None
+
+
+class TestExecutorFactory:
+    """Tests for ExecutorFactory provider routing."""
+
+    def test_ionq_direct_is_supported(self) -> None:
+        """IonQ Direct is listed as a supported provider."""
+        assert ExecutorFactory.is_provider_supported("IonQ Direct")
+        assert "IonQ Direct" in ExecutorFactory.get_supported_providers()
+
+    def test_create_ionq_executor(self) -> None:
+        """Factory builds an IonQExecutor for the IonQ Direct provider."""
+        executor = ExecutorFactory.create_executor(
+            "qpu.aria-1",
+            {"provider": "IonQ Direct", "api_key": "test-key"},
+        )
+        assert isinstance(executor, IonQExecutor)
+        assert executor.config.target == "qpu.aria-1"
+        assert executor.config.api_key == "test-key"
+
+    def test_create_ionq_executor_uses_explicit_target(self) -> None:
+        """An explicit target overrides the backend slug."""
+        executor = ExecutorFactory.create_executor(
+            "ignored-slug",
+            {"provider": "IonQ Direct", "target": "simulator"},
+        )
+        assert isinstance(executor, IonQExecutor)
+        assert executor.config.target == "simulator"
+
+    def test_missing_provider_raises(self) -> None:
+        """A config without a provider raises ValueError."""
+        with pytest.raises(ValueError, match="missing 'provider'"):
+            ExecutorFactory.create_executor("sv1", {})

--- a/tests/test_ionq_executor.py
+++ b/tests/test_ionq_executor.py
@@ -5,6 +5,7 @@ require IonQ credentials. A commented integration template at the bottom shows h
 to run against the real API via the IONQ_API_KEY environment variable.
 """
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -350,6 +351,24 @@ class TestIonQExecutorExecute:
             await executor.execute(circuit, shots=10)
 
         assert captured["noise"] == {"model": "aria-1"}
+
+    @pytest.mark.asyncio
+    async def test_execute_times_out(self) -> None:
+        """A perpetually-running job raises TimeoutError when timeout_seconds is set."""
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            if method == "POST":
+                return {"id": "job-t", "status": "submitted"}
+            return {"status": "running"}  # never reaches a terminal state
+
+        config = IonQExecutorConfig(
+            api_key="k", poll_interval_seconds=0.0, timeout_seconds=0.05
+        )
+        executor = IonQExecutor(config, session=_make_session(router))
+        circuit = Circuit().h(0)
+        with _patch_qasm(num_qubits=1):
+            with pytest.raises(asyncio.TimeoutError):
+                await executor.execute(circuit, shots=10)
 
     @pytest.mark.asyncio
     async def test_execute_failed_job_raises(self) -> None:

--- a/tests/test_ionq_executor.py
+++ b/tests/test_ionq_executor.py
@@ -1,0 +1,370 @@
+"""Tests for the IonQ Direct API executor.
+
+All tests use an injected stub HTTP session, so they never touch the network or
+require IonQ credentials. A commented integration template at the bottom shows how
+to run against the real API via the IONQ_API_KEY environment variable.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from marqov.circuits import Circuit, bell_state
+from marqov.executors import ExecutionResult, IonQExecutor
+from marqov.executors.ionq import IonQExecutorConfig
+
+
+def _make_session(router) -> MagicMock:
+    """Build a stub HTTP session whose .request() is driven by ``router``.
+
+    Mirrors ``requests.Session.request(method, url, **kwargs) -> Response``.
+
+    Args:
+        router: Callable (method, url, **kwargs) -> dict returning the JSON body
+            for a given request. Raising propagates to the executor.
+
+    Returns:
+        A MagicMock session compatible with IonQExecutor's request path.
+    """
+    session = MagicMock()
+
+    def request(method, url, **kwargs):  # noqa: ANN001, ANN202
+        response = MagicMock()
+        response.json.return_value = router(method, url, **kwargs)
+        response.raise_for_status.return_value = None
+        return response
+
+    session.request.side_effect = request
+    return session
+
+
+def _patch_qasm(num_qubits: int = 2):
+    """Patch _circuit_to_qasm so execute tests don't need a real conversion.
+
+    The real to_qiskit() -> QASM conversion is covered by TestCircuitToQasm.
+    """
+    return patch.object(
+        IonQExecutor,
+        "_circuit_to_qasm",
+        return_value=("OPENQASM 2.0;\n", num_qubits),
+    )
+
+
+class TestIonQExecutorConfig:
+    """Tests for IonQExecutorConfig."""
+
+    def test_defaults(self) -> None:
+        """Config has sensible defaults."""
+        config = IonQExecutorConfig()
+        assert config.target == "simulator"
+        assert config.api_key is None
+        assert config.base_url == "https://api.ionq.co/v0.3"
+        assert config.poll_interval_seconds == 1.0
+        assert config.timeout_seconds is None
+        assert config.noise_model is None
+
+    def test_custom_values(self) -> None:
+        """Config stores custom values."""
+        config = IonQExecutorConfig(
+            target="qpu.aria-1",
+            api_key="secret",
+            base_url="https://example.test/v1",
+            poll_interval_seconds=0.5,
+            timeout_seconds=120.0,
+            noise_model="aria-1",
+        )
+        assert config.target == "qpu.aria-1"
+        assert config.api_key == "secret"
+        assert config.base_url == "https://example.test/v1"
+        assert config.poll_interval_seconds == 0.5
+        assert config.timeout_seconds == 120.0
+        assert config.noise_model == "aria-1"
+
+
+class TestHistogramToCounts:
+    """Tests for the histogram -> counts conversion."""
+
+    def test_basic_conversion(self) -> None:
+        """State indices are zero-padded and scaled by shots."""
+        counts = IonQExecutor._histogram_to_counts({"0": 0.5, "3": 0.5}, 1000, 2)
+        assert counts == {"00": 500, "11": 500}
+
+    def test_zero_padding(self) -> None:
+        """Indices are padded to the qubit width."""
+        counts = IonQExecutor._histogram_to_counts({"1": 1.0}, 100, 3)
+        assert counts == {"001": 100}
+
+    def test_rounding(self) -> None:
+        """Probabilities are rounded to the nearest integer count."""
+        counts = IonQExecutor._histogram_to_counts({"0": 0.333, "1": 0.667}, 9, 1)
+        assert counts == {"0": 3, "1": 6}
+
+
+class TestCircuitToQasm:
+    """Tests for the to_qiskit() -> QASM conversion path."""
+
+    def test_uses_to_qiskit_and_dumps_qasm(self) -> None:
+        """Conversion goes through to_qiskit() and returns QASM + qubit count."""
+        circuit = bell_state()
+        qasm, num_qubits = IonQExecutor._circuit_to_qasm(circuit)
+        assert "OPENQASM" in qasm
+        assert num_qubits == 2
+
+
+class TestAuthHeaders:
+    """Tests for API key resolution."""
+
+    def test_missing_key_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No config key and no env var raises ValueError."""
+        monkeypatch.delenv("IONQ_API_KEY", raising=False)
+        executor = IonQExecutor(IonQExecutorConfig())
+        with pytest.raises(ValueError, match="IonQ API key not found"):
+            executor._auth_headers()
+
+    def test_config_key_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Config key takes effect."""
+        monkeypatch.delenv("IONQ_API_KEY", raising=False)
+        executor = IonQExecutor(IonQExecutorConfig(api_key="cfg-key"))
+        assert executor._auth_headers() == {"Authorization": "apiKey cfg-key"}
+
+    def test_env_key_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Environment variable is used when config key is absent."""
+        monkeypatch.setenv("IONQ_API_KEY", "env-key")
+        executor = IonQExecutor(IonQExecutorConfig())
+        assert executor._auth_headers() == {"Authorization": "apiKey env-key"}
+
+
+class TestIonQExecutorExecute:
+    """Tests for IonQExecutor.execute with a stubbed session."""
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_result(self) -> None:
+        """A completed job yields counts from the histogram."""
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            if method == "POST" and url.endswith("/jobs"):
+                return {"id": "job-123", "status": "submitted"}
+            if method == "GET" and url.endswith("/jobs/job-123"):
+                return {
+                    "status": "completed",
+                    "data": {"histogram": {"0": 0.5, "3": 0.5}},
+                    "execution_time": 42,
+                }
+            raise AssertionError(f"unexpected request: {method} {url}")
+
+        config = IonQExecutorConfig(target="simulator", api_key="k")
+        executor = IonQExecutor(config, session=_make_session(router))
+        circuit = bell_state()
+
+        with _patch_qasm(num_qubits=2):
+            result = await executor.execute(circuit, shots=1000)
+
+        assert isinstance(result, ExecutionResult)
+        assert result.counts == {"00": 500, "11": 500}
+        assert result.shots == 1000
+        assert result.backend == "simulator"
+        assert result.metadata["job_id"] == "job-123"
+        assert result.metadata["provider"] == "ionq"
+        assert result.probabilities == {"00": 0.5, "11": 0.5}
+
+    @pytest.mark.asyncio
+    async def test_execute_submits_qasm_input(self) -> None:
+        """The submission payload carries the QASM input format."""
+        captured: dict = {}
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            if method == "POST":
+                captured.update(kwargs.get("json", {}))
+                return {"id": "job-1", "status": "submitted"}
+            return {"status": "completed", "data": {"histogram": {"0": 1.0}}}
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        circuit = Circuit().h(0)
+        with _patch_qasm(num_qubits=1):
+            await executor.execute(circuit, shots=10)
+
+        assert captured["input"]["format"] == "qasm"
+        assert "data" in captured["input"]
+        assert captured["target"] == "simulator"
+        assert captured["shots"] == 10
+
+    @pytest.mark.asyncio
+    async def test_execute_polls_until_complete(self) -> None:
+        """Execute keeps polling while the job is still running."""
+        calls = {"n": 0}
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            if method == "POST":
+                return {"id": "job-xyz", "status": "submitted"}
+            calls["n"] += 1
+            if calls["n"] < 3:
+                return {"status": "running"}
+            return {"status": "completed", "data": {"histogram": {"0": 1.0}}}
+
+        config = IonQExecutorConfig(api_key="k", poll_interval_seconds=0.0)
+        executor = IonQExecutor(config, session=_make_session(router))
+        circuit = Circuit().h(0)
+
+        with _patch_qasm(num_qubits=1):
+            result = await executor.execute(circuit, shots=100)
+
+        assert calls["n"] == 3
+        assert result.counts == {"0": 100}
+
+    @pytest.mark.asyncio
+    async def test_execute_records_job_id(self) -> None:
+        """The submitted job id is tracked for cancellation."""
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            if method == "POST":
+                return {"id": "track-me", "status": "submitted"}
+            return {"status": "completed", "data": {"histogram": {"0": 1.0}}}
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        circuit = Circuit().h(0)
+        with _patch_qasm(num_qubits=1):
+            await executor.execute(circuit, shots=10)
+
+        assert executor._current_job_id == "track-me"
+
+    @pytest.mark.asyncio
+    async def test_execute_applies_noise_model(self) -> None:
+        """A simulator noise model is included in the submission payload."""
+        captured: dict = {}
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            if method == "POST":
+                captured.update(kwargs.get("json", {}))
+                return {"id": "job-1", "status": "submitted"}
+            return {"status": "completed", "data": {"histogram": {"0": 1.0}}}
+
+        config = IonQExecutorConfig(api_key="k", target="simulator", noise_model="aria-1")
+        executor = IonQExecutor(config, session=_make_session(router))
+        circuit = Circuit().h(0)
+        with _patch_qasm(num_qubits=1):
+            await executor.execute(circuit, shots=10)
+
+        assert captured["noise"] == {"model": "aria-1"}
+
+    @pytest.mark.asyncio
+    async def test_execute_failed_job_raises(self) -> None:
+        """A failed job raises RuntimeError with the IonQ message."""
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            if method == "POST":
+                return {"id": "bad-job", "status": "submitted"}
+            return {"status": "failed", "failure": {"error": "boom"}}
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        circuit = Circuit().h(0)
+        with _patch_qasm(num_qubits=1):
+            with pytest.raises(RuntimeError, match="boom"):
+                await executor.execute(circuit, shots=10)
+
+
+class TestIonQExecutorCancel:
+    """Tests for IonQExecutor.cancel."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_success(self) -> None:
+        """Cancel returns True on success."""
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            assert method == "PUT"
+            assert url.endswith("/jobs/job-1/status/cancel")
+            return {}
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        assert await executor.cancel("job-1") is True
+
+    @pytest.mark.asyncio
+    async def test_cancel_failure(self) -> None:
+        """Cancel returns False when the request fails."""
+        session = MagicMock()
+        session.request.side_effect = Exception("network down")
+        executor = IonQExecutor(IonQExecutorConfig(api_key="k"), session=session)
+        assert await executor.cancel("job-1") is False
+
+
+class TestIonQExecutorGetStatus:
+    """Tests for IonQExecutor.get_status."""
+
+    @pytest.mark.asyncio
+    async def test_available_maps_to_online(self) -> None:
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            return {"status": "available", "jobs_queued": 4, "average_queue_time": 120}
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        status = await executor.get_status()
+        assert status.status == "online"
+        assert status.queue_depth == 4
+        assert status.queue_time_seconds == 120
+
+    @pytest.mark.asyncio
+    async def test_unavailable_maps_to_offline(self) -> None:
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            return {"status": "unavailable"}
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        status = await executor.get_status()
+        assert status.status == "offline"
+
+    @pytest.mark.asyncio
+    async def test_calibrating_maps_to_maintenance(self) -> None:
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            return {"status": "calibrating"}
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        status = await executor.get_status()
+        assert status.status == "maintenance"
+
+    @pytest.mark.asyncio
+    async def test_error_returns_maintenance(self) -> None:
+        session = MagicMock()
+        session.request.side_effect = Exception("API error")
+        executor = IonQExecutor(IonQExecutorConfig(api_key="k"), session=session)
+        status = await executor.get_status()
+        assert status.status == "maintenance"
+        assert status.queue_depth is None
+
+
+class TestIonQExecutorMisc:
+    """Miscellaneous IonQExecutor behavior."""
+
+    def test_executor_name(self) -> None:
+        """Executor name property works."""
+        executor = IonQExecutor(IonQExecutorConfig(api_key="k"))
+        assert executor.name == "IonQExecutor"
+
+    @pytest.mark.asyncio
+    async def test_non_circuit_raises_type_error(self) -> None:
+        """Passing a non-Circuit reuses the base validation error."""
+        executor = IonQExecutor(IonQExecutorConfig(api_key="k"))
+        with pytest.raises(TypeError, match="Expected a Marqov Circuit"):
+            await executor.execute("not a circuit")
+
+
+# Integration test template (requires real IonQ credentials, not run in CI):
+#
+# @pytest.mark.integration
+# @pytest.mark.asyncio
+# async def test_execute_on_ionq_simulator() -> None:
+#     """Execute on the IonQ cloud simulator (requires IONQ_API_KEY)."""
+#     config = IonQExecutorConfig(target="simulator")  # key from IONQ_API_KEY
+#     executor = IonQExecutor(config)
+#     result = await executor.execute(bell_state(), shots=100)
+#     assert set(result.counts).issubset({"00", "11"})

--- a/tests/test_ionq_executor.py
+++ b/tests/test_ionq_executor.py
@@ -99,6 +99,25 @@ class TestHistogramToCounts:
         counts = IonQExecutor._histogram_to_counts({"0": 0.333, "1": 0.667}, 9, 1)
         assert counts == {"0": 3, "1": 6}
 
+    def test_counts_sum_to_shots(self) -> None:
+        """Largest-remainder allocation keeps the total exactly equal to shots."""
+        # Three equal thirds would each round to 33 (sum 99) with naive rounding.
+        histogram = {"0": 1 / 3, "1": 1 / 3, "2": 1 / 3}
+        counts = IonQExecutor._histogram_to_counts(histogram, 100, 2)
+        assert sum(counts.values()) == 100
+        # The leftover shot goes to a single bin: counts are 34/33/33 in some order.
+        assert sorted(counts.values()) == [33, 33, 34]
+
+    def test_counts_sum_to_shots_many_states(self) -> None:
+        """Totals stay exact even when many bins each carry a fractional part."""
+        histogram = {str(i): 1 / 7 for i in range(7)}
+        counts = IonQExecutor._histogram_to_counts(histogram, 1000, 3)
+        assert sum(counts.values()) == 1000
+
+    def test_empty_histogram(self) -> None:
+        """An empty histogram yields no counts."""
+        assert IonQExecutor._histogram_to_counts({}, 100, 2) == {}
+
 
 class TestCircuitToQasm:
     """Tests for the to_qiskit() -> QASM conversion path."""

--- a/tests/test_ionq_executor.py
+++ b/tests/test_ionq_executor.py
@@ -119,6 +119,27 @@ class TestHistogramToCounts:
         assert IonQExecutor._histogram_to_counts({}, 100, 2) == {}
 
 
+class TestExtractHistogram:
+    """Tests for normalizing the results-endpoint response shape."""
+
+    def test_direct_mapping(self) -> None:
+        """A bare histogram mapping is returned as-is."""
+        assert IonQExecutor._extract_histogram({"0": 0.5, "1": 0.5}) == {"0": 0.5, "1": 0.5}
+
+    def test_histogram_wrapped(self) -> None:
+        """A {'histogram': {...}} shape is unwrapped."""
+        assert IonQExecutor._extract_histogram({"histogram": {"0": 1.0}}) == {"0": 1.0}
+
+    def test_data_histogram_wrapped(self) -> None:
+        """A {'data': {'histogram': {...}}} shape is unwrapped."""
+        payload = {"data": {"histogram": {"3": 1.0}}}
+        assert IonQExecutor._extract_histogram(payload) == {"3": 1.0}
+
+    def test_probabilities_key(self) -> None:
+        """A {'probabilities': {...}} shape is unwrapped."""
+        assert IonQExecutor._extract_histogram({"probabilities": {"2": 1.0}}) == {"2": 1.0}
+
+
 class TestCircuitToQasm:
     """Tests for the to_qiskit() -> QASM conversion path."""
 
@@ -210,6 +231,67 @@ class TestIonQExecutorExecute:
         assert captured["shots"] == 10
 
     @pytest.mark.asyncio
+    async def test_execute_uses_results_endpoint_when_no_inline_histogram(self) -> None:
+        """Falls back to /results and unwraps a wrapped histogram shape."""
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            if method == "POST":
+                return {"id": "job-9", "status": "submitted"}
+            if url.endswith("/jobs/job-9/results"):
+                # Wrapped shape — must be unwrapped, not passed through verbatim.
+                return {"data": {"histogram": {"0": 0.5, "3": 0.5}}}
+            return {"status": "completed"}  # job object has no inline histogram
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        circuit = bell_state()
+        with _patch_qasm(num_qubits=2):
+            result = await executor.execute(circuit, shots=1000)
+
+        assert result.counts == {"00": 500, "11": 500}
+
+    @pytest.mark.asyncio
+    async def test_execute_preserves_zero_execution_time(self) -> None:
+        """A reported execution_time of 0 is preserved, not treated as missing."""
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            if method == "POST":
+                return {"id": "job-0", "status": "submitted"}
+            return {
+                "status": "completed",
+                "data": {"histogram": {"0": 1.0}},
+                "execution_time": 0,
+            }
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        circuit = Circuit().h(0)
+        with _patch_qasm(num_qubits=1):
+            result = await executor.execute(circuit, shots=10)
+
+        assert result.execution_time_ms == 0
+
+    @pytest.mark.asyncio
+    async def test_execute_falls_back_to_wall_time_when_unreported(self) -> None:
+        """When IonQ omits execution_time, wall time (a positive float) is used."""
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            if method == "POST":
+                return {"id": "job-w", "status": "submitted"}
+            return {"status": "completed", "data": {"histogram": {"0": 1.0}}}
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        circuit = Circuit().h(0)
+        with _patch_qasm(num_qubits=1):
+            result = await executor.execute(circuit, shots=10)
+
+        assert result.execution_time_ms > 0
+
+    @pytest.mark.asyncio
     async def test_execute_polls_until_complete(self) -> None:
         """Execute keeps polling while the job is still running."""
         calls = {"n": 0}
@@ -287,6 +369,27 @@ class TestIonQExecutorExecute:
                 await executor.execute(circuit, shots=10)
 
 
+class TestRequestHeaders:
+    """Tests for header handling in the internal request helper."""
+
+    @pytest.mark.asyncio
+    async def test_caller_headers_merged_with_auth(self) -> None:
+        """Caller-supplied headers merge with auth headers (no TypeError)."""
+        captured: dict = {}
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            captured.update(kwargs)
+            return {"ok": True}
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        await executor._request("GET", "/jobs", headers={"X-Custom": "1"})
+
+        assert captured["headers"]["Authorization"] == "apiKey k"
+        assert captured["headers"]["X-Custom"] == "1"
+
+
 class TestIonQExecutorCancel:
     """Tests for IonQExecutor.cancel."""
 
@@ -328,6 +431,19 @@ class TestIonQExecutorGetStatus:
         assert status.status == "online"
         assert status.queue_depth == 4
         assert status.queue_time_seconds == 120
+
+    @pytest.mark.asyncio
+    async def test_zero_queue_depth_preserved(self) -> None:
+        """A queue_depth of 0 (empty queue) is reported, not treated as missing."""
+
+        def router(method, url, **kwargs):  # noqa: ANN001, ANN202
+            return {"status": "available", "queue_depth": 0, "jobs_queued": 5}
+
+        executor = IonQExecutor(
+            IonQExecutorConfig(api_key="k"), session=_make_session(router)
+        )
+        status = await executor.get_status()
+        assert status.queue_depth == 0
 
     @pytest.mark.asyncio
     async def test_unavailable_maps_to_offline(self) -> None:


### PR DESCRIPTION
## Summary
 
Closes #1 

Adds a native **IonQ Direct** executor  that runs circuits straight against IonQ's REST API, bypassing the AWS Braket intermediary — no AWS account or S3 bucket required. Circuits are converted with `circuit.to_qiskit()` then dumped to OpenQASM and submitted using IonQ's `qasm` input format. `execute()` submits, polls for completion, and decodes IonQ's probability histogram into measurement counts.

## Type of change

- [ ] Bug fix
- [x] New executor
- [ ] Circuit format converter
- [ ] Documentation
- [ ] Other (describe):

## Testing

- [x] I ran `pytest tests/ -v` and tests pass
- [x] For new executors: tested against local simulator or QVM (describe below)
- [ ] For circuit converters: roundtrip test passes with known-correct reference circuit

**Test details:**

- New mocked suite `tests/test_ionq_executor.py` (23 tests) injects a fake HTTP session — no network or credentials needed. Covers: `execute()` happy path, payload uses `qasm` input format, job polling, noise model, job-failure -> `RuntimeError`, histogram→counts decoding, API-key resolution, `cancel()` (success/failure), and `get_status()` mapping (online/offline/maintenance/error).
- Factory routing covered in `tests/test_executors.py` (`"IonQ Direct"` supported + builds an `IonQExecutor`).
- Full suite green locally: **328 passed, 13 skipped**. `ruff` and `mypy` (strict) clean on the new code.
- A commented `@pytest.mark.integration` template is included for running against the live IonQ simulator via `IONQ_API_KEY` (not run in CI).

## Checklist

- [x] No hardcoded credentials or API keys (key comes from config or `IONQ_API_KEY` env)
- [x] Handles the canonical gate set from `CONTRIBUTING.md §1` (conversion reuses the
  SDK's existing `to_qiskit()` path, so the canonical set is preserved)

**For new executors only:**

- [x] Registered in `ExecutorFactory` per `CONTRIBUTING.md §3` (provider string  `"IonQ Direct"`, `_create_ionq_executor()`, listed in `get_supported_providers()`, exported, new optional `[ionq]` extra)
- [x] `get_status()` returns device-level availability (`"online"/"offline"/"maintenance"`) by querying `GET /backends/{target}` — not job-level status (per `CONTRIBUTING.md §2`)

## Note on the official `ionq` client

The issue suggested the official `ionq` Python client. Its only release (`0.0.0a15`, pre-release) pins **`pydantic<2`**, which is unresolvable against marqov's core **`pydantic>=2`** requirement — `pip install marqov[ionq]` fails with ResolutionImpossible`. Transport therefore uses `requests` (the same HTTP library the official client uses internally) to call IonQ's REST API directly. This is documented in the executor's module docstring; happy to migrate to the official client once it supports pydantic 2.

## AI Disclosure

I used Claude to help implement and debug this PR: studying the existing executor patterns (Braket/IBM/Azure), scaffolding the IonQ executor and mocked tests, and diagnosing the `ionq` client's `pydantic<2` conflict with marqov's `pydantic>=2` (which is why transport uses `requests` directly). I reviewed all generated changes, ran `ruff`/`mypy`/`pytest` locally, and verified the executor end-to-end against a mocked IonQ API before submitting (no live API key, so the live path is untested).