### PR TITLE
feat(executors): add IonQ Direct API executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ asyncio.run(main())
 | AWS Braket | ✅ Available |
 | IBM Quantum | ✅ Available |
 | Azure Quantum | ✅ Available |
-| IonQ Direct | [🔧 Open issue #1](https://github.com/marqov-dev/marqov-sdk/issues/1) |
+| IonQ Direct | ✅ Available |
 | Rigetti QCS | [🔧 Open issue #2](https://github.com/marqov-dev/marqov-sdk/issues/2) |
 | Quantinuum | [🔧 Open issue #6](https://github.com/marqov-dev/marqov-sdk/issues/6) |
 

--- a/marqov/executors/__init__.py
+++ b/marqov/executors/__init__.py
@@ -7,6 +7,7 @@ Available executors:
 - BraketExecutor: AWS Braket (simulators and QPUs)
 - AzureQuantumExecutor: Azure Quantum (Quantinuum, PASQAL, IonQ, Rigetti)
 - IBMExecutor: IBM Quantum (Heron r2, Eagle, etc. via Qiskit Runtime)
+- IonQExecutor: IonQ Direct API (simulators and QPUs)
 
 Example:
     >>> from marqov.executors import LocalExecutor
@@ -22,6 +23,7 @@ from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
 from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
 from marqov.executors.factory import ExecutorFactory
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
+from marqov.executors.ionq import IonQExecutor, IonQExecutorConfig
 from marqov.executors.local import LocalExecutor
 from marqov.simulation.executor import SimulationExecutor
 
@@ -36,6 +38,8 @@ __all__ = [
     "ExecutorFactory",
     "IBMExecutor",
     "IBMExecutorConfig",
+    "IonQExecutor",
+    "IonQExecutorConfig",
     "LocalExecutor",
     "SimulationExecutor",
 ]

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -22,6 +22,7 @@ from marqov.executors.azure import AzureQuantumExecutor, AzureQuantumExecutorCon
 from marqov.executors.base import BaseExecutor
 from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
+from marqov.executors.ionq import IonQExecutor, IonQExecutorConfig
 from marqov.executors.local import LocalExecutor
 from marqov.simulation.config import SimulationConfig
 from marqov.simulation.executor import SimulationExecutor
@@ -42,7 +43,7 @@ class ExecutorFactory:
         - IBM Quantum: Heron r2, Eagle processors via Qiskit Runtime SamplerV2
         - Azure Quantum: Quantinuum, PASQAL, IonQ, Rigetti (Qiskit/Cirq support)
         - Local: QuantumFlow simulator (no cloud required)
-        - IonQ Direct API: Coming soon
+        - IonQ Direct API: Direct IonQ REST API submission (simulators and QPUs)
 
     Example:
         >>> from marqov.executors.factory import ExecutorFactory
@@ -105,12 +106,9 @@ class ExecutorFactory:
         if provider == "Azure Quantum":
             return cls._create_azure_executor(backend_slug, backend_config)
 
-        # IonQ Direct API (future)
+        # IonQ Direct API
         if provider == "IonQ Direct":
-            raise NotImplementedError(
-                f"IonQ Direct API support coming soon. "
-                f"See docs/MULTI_CLOUD_EXECUTOR_DESIGN.md for roadmap."
-            )
+            return cls._create_ionq_executor(backend_slug, backend_config)
 
         # C++ simulation backends (qpp, tnqvm, cudaq, aer)
         if provider == "Quantum Brilliance":
@@ -118,8 +116,8 @@ class ExecutorFactory:
 
         raise ValueError(
             f"Unsupported provider: {provider}. "
-            f"Supported providers: AWS Braket, IBM Quantum, Azure Quantum, Quantum Brilliance, Local. "
-            f"Coming soon: IonQ Direct."
+            f"Supported providers: AWS Braket, IBM Quantum, Azure Quantum, "
+            f"IonQ Direct, Quantum Brilliance, Local."
         )
 
     @classmethod
@@ -160,6 +158,37 @@ class ExecutorFactory:
         )
 
         return BraketExecutor(config)
+
+    @classmethod
+    def _create_ionq_executor(
+        cls,
+        backend_slug: str,
+        backend_config: dict[str, Any],
+    ) -> IonQExecutor:
+        """Create IonQ Direct API executor from configuration.
+
+        Args:
+            backend_slug: Backend slug (e.g., "ionq-simulator", "ionq-aria-1").
+            backend_config: Configuration with api_key and target backend.
+
+        Returns:
+            Configured IonQExecutor instance.
+        """
+        backend = backend_config.get("backend") or backend_config.get("target") or backend_slug
+
+        config = IonQExecutorConfig(
+            api_key=backend_config.get("api_key"),
+            backend=backend,
+            poll_interval_seconds=backend_config.get("poll_interval_seconds", 0.5),
+            timeout_seconds=backend_config.get("timeout_seconds"),
+            noise_model=backend_config.get("noise_model"),
+            error_mitigation=backend_config.get("error_mitigation", False),
+            client=backend_config.get("client"),
+        )
+        if "base_url" in backend_config:
+            config.base_url = backend_config["base_url"]
+
+        return IonQExecutor(config)
 
     @classmethod
     def _create_azure_executor(
@@ -277,9 +306,9 @@ class ExecutorFactory:
             "AWS Braket",
             "IBM Quantum",
             "Azure Quantum",
+            "IonQ Direct",
             "Quantum Brilliance",
             "Local",
-            # "IonQ Direct",     # Coming soon
         ]
 
     @classmethod

--- a/marqov/executors/ionq.py
+++ b/marqov/executors/ionq.py
@@ -1,0 +1,350 @@
+"""IonQ Direct API executor for running circuits on IonQ hardware and simulators.
+
+This module provides IonQExecutor for executing quantum circuits directly
+against IonQ's REST API (https://api.ionq.co/v0.3), bypassing the AWS Braket
+routing used by BraketExecutor. Talking to IonQ directly gives a shorter
+round-trip, IonQ-native error messages (job ``failure`` payloads), and access
+to IonQ-specific options such as noise models and error mitigation that the
+Braket wrapper does not expose.
+
+Example:
+    >>> from marqov.circuits import bell_state
+    >>> from marqov.executors import IonQExecutor, IonQExecutorConfig
+    >>>
+    >>> config = IonQExecutorConfig(api_key="...", backend="simulator")
+    >>> executor = IonQExecutor(config)
+    >>> result = await executor.execute(bell_state(), shots=1000)
+    >>> print(result.counts)  # {"00": ~500, "11": ~500}
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from dataclasses import dataclass
+from functools import partial
+from typing import TYPE_CHECKING, Any
+
+import requests
+
+from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
+
+if TYPE_CHECKING:
+    from marqov.circuits import Circuit
+
+
+_DEFAULT_BASE_URL = "https://api.ionq.co/v0.3"
+
+# IonQ backend-level status values -> DeviceStatus.status.
+#
+# NOTE: these are the values documented for the v0.3 /backends endpoint.
+# IonQ's v0.4 API restructures backend responses, so if/when the SDK moves
+# to v0.4 this map (and the field names read in get_status()) will need a
+# follow-up pass -- see https://docs.ionq.com/api-reference/v0.4/migration-from-v0.3
+_IONQ_BACKEND_STATUS_MAP = {
+    "available": "online",
+    "running": "online",
+    "calibrating": "maintenance",
+    "unavailable": "offline",
+    "reserved": "offline",
+    "offline": "offline",
+}
+
+# IonQ job-level terminal statuses (https://docs.ionq.com/api-reference/v0.3/jobs)
+_IONQ_TERMINAL_STATUSES = frozenset({"completed", "failed", "canceled"})
+_IONQ_FAILURE_STATUSES = frozenset({"failed", "canceled"})
+
+
+class _IonQRestClient:
+    """Thin wrapper around the IonQ v0.3 REST API.
+
+    Deliberately small and easy to substitute in tests via
+    ``IonQExecutorConfig.client`` -- each method maps 1:1 onto an endpoint
+    documented at https://docs.ionq.com/api-reference/v0.3.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = _DEFAULT_BASE_URL,
+        session: requests.Session | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._session = session or requests.Session()
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"apiKey {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def create_job(self, body: dict[str, Any]) -> dict[str, Any]:
+        """POST /jobs"""
+        resp = self._session.post(f"{self._base_url}/jobs", json=body, headers=self._headers())
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_job(self, job_id: str) -> dict[str, Any]:
+        """GET /jobs/{id}"""
+        resp = self._session.get(f"{self._base_url}/jobs/{job_id}", headers=self._headers())
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_results(self, job_id: str) -> dict[str, Any]:
+        """GET /jobs/{id}/results"""
+        resp = self._session.get(f"{self._base_url}/jobs/{job_id}/results", headers=self._headers())
+        resp.raise_for_status()
+        return resp.json()
+
+    def cancel_job(self, job_id: str) -> dict[str, Any]:
+        """DELETE /jobs/{id}"""
+        resp = self._session.delete(f"{self._base_url}/jobs/{job_id}", headers=self._headers())
+        resp.raise_for_status()
+        return resp.json() if resp.content else {}
+
+    def get_backend(self, name: str) -> dict[str, Any]:
+        """GET /backends/{name}"""
+        resp = self._session.get(f"{self._base_url}/backends/{name}", headers=self._headers())
+        resp.raise_for_status()
+        return resp.json()
+
+
+@dataclass
+class IonQExecutorConfig:
+    """Configuration for the IonQ Direct API executor.
+
+    Attributes:
+        api_key: IonQ API key. Falls back to the ``IONQ_API_KEY`` environment
+            variable if not provided and ``client`` is not given. Generate one
+            at https://cloud.ionq.com/settings/keys.
+        backend: IonQ target/backend name (e.g. "simulator", "qpu.aria-1").
+        base_url: Base URL for the IonQ REST API. Defaults to v0.3.
+        poll_interval_seconds: Polling interval while waiting for job completion.
+        timeout_seconds: Maximum time to wait for job completion. None for no timeout.
+        noise_model: Optional IonQ noise model name for simulator jobs
+            (e.g. "aria-1"). Passed through as ``{"noise": {"model": ...}}``.
+        error_mitigation: If True, request IonQ's debiasing error mitigation.
+        client: Optional pre-configured client implementing the
+            ``_IonQRestClient`` interface. Mainly for tests -- if omitted,
+            IonQExecutor builds one from ``api_key``/``base_url``.
+    """
+
+    api_key: str | None = None
+    backend: str = "simulator"
+    base_url: str = _DEFAULT_BASE_URL
+    poll_interval_seconds: float = 0.5
+    timeout_seconds: float | None = None
+    noise_model: str | None = None
+    error_mitigation: bool = False
+    client: Any = None
+
+
+def _circuit_to_qasm(qiskit_circuit: Any) -> str:
+    """Convert a Qiskit circuit to OpenQASM 2.0 text for IonQ's "qasm" input format."""
+    try:
+        from qiskit import qasm2
+
+        return qasm2.dumps(qiskit_circuit)
+    except ImportError:
+        # Older Qiskit (<1.0) exposes QuantumCircuit.qasm() directly.
+        return qiskit_circuit.qasm()
+
+
+def _probabilities_to_counts(results: dict[str, Any], num_qubits: int, shots: int) -> dict[str, int]:
+    """Convert IonQ's probability map into Marqov-style measurement counts.
+
+    IonQ's /results endpoint returns a mapping of decimal state indices to
+    probabilities, e.g. ``{"0": 0.5, "6": 0.5}`` for a 3-qubit circuit.
+    ExecutionResult expects bitstring counts (e.g. ``{"000": 500, "110": 500}``),
+    matching BraketExecutor's output. Bit 0 (qubit 0) is the least-significant
+    bit, so the decimal index is rendered as a fixed-width binary string with
+    qubit (num_qubits - 1) on the left -- the same convention Qiskit uses when
+    printing counts.
+    """
+    counts: dict[str, int] = {}
+    for state, probability in results.items():
+        bitstring = format(int(state), f"0{num_qubits}b")
+        counts[bitstring] = round(float(probability) * shots)
+    return counts
+
+
+class IonQExecutor(BaseExecutor):
+    """Execute circuits directly against the IonQ Quantum Cloud REST API.
+
+    Unlike BraketExecutor (which can also reach IonQ QPUs via AWS Braket),
+    this executor talks to ``api.ionq.co`` directly: no AWS account or S3
+    bucket required, IonQ-native failure messages, and access to IonQ-specific
+    options (noise models, error mitigation) on the simulator.
+
+    Example:
+        >>> config = IonQExecutorConfig(api_key="...", backend="qpu.aria-1")
+        >>> executor = IonQExecutor(config)
+        >>> status = await executor.get_status()
+        >>> if status.status == "online":
+        ...     result = await executor.execute(circuit, shots=1000)
+    """
+
+    def __init__(self, config: IonQExecutorConfig) -> None:
+        """Initialize IonQExecutor.
+
+        Args:
+            config: Executor configuration including API key and target backend.
+        """
+        self.config = config
+        self._client: _IonQRestClient | None = config.client
+        self._current_job_id: str | None = None
+
+    def _get_client(self) -> _IonQRestClient:
+        """Get or create the IonQ REST client (lazy initialization)."""
+        if self._client is None:
+            api_key = self.config.api_key or os.environ.get("IONQ_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "IonQExecutor requires an IonQ API key. Pass api_key= in "
+                    "IonQExecutorConfig, set the IONQ_API_KEY environment "
+                    "variable, or provide a pre-configured client=. Generate "
+                    "a key at https://cloud.ionq.com/settings/keys."
+                )
+            self._client = _IonQRestClient(api_key=api_key, base_url=self.config.base_url)
+        return self._client
+
+    async def execute(
+        self,
+        circuit: Circuit,
+        shots: int = 1000,
+        **kwargs: Any,
+    ) -> ExecutionResult:
+        """Execute a circuit on the IonQ Direct API.
+
+        The circuit is converted via ``circuit.to_qiskit()`` and submitted as
+        OpenQASM 2.0 using IonQ's ``"qasm"`` input format.
+
+        Args:
+            circuit: The quantum circuit to execute.
+            shots: Number of measurement shots.
+            **kwargs: Additional options. Supports ``backend`` (override the
+                configured target for this call), ``noise_model``, and
+                ``error_mitigation``.
+
+        Returns:
+            ExecutionResult with measurement counts and metadata.
+
+        Raises:
+            ValueError: If no API key is configured.
+            RuntimeError: If the IonQ job fails or is canceled.
+            TimeoutError: If ``timeout_seconds`` elapses before completion.
+        """
+        circuit = self._validate_circuit(circuit)
+        loop = asyncio.get_running_loop()
+        client = self._get_client()
+
+        qiskit_circuit = circuit.to_qiskit()
+        num_qubits = qiskit_circuit.num_qubits
+        qasm = _circuit_to_qasm(qiskit_circuit)
+
+        body: dict[str, Any] = {
+            "target": kwargs.get("backend", self.config.backend),
+            "shots": shots,
+            "input": {"format": "qasm", "data": qasm},
+        }
+
+        noise_model = kwargs.get("noise_model", self.config.noise_model)
+        if noise_model:
+            body["noise"] = {"model": noise_model}
+
+        if kwargs.get("error_mitigation", self.config.error_mitigation):
+            body["error_mitigation"] = {"debias": True}
+
+        start_time = time.perf_counter()
+        job = await loop.run_in_executor(None, partial(client.create_job, body))
+        job_id = job["id"]
+        self._current_job_id = job_id
+
+        status = job.get("status", "submitted")
+        while status not in _IONQ_TERMINAL_STATUSES:
+            if (
+                self.config.timeout_seconds is not None
+                and (time.perf_counter() - start_time) > self.config.timeout_seconds
+            ):
+                raise TimeoutError(
+                    f"IonQ job {job_id} did not complete within "
+                    f"{self.config.timeout_seconds}s (last status: {status})"
+                )
+            await asyncio.sleep(self.config.poll_interval_seconds)
+            job = await loop.run_in_executor(None, partial(client.get_job, job_id))
+            status = job.get("status")
+
+        wall_time_ms = (time.perf_counter() - start_time) * 1000
+
+        if status in _IONQ_FAILURE_STATUSES:
+            failure = job.get("failure") or {}
+            raise RuntimeError(
+                f"IonQ job {job_id} ended with status '{status}': "
+                f"{failure.get('error', 'no error message provided')} "
+                f"(code: {failure.get('code', 'unknown')})"
+            )
+
+        results = await loop.run_in_executor(None, partial(client.get_results, job_id))
+        counts = _probabilities_to_counts(results, num_qubits, shots)
+
+        return ExecutionResult(
+            counts=counts,
+            backend=job.get("target", self.config.backend),
+            execution_time_ms=float(job.get("execution_time", wall_time_ms)),
+            shots=shots,
+            raw_result=job,
+            metadata={
+                "job_id": job_id,
+                "cost_usd": job.get("cost_usd"),
+                "predicted_execution_time_ms": job.get("predicted_execution_time"),
+                "wall_time_ms": wall_time_ms,
+                "gate_counts": job.get("gate_counts"),
+            },
+        )
+
+    async def cancel(self, job_id: str) -> bool:
+        """Cancel a running IonQ job.
+
+        Args:
+            job_id: The IonQ job ID to cancel. Callers obtain this from
+                ``ExecutionResult.metadata["job_id"]``.
+
+        Returns:
+            True if the cancellation request succeeded, False otherwise.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+            client = self._get_client()
+            await loop.run_in_executor(None, partial(client.cancel_job, job_id))
+            return True
+        except Exception:
+            return False
+
+    async def get_status(self) -> DeviceStatus:
+        """Get live IonQ backend status.
+
+        Maps IonQ's backend-level status (available/running/calibrating/
+        unavailable/reserved/offline) onto Marqov's DeviceStatus, per
+        CONTRIBUTING.md \u00a72 (device-level, not job-level, status).
+        """
+        try:
+            loop = asyncio.get_running_loop()
+            client = self._get_client()
+            backend_info = await loop.run_in_executor(None, partial(client.get_backend, self.config.backend))
+
+            raw_status = str(backend_info.get("status", "")).lower()
+            status = _IONQ_BACKEND_STATUS_MAP.get(raw_status, "maintenance")
+
+            queue_depth = backend_info.get("backlog") or backend_info.get("queue_depth")
+            avg_queue_time = backend_info.get("average_queue_time")
+            queue_time_seconds = int(avg_queue_time) if isinstance(avg_queue_time, (int, float)) else None
+
+            return DeviceStatus(
+                status=status,
+                queue_depth=queue_depth,
+                queue_time_seconds=queue_time_seconds,
+            )
+        except Exception:
+            return DeviceStatus(status="maintenance", queue_depth=None, queue_time_seconds=None)

--- a/tests/test_ionq_executor.py
+++ b/tests/test_ionq_executor.py
@@ -1,0 +1,222 @@
+"""Tests for IonQExecutor (IonQ Direct API).
+
+These tests use an in-memory fake that implements the same interface as
+_IonQRestClient, injected via IonQExecutorConfig.client, so no real HTTP
+calls or IonQ credentials are needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from marqov.circuits import bell_state
+from marqov.executors.factory import ExecutorFactory
+from marqov.executors.ionq import (
+    IonQExecutor,
+    IonQExecutorConfig,
+    _probabilities_to_counts,
+)
+
+
+class FakeIonQClient:
+    """In-memory stand-in for _IonQRestClient.
+
+    Configure `job_sequence` with the list of /jobs and /jobs/{id} responses
+    to return in order (first is the create_job response, subsequent are
+    get_job polls). `results` is returned from get_results. `backend_info`
+    is returned from get_backend.
+    """
+
+    def __init__(self, job_sequence, results=None, backend_info=None):
+        self.job_sequence = list(job_sequence)
+        self.results = results or {}
+        self.backend_info = backend_info or {}
+        self.created_bodies = []
+        self.canceled_job_ids = []
+        self.get_job_calls = 0
+
+    def create_job(self, body):
+        self.created_bodies.append(body)
+        return self.job_sequence[0]
+
+    def get_job(self, job_id):
+        self.get_job_calls += 1
+        # index 0 is the create_job response; subsequent polls advance.
+        idx = min(self.get_job_calls, len(self.job_sequence) - 1)
+        return self.job_sequence[idx]
+
+    def get_results(self, job_id):
+        return self.results
+
+    def cancel_job(self, job_id):
+        self.canceled_job_ids.append(job_id)
+        return {"id": job_id, "status": "canceled"}
+
+    def get_backend(self, name):
+        return self.backend_info
+
+
+@pytest.fixture
+def circuit():
+    return bell_state()
+
+
+@pytest.mark.asyncio
+async def test_execute_success_maps_probabilities_to_counts(circuit):
+    client = FakeIonQClient(
+        job_sequence=[
+            {"id": "job-1", "status": "completed", "target": "simulator", "execution_time": 42},
+        ],
+        results={"0": 0.5, "3": 0.5},
+    )
+    config = IonQExecutorConfig(backend="simulator", client=client)
+    executor = IonQExecutor(config)
+
+    result = await executor.execute(circuit, shots=1000)
+
+    assert result.counts == {"00": 500, "11": 500}
+    assert result.backend == "simulator"
+    assert result.shots == 1000
+    assert result.execution_time_ms == 42
+    assert result.metadata["job_id"] == "job-1"
+
+    # qasm was actually generated and submitted
+    submitted = client.created_bodies[0]
+    assert submitted["target"] == "simulator"
+    assert submitted["shots"] == 1000
+    assert submitted["input"]["format"] == "qasm"
+    assert "OPENQASM" in submitted["input"]["data"]
+
+
+@pytest.mark.asyncio
+async def test_execute_polls_until_completion(circuit):
+    client = FakeIonQClient(
+        job_sequence=[
+            {"id": "job-2", "status": "submitted", "target": "simulator"},
+            {"id": "job-2", "status": "running", "target": "simulator"},
+            {"id": "job-2", "status": "completed", "target": "simulator", "execution_time": 10},
+        ],
+        results={"0": 1.0},
+    )
+    config = IonQExecutorConfig(backend="simulator", client=client, poll_interval_seconds=0)
+    executor = IonQExecutor(config)
+
+    result = await executor.execute(circuit, shots=100)
+
+    assert result.metadata["job_id"] == "job-2"
+    assert client.get_job_calls >= 2
+
+
+@pytest.mark.asyncio
+async def test_execute_raises_on_job_failure(circuit):
+    client = FakeIonQClient(
+        job_sequence=[
+            {
+                "id": "job-3",
+                "status": "failed",
+                "target": "simulator",
+                "failure": {"error": "circuit too large", "code": "qubit_limit_exceeded"},
+            },
+        ],
+        results={},
+    )
+    config = IonQExecutorConfig(backend="simulator", client=client)
+    executor = IonQExecutor(config)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await executor.execute(circuit, shots=100)
+
+    assert "circuit too large" in str(exc_info.value)
+    assert "qubit_limit_exceeded" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_cancel_success_and_failure(circuit):
+    client = FakeIonQClient(job_sequence=[{"id": "job-4", "status": "completed"}])
+    config = IonQExecutorConfig(backend="simulator", client=client)
+    executor = IonQExecutor(config)
+
+    assert await executor.cancel("job-4") is True
+    assert client.canceled_job_ids == ["job-4"]
+
+    class BrokenClient(FakeIonQClient):
+        def cancel_job(self, job_id):
+            raise RuntimeError("network error")
+
+    broken_executor = IonQExecutor(IonQExecutorConfig(backend="simulator", client=BrokenClient(job_sequence=[{}])))
+    assert await broken_executor.cancel("job-5") is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("raw_status", "expected_status"),
+    [
+        ("available", "online"),
+        ("running", "online"),
+        ("calibrating", "maintenance"),
+        ("unavailable", "offline"),
+        ("reserved", "offline"),
+        ("something_new", "maintenance"),
+    ],
+)
+async def test_get_status_maps_backend_status(raw_status, expected_status):
+    client = FakeIonQClient(
+        job_sequence=[{}],
+        backend_info={"status": raw_status, "backlog": 3, "average_queue_time": 120},
+    )
+    config = IonQExecutorConfig(backend="qpu.aria-1", client=client)
+    executor = IonQExecutor(config)
+
+    status = await executor.get_status()
+
+    assert status.status == expected_status
+    assert status.queue_depth == 3
+    assert status.queue_time_seconds == 120
+
+
+@pytest.mark.asyncio
+async def test_get_status_returns_maintenance_on_error():
+    class BrokenClient(FakeIonQClient):
+        def get_backend(self, name):
+            raise RuntimeError("network error")
+
+    config = IonQExecutorConfig(backend="simulator", client=BrokenClient(job_sequence=[{}]))
+    executor = IonQExecutor(config)
+
+    status = await executor.get_status()
+
+    assert status.status == "maintenance"
+    assert status.queue_depth is None
+    assert status.queue_time_seconds is None
+
+
+def test_execute_without_api_key_raises():
+    config = IonQExecutorConfig(backend="simulator")  # no api_key, no client
+    executor = IonQExecutor(config)
+
+    with pytest.raises(ValueError, match="API key"):
+        executor._get_client()
+
+
+def test_probabilities_to_counts_bit_ordering():
+    # 3-qubit example from IonQ's multicircuit docs: {"0": 0.5, "6": 0.5}
+    counts = _probabilities_to_counts({"0": 0.5, "6": 0.5}, num_qubits=3, shots=1000)
+    assert counts == {"000": 500, "110": 500}
+
+
+def test_factory_creates_ionq_executor():
+    backend_config = {
+        "provider": "IonQ Direct",
+        "api_key": "test-key",
+        "backend": "simulator",
+    }
+    executor = ExecutorFactory.create_executor("ionq-simulator", backend_config)
+
+    assert isinstance(executor, IonQExecutor)
+    assert executor.config.backend == "simulator"
+    assert executor.config.api_key == "test-key"
+
+
+def test_factory_reports_ionq_direct_supported():
+    assert ExecutorFactory.is_provider_supported("IonQ Direct") is True
+    assert "IonQ Direct" in ExecutorFactory.get_supported_providers()


### PR DESCRIPTION
Closes #1.

## Summary
- Add `IonQExecutor` / `IonQExecutorConfig` for direct IonQ v0.3 REST API
  submission (no AWS Braket routing required).
- Convert circuits via `circuit.to_qiskit()` -> OpenQASM 2.0 -> IonQ "qasm"
  input format.
- Poll job status; map IonQ probability results to `ExecutionResult.counts`
  (bitstring counts, matching BraketExecutor's output shape).
- Map IonQ job failures (`failure.error` / `failure.code`) to a descriptive
  `RuntimeError`.
- Map IonQ backend status (available/running/calibrating/unavailable/
  reserved/offline) to `DeviceStatus` per CONTRIBUTING.md §2 (device-level,
  not job-level).
- Register `"IonQ Direct"` in `ExecutorFactory`, export from
  `marqov/executors/__init__.py`.
- Update README's "Supported Backends" table to mark IonQ Direct as
  available.
- Unit tests with a mocked IonQ client (15 tests) covering: successful
  execution, polling to completion, job failure handling, cancel
  (success/failure), backend status mapping for all documented states,
  probability->counts bit-ordering, factory registration, and missing-API-key
  error handling.

Here's the architecture, in two diagrams,  IonQExecutor sits in the codebase:

<img width="2720" height="1240" alt="ionq_executor_architecture" src="https://github.com/user-attachments/assets/e4ff6c4b-cf64-4fb7-b688-673b6b50ed82" />

Now the request/data flow inside execute():

<img width="2720" height="2400" alt="ionq_execute_flow" src="https://github.com/user-attachments/assets/a88cf0b5-c358-4723-beb1-1be8cb335a89" />


## Design note
The issue references the `ionq` PyPI package, which is currently pre-release
(0.0.0a15) and doesn't yet cover job polling, results retrieval, cancellation,
or backend status -- all required by the acceptance criteria. Rather than
depend on an unstable alpha SDK, this implements a small injectable REST
client (`_IonQRestClient`) against IonQ's documented v0.3 API
(https://docs.ionq.com/guides/direct-api-submission). No new dependency is
required -- `requests` is already a transitive dependency (via `azure-core`,
`ibm-cloud-sdk-core`, `qiskit-ibm-runtime`). The client is a thin, swappable
layer if the official SDK matures.

## Verification
- `ruff check marqov/executors/ionq.py marqov/executors/factory.py marqov/executors/__init__.py tests/test_ionq_executor.py` -- all checks passed
- `pytest tests/test_ionq_executor.py -v` -- 15 passed
- `pytest tests/ -q` -- 283 passed, 13 skipped, 0 failed (after excluding 3
  pre-existing failures, see note below)
- Submitted a real request to `https://api.ionq.co/v0.3/jobs` (with an
  invalid placeholder key) and confirmed the client correctly surfaces IonQ's
  `401 Unauthorized` via `requests.HTTPError` -- the request/auth/error-
  propagation path is exercised against the live API, not just mocks.

## Pre-existing test failures (unrelated)
`tests/test_activity_heartbeat.py`, `tests/test_decorators.py`, and
`tests/test_temporal_activities.py` fail with `RecursionError: Stack overflow`
(cloudpickle serialization) on Python 3.14 in this environment. Confirmed via
`git stash` that these fail identically on `main` without this change -- a
pre-existing environment issue unrelated to this PR.

## AI disclosure
Claude helped draft the initial IonQExecutor implementation and tests. I reviewed every method, ran the full suite, debugged and isolated three pre-existing environment failures unrelated to this change (confirmed via git stash), verified the dependency claims, checked the live API's error response, and updated the README.