### PR TITLE
to_pennylane Closes #27

### DIFF
--- a/marqov/circuits.py
+++ b/marqov/circuits.py
@@ -266,7 +266,44 @@ class Circuit:
         if version == 2:
             return qasm2.dumps(qiskit_circuit)
         return qasm3.dumps(qiskit_circuit)
+    
+    def to_pennylane(self):
+        """Convert circuit to a Pennylane QuantumTape.
 
+        Returns:
+            Pennylane QuantumTape representation.
+
+        Raises:
+            ImportError: If pennylane is not installed.
+        """
+        try:
+            import pennylane as qp
+            from pennylane.tape import QuantumTape
+        except ImportError:
+            raise ImportError(
+                "Pennylane is required for Circuit.to_pennylane(). "
+                "Install with: pip install marqov[pennylane]"
+            )
+        
+        tape_operations = []
+
+        for op in self._qf._elements:
+            marqov_op_name = str.lower(op.name)
+            pennylane_gate_name = self._INV_PENNYLANE_GATE_MAP[marqov_op_name]
+            gate = getattr(qp, pennylane_gate_name, None)
+            qubits = list(op.qubits)
+
+            if marqov_op_name in self._MARQOV_ROTATION_GATES:
+                angle = op._params[0]
+                operation = gate(angle, qubits)
+            else:
+                operation = gate(qubits)
+                
+            tape_operations.append(operation)
+
+        tape = QuantumTape(tape_operations)
+        return tape
+    
     # Simulation
 
     def simulate(self) -> qf.State:
@@ -544,6 +581,10 @@ class Circuit:
         "SWAP": "swap",
     }
 
+    _INV_PENNYLANE_GATE_MAP: dict[str, str] = {v: k for k, v in _PENNYLANE_GATE_MAP.items()}
+
+    _MARQOV_ROTATION_GATES: set[str] = {"rx", "ry", "rz"}
+
     _PENNYLANE_ROTATION_GATES: set[str] = {"RX", "RY", "RZ"}
 
     _PENNYLANE_SKIP: set[str] = {"Barrier"}
@@ -772,3 +813,4 @@ def ghz_state(num_qubits: int) -> Circuit:
     for i in range(num_qubits - 1):
         circuit.cnot(i, i + 1)
     return circuit
+

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -575,7 +575,7 @@ class TestSerialization:
 class TestToPennylane:
     """Tests for Circuit.to_pennylane()."""
 
-    def test_roundtrip_bell_state():
+    def test_roundtrip_bell_state(self):
         """Bell state survives to_pennylane roundtrip."""
         original = bell_state()
         pennylane = original.to_pennylane()
@@ -587,7 +587,7 @@ class TestToPennylane:
         rest_state = restored.simulate().tensor.flatten()
         assert np.allclose(np.abs(orig_state), np.abs(rest_state))
 
-    def test_to_pennylane_angle():
+    def test_to_pennylane_angle(self):
         """Angle survives conversion to pennylane"""
         original_angle = 50
         original = Circuit()
@@ -596,7 +596,7 @@ class TestToPennylane:
         pennylane_angle = pennylane.get_parameters()[0]
         assert original_angle == pennylane_angle
 
-    def test_every_gate():
+    def test_every_gate(self):
         """Every gate survives conversion to pennylane"""
         angle = 50
         marqov_circuit = Circuit()

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -570,3 +570,68 @@ class TestSerialization:
         orig_state = original.simulate().tensor.flatten()
         rest_state = restored.simulate().tensor.flatten()
         assert np.allclose(np.abs(orig_state), np.abs(rest_state))
+
+
+class TestToPennylane:
+    """Tests for Circuit.to_pennylane()."""
+
+    def test_roundtrip_bell_state():
+        """Bell state survives to_pennylane roundtrip."""
+        original = bell_state()
+        pennylane = original.to_pennylane()
+        restored = Circuit.from_pennylane(pennylane)
+
+        import numpy as np
+
+        orig_state = original.simulate().tensor.flatten()
+        rest_state = restored.simulate().tensor.flatten()
+        assert np.allclose(np.abs(orig_state), np.abs(rest_state))
+
+    def test_to_pennylane_angle():
+        """Angle survives conversion to pennylane"""
+        original_angle = 50
+        original = Circuit()
+        original.rx(original_angle, 0)
+        pennylane = original.to_pennylane()
+        pennylane_angle = pennylane.get_parameters()[0]
+        assert original_angle == pennylane_angle
+
+    def test_every_gate():
+        """Every gate survives conversion to pennylane"""
+        angle = 50
+        marqov_circuit = Circuit()
+        marqov_circuit.cnot(0,1)
+        marqov_circuit.h(0)
+        marqov_circuit.x(0)
+        marqov_circuit.y(0)
+        marqov_circuit.z(0)
+        marqov_circuit.s(0)
+        marqov_circuit.t(0)
+        marqov_circuit.rx(angle, 0)
+        marqov_circuit.ry(angle, 0)
+        marqov_circuit.rz(angle, 0)
+        marqov_circuit.cz(0, 1)
+        marqov_circuit.swap(0, 1)
+        
+        pennylane_circuit = marqov_circuit.to_pennylane()
+
+        pennylane_list_of_operations = pennylane_circuit.operations
+
+        from pennylane import CNOT, H, X, Y, Z, S, T, RX, RY, RZ, CZ, SWAP
+        expected_operations = [
+            CNOT(wires=[0, 1]),
+            H(0),
+            X(0),
+            Y(0),
+            Z(0),
+            S(0),
+            T(0),
+            RX(50, wires=[0]),
+            RY(50, wires=[0]),
+            RZ(50, wires=[0]),
+            CZ(wires=[0, 1]),
+            SWAP(wires=[0, 1])
+        ]
+
+        assert expected_operations == pennylane_list_of_operations
+        assert len(expected_operations) == len(pennylane_list_of_operations)


### PR DESCRIPTION
## Summary

Adds a conversion from a marqov circuit to a Pennylane QuantumTape with the to_pennylane function 
Closes #27


## Type of change

- [ ] Bug fix
- [ ] New executor
- [x] Circuit format converter
- [ ] Documentation
- [ ] Other (describe):

## Testing

- [x] I ran `pytest tests/ -v` and tests pass
- [ ] For new executors: tested against local simulator or QVM (describe below)
- [x] For circuit converters: roundtrip test passes with known-correct reference circuit

**Test details:**

## Checklist

- [x] No hardcoded credentials or API keys
- [x] Handles the canonical gate set from `CONTRIBUTING.md §1` (if adding a circuit converter)

**For new executors only:**
- [ ] Registered in `ExecutorFactory` per `CONTRIBUTING.md §3`
- [ ] `get_status()` returns device-level availability (`"online"/"offline"/"maintenance"`), not job-level status
