### PR TITLE
feat(circuits): add Circuit.from_pyquil() import

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Import from other formats:
 circuit = Circuit.from_qiskit(qiskit_circuit)
 circuit = Circuit.from_cirq(cirq_circuit)
 circuit = Circuit.from_pennylane(tape)
+circuit = Circuit.from_pyquil(pyquil_program)  # requires pip install marqov[pyquil]
 ```
 
 ## Marqov Platform

--- a/marqov/circuits.py
+++ b/marqov/circuits.py
@@ -18,6 +18,7 @@ import quantumflow as qf
 
 if TYPE_CHECKING:
     from braket.circuits import Circuit as BraketCircuit
+    from pyquil import Program as PyQuilProgram
 
 
 class Circuit:
@@ -645,6 +646,154 @@ class Circuit:
 
         # tape.operations excludes measurements — no skip logic needed.
         _process_operations(tape.operations)
+        return circuit
+
+    # PyQuil gate name -> Circuit fluent method mapping.
+    _PYQUIL_GATE_MAP: dict[str, str] = {
+        "H": "h",
+        "X": "x",
+        "Y": "y",
+        "Z": "z",
+        "S": "s",
+        "T": "t",
+        "RX": "rx",
+        "RY": "ry",
+        "RZ": "rz",
+        "CNOT": "cnot",
+        "CX": "cnot",
+        "CZ": "cz",
+        "SWAP": "swap",
+    }
+
+    _PYQUIL_ROTATION_GATES: set[str] = {"RX", "RY", "RZ"}
+
+    # Classical declarations and measurement instructions do not affect the
+    # unitary circuit representation imported by this SDK.
+    _PYQUIL_SKIP_INSTRUCTIONS: set[str] = {"Declare", "Measurement", "Halt", "Pragma"}
+
+    @classmethod
+    def _pyquil_float_param(cls, value) -> float:
+        """Return a real-valued PyQuil gate parameter."""
+        try:
+            numeric = complex(value)
+        except (TypeError, ValueError) as exc:
+            raise NotImplementedError(
+                "Circuit.from_pyquil() only supports numeric real-valued "
+                "rotation parameters."
+            ) from exc
+
+        if abs(numeric.imag) > 1e-12:
+            raise NotImplementedError(
+                "Circuit.from_pyquil() only supports real-valued rotation parameters."
+            )
+        return float(numeric.real)
+
+    @classmethod
+    def _try_consume_swap_from_cnots(cls, instructions: list, index: int) -> tuple[int, int, int] | None:
+        """Detect a three-CNOT SWAP decomposition and return (q0, q1, consumed)."""
+        if index + 2 >= len(instructions):
+            return None
+
+        gates = instructions[index : index + 3]
+        try:
+            from pyquil.quilbase import Gate
+        except ImportError:
+            return None
+
+        if not all(isinstance(gate, Gate) for gate in gates):
+            return None
+
+        names = [gate.name.upper() for gate in gates]
+        if names != ["CNOT", "CNOT", "CNOT"]:
+            return None
+
+        q0, q1 = gates[0].get_qubit_indices()
+        if (
+            gates[1].get_qubit_indices() == [q1, q0]
+            and gates[2].get_qubit_indices() == [q0, q1]
+        ):
+            return q0, q1, 3
+
+        return None
+
+    @classmethod
+    def from_pyquil(cls, program: "PyQuilProgram") -> "Circuit":
+        """Import from a PyQuil Program.
+
+        Known gates in the Marqov canonical gate set are mapped directly.
+        SWAP is accepted either as a native ``SWAP`` instruction or as the
+        standard three-``CNOT`` decomposition. Classical declarations and
+        measurements are skipped. Quil-native gates outside the canonical set
+        raise ``NotImplementedError`` so callers can decompose them explicitly
+        before importing.
+
+        Requires PyQuil to be installed (``pip install marqov[pyquil]``).
+
+        Args:
+            program: A PyQuil ``Program`` instance.
+
+        Returns:
+            New Circuit instance.
+
+        Raises:
+            ImportError: If PyQuil is not installed.
+            TypeError: If the input is not a PyQuil Program or uses non-integer qubits.
+            NotImplementedError: If a Quil instruction cannot be mapped.
+        """
+        try:
+            from pyquil import Program
+            from pyquil.quilbase import Gate
+        except ImportError:
+            raise ImportError(
+                "PyQuil is required for Circuit.from_pyquil(). "
+                "Install with: pip install marqov[pyquil]"
+            )
+
+        if not isinstance(program, Program):
+            raise TypeError(f"Expected a PyQuil Program, got {type(program).__name__}")
+
+        circuit = cls()
+        instructions = list(program.instructions)
+        index = 0
+
+        while index < len(instructions):
+            swap_match = cls._try_consume_swap_from_cnots(instructions, index)
+            if swap_match is not None:
+                q0, q1, consumed = swap_match
+                circuit.swap(q0, q1)
+                index += consumed
+                continue
+
+            instruction = instructions[index]
+            index += 1
+
+            if not isinstance(instruction, Gate):
+                instruction_type = type(instruction).__name__
+                if instruction_type in cls._PYQUIL_SKIP_INSTRUCTIONS:
+                    continue
+                raise NotImplementedError(
+                    f"Unsupported PyQuil instruction '{instruction_type}'. "
+                    "Only canonical gates plus declarations and measurements are supported."
+                )
+
+            name = instruction.name.upper()
+            if name not in cls._PYQUIL_GATE_MAP:
+                raise NotImplementedError(
+                    f"Unsupported PyQuil gate '{name}'. Supported gates: "
+                    f"{', '.join(sorted(cls._PYQUIL_GATE_MAP))}"
+                )
+
+            qubits = list(instruction.get_qubit_indices())
+            method_name = cls._PYQUIL_GATE_MAP[name]
+
+            if name in cls._PYQUIL_ROTATION_GATES:
+                angle = cls._pyquil_float_param(instruction.params[0])
+                getattr(circuit, method_name)(angle, qubits[0])
+            elif len(qubits) == 1:
+                getattr(circuit, method_name)(qubits[0])
+            else:
+                getattr(circuit, method_name)(qubits[0], qubits[1])
+
         return circuit
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ cirq = [
 pennylane = [
     "pennylane>=0.35.0",
 ]
+pyquil = [
+    "pyquil>=4.0.0",
+]
 openqasm = [
     "qiskit>=1.0.0",
     "qiskit-qasm3-import>=0.5.0",
@@ -61,6 +64,7 @@ all = [
     "qiskit-qasm3-import>=0.5.0",
     "cirq-core>=1.0.0",
     "pennylane>=0.35.0",
+    "pyquil>=4.0.0",
 ]
 
 [project.scripts]

--- a/tests/test_circuits.py
+++ b/tests/test_circuits.py
@@ -446,6 +446,144 @@ class TestFromPennylane:
         assert np.isclose(np.abs(amps[3]) ** 2, 0.5, atol=0.01)
 
 
+class TestFromPyquil:
+    """Tests for Circuit.from_pyquil()."""
+
+    def test_bell_state_roundtrip(self) -> None:
+        """Bell state survives PyQuil roundtrip (state vector preserved)."""
+        import numpy as np
+
+        original = bell_state()
+        pyquil_program = original.to_pyquil()
+        imported = Circuit.from_pyquil(pyquil_program)
+
+        orig_amps = original.simulate().tensor.flatten()
+        imported_amps = imported.simulate().tensor.flatten()
+        assert imported.num_qubits == original.num_qubits
+        assert np.allclose(np.abs(orig_amps), np.abs(imported_amps))
+
+    def test_single_qubit_gates(self) -> None:
+        """All single-qubit gates convert correctly."""
+        from pyquil import Program
+        from pyquil.gates import H, S, T, X, Y, Z
+
+        original = Circuit().h(0).x(1).y(2).z(3).s(4).t(5)
+        pyquil_program = Program(
+            H(0),
+            X(1),
+            Y(2),
+            Z(3),
+            S(4),
+            T(5),
+        )
+        imported = Circuit.from_pyquil(pyquil_program)
+        assert imported.num_qubits == original.num_qubits
+
+    def test_rotation_gates_preserve_angles(self) -> None:
+        """Parameterized rotation gates preserve angles through roundtrip."""
+        import math
+        import numpy as np
+
+        original = Circuit().rx(math.pi / 3, 0).ry(math.pi / 5, 1).rz(math.pi / 7, 2)
+        imported = Circuit.from_pyquil(original.to_pyquil())
+
+        orig_amps = original.simulate().tensor.flatten()
+        imported_amps = imported.simulate().tensor.flatten()
+        assert np.allclose(np.abs(orig_amps), np.abs(imported_amps))
+
+    def test_two_qubit_gates(self) -> None:
+        """Two-qubit gates (CNOT, CZ, SWAP) convert correctly."""
+        import numpy as np
+
+        original = Circuit().h(0).cnot(0, 1).cz(1, 2).swap(0, 2)
+        imported = Circuit.from_pyquil(original.to_pyquil())
+
+        orig_amps = original.simulate().tensor.flatten()
+        imported_amps = imported.simulate().tensor.flatten()
+        assert np.allclose(np.abs(orig_amps), np.abs(imported_amps))
+
+    def test_native_swap_instruction(self) -> None:
+        """Native PyQuil SWAP is supported directly."""
+        import numpy as np
+        from pyquil import Program
+        from pyquil.gates import SWAP, X
+
+        original = Circuit().x(0).swap(0, 1)
+        imported = Circuit.from_pyquil(Program(X(0), SWAP(0, 1)))
+
+        orig_amps = original.simulate().tensor.flatten()
+        imported_amps = imported.simulate().tensor.flatten()
+        assert np.allclose(np.abs(orig_amps), np.abs(imported_amps))
+
+    def test_swap_cnot_decomposition(self) -> None:
+        """SWAP decomposed as three CNOTs is recognized and imported."""
+        import numpy as np
+        from pyquil import Program
+        from pyquil.gates import CNOT, X
+
+        original = Circuit().x(0).swap(0, 1)
+        imported = Circuit.from_pyquil(
+            Program(
+                X(0),
+                CNOT(0, 1),
+                CNOT(1, 0),
+                CNOT(0, 1),
+            )
+        )
+
+        orig_amps = original.simulate().tensor.flatten()
+        imported_amps = imported.simulate().tensor.flatten()
+        assert np.allclose(np.abs(orig_amps), np.abs(imported_amps))
+
+    def test_measurements_skipped(self) -> None:
+        """Measurement instructions are silently skipped."""
+        from pyquil import Program
+        from pyquil.gates import CNOT, H, MEASURE
+
+        program = Program()
+        program.declare("ro", "BIT", 2)
+        program += Program(H(0), CNOT(0, 1))
+        program += MEASURE(0, ("ro", 0))
+        program += MEASURE(1, ("ro", 1))
+
+        imported = Circuit.from_pyquil(program)
+        assert imported.num_qubits == 2
+
+    def test_type_error_on_wrong_input(self) -> None:
+        """TypeError raised for non-Program input."""
+        with pytest.raises(TypeError, match="Expected a PyQuil Program"):
+            Circuit.from_pyquil("not a program")
+
+    def test_not_implemented_for_unsupported_gate(self) -> None:
+        """Quil-native gates outside the canonical set raise NotImplementedError."""
+        from pyquil import Program
+        from pyquil.gates import CCNOT
+
+        with pytest.raises(NotImplementedError, match="CCNOT"):
+            Circuit.from_pyquil(Program(CCNOT(0, 1, 2)))
+
+    def test_symbolic_rotation_parameter_raises_not_implemented(self) -> None:
+        """Symbolic PyQuil rotation parameters fail with a clear error."""
+        from pyquil import Program
+        from pyquil.gates import RX
+        from pyquil.quilatom import Parameter
+
+        with pytest.raises(NotImplementedError, match="numeric real-valued"):
+            Circuit.from_pyquil(Program(RX(Parameter("theta"), 0)))
+
+    def test_native_pyquil_bell_pair(self) -> None:
+        """A hand-written PyQuil Bell pair produces the correct state vector."""
+        import numpy as np
+        from pyquil import Program
+        from pyquil.gates import CNOT, H
+
+        imported = Circuit.from_pyquil(Program(H(0), CNOT(0, 1)))
+        amps = imported.simulate().tensor.flatten()
+
+        assert np.isclose(np.abs(amps[0]) ** 2, 0.5, atol=0.01)
+        assert np.isclose(np.abs(amps[3]) ** 2, 0.5, atol=0.01)
+
+
 class TestOpenQASM:
     """Tests for OpenQASM import and export."""
 


### PR DESCRIPTION
## Summary

Adds `Circuit.from_pyquil()` - the missing import path for pyQuil `Program` objects, completing the round-trip with the existing `to_pyquil()` export.

- Maps the canonical Marqov gate set: H, X, Y, Z, S, T, Rx/Ry/Rz, CNOT, CZ, SWAP
- Handles SWAP as a native `SWAP` instruction **and** as the standard 3-CNOT decomposition (`CNOT(a,b); CNOT(b,a); CNOT(a,b)`)
- Skips non-unitary instructions (Declare, Measurement, Halt, Pragma)
- Raises `NotImplementedError` for Quil-native gates outside the canonical set (e.g. CCNOT, symbolic rotation parameters)
- Adds `pyquil` optional extra to `pyproject.toml` and includes it in `all`

Closes #4

## Type of change

- [ ] Bug fix
- [ ] New executor
- [x] Circuit format converter
- [ ] Documentation
- [ ] Other (describe):

## Testing

- [x] I ran `pytest tests/ -v` and tests pass
- [ ] For new executors: tested against local simulator or QVM (describe below)
- [x] For circuit converters: roundtrip test passes with known-correct reference circuit

**Test details:**

```bash
# Setup
python3.12 -m venv .venv && source .venv/bin/activate
pip install -e ".[all,dev]"

# Lint
ruff check marqov/circuits.py tests/test_circuits.py pyproject.toml

# New tests (11 passed)
pytest tests/test_circuits.py::TestFromPyquil -v

# Full circuit test module (63 passed, no regressions)
pytest tests/test_circuits.py -v