### PR TITLE
Add Rigetti QCS executor (closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ executor = ExecutorFactory.create_executor("qpu.aria-1", {
 result = await executor.execute(circuit, shots=1000)
 ```
 
+Or run on Rigetti QPUs (or the local QVM, no cloud account needed) via Rigetti QCS:
+
+```python
+executor = ExecutorFactory.create_executor("2q-qvm", {
+    "provider": "Rigetti QCS",
+})
+result = await executor.execute(circuit, shots=1000)
+```
+
 ## Supported Backends
 
 | Backend | Status |
@@ -108,7 +117,7 @@ result = await executor.execute(circuit, shots=1000)
 | IBM Quantum | ✅ Available |
 | Azure Quantum | ✅ Available |
 | IonQ Direct | ✅ Available |
-| Rigetti QCS | [🔧 Open issue #2](https://github.com/marqov-dev/marqov-sdk/issues/2) |
+| Rigetti QCS | ✅ Available |
 | Quantinuum | [🔧 Open issue #6](https://github.com/marqov-dev/marqov-sdk/issues/6) |
 
 ## Circuit Interop

--- a/marqov/executors/__init__.py
+++ b/marqov/executors/__init__.py
@@ -8,6 +8,7 @@ Available executors:
 - AzureQuantumExecutor: Azure Quantum (Quantinuum, PASQAL, IonQ, Rigetti)
 - IBMExecutor: IBM Quantum (Heron r2, Eagle, etc. via Qiskit Runtime)
 - IonQExecutor: IonQ Direct API (native REST, no Braket intermediary)
+- RigettiExecutor: Rigetti QCS QPUs and the local QVM (via pyquil)
 
 Example:
     >>> from marqov.executors import LocalExecutor
@@ -25,6 +26,7 @@ from marqov.executors.factory import ExecutorFactory
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
 from marqov.executors.ionq import IonQExecutor, IonQExecutorConfig
 from marqov.executors.local import LocalExecutor
+from marqov.executors.rigetti import RigettiExecutor, RigettiExecutorConfig
 from marqov.simulation.executor import SimulationExecutor
 
 __all__ = [
@@ -41,5 +43,7 @@ __all__ = [
     "IonQExecutor",
     "IonQExecutorConfig",
     "LocalExecutor",
+    "RigettiExecutor",
+    "RigettiExecutorConfig",
     "SimulationExecutor",
 ]

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -24,6 +24,7 @@ from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
 from marqov.executors.ionq import IonQExecutor, IonQExecutorConfig
 from marqov.executors.local import LocalExecutor
+from marqov.executors.rigetti import RigettiExecutor, RigettiExecutorConfig
 from marqov.simulation.config import SimulationConfig
 from marqov.simulation.executor import SimulationExecutor
 
@@ -110,6 +111,10 @@ class ExecutorFactory:
         if provider == "IonQ Direct":
             return cls._create_ionq_executor(backend_slug, backend_config)
 
+        # Rigetti QCS (and local QVM)
+        if provider == "Rigetti QCS":
+            return cls._create_rigetti_executor(backend_slug, backend_config)
+
         # C++ simulation backends (qpp, tnqvm, cudaq, aer)
         if provider == "Quantum Brilliance":
             return cls._create_simulation_executor(backend_slug, backend_config)
@@ -117,7 +122,7 @@ class ExecutorFactory:
         raise ValueError(
             f"Unsupported provider: {provider}. "
             f"Supported providers: AWS Braket, IBM Quantum, Azure Quantum, "
-            f"IonQ Direct, Quantum Brilliance, Local."
+            f"IonQ Direct, Rigetti QCS, Quantum Brilliance, Local."
         )
 
     @classmethod
@@ -268,13 +273,59 @@ class ExecutorFactory:
         config_kwargs: dict[str, Any] = {
             "target": backend_config.get("target", backend_slug),
         }
-        for key in ("api_key", "base_url", "poll_interval_seconds", "timeout_seconds", "noise_model"):
+        for key in (
+            "api_key",
+            "base_url",
+            "poll_interval_seconds",
+            "timeout_seconds",
+            "noise_model",
+        ):
             if key in backend_config:
                 config_kwargs[key] = backend_config[key]
 
         config = IonQExecutorConfig(**config_kwargs)
 
         return IonQExecutor(config)
+
+    @classmethod
+    def _create_rigetti_executor(
+        cls,
+        backend_slug: str,
+        backend_config: dict[str, Any],
+    ) -> RigettiExecutor:
+        """Create a Rigetti QCS executor from configuration.
+
+        No field is strictly required: the quantum-processor id falls back to the
+        backend slug, so ``{"provider": "Rigetti QCS"}`` with a ``"2q-qvm"`` slug
+        runs against a local QVM without any cloud account.
+
+        Args:
+            backend_slug: Backend slug used as the quantum-processor id if not
+                given (e.g. ``"2q-qvm"``, ``"Ankaa-3"``).
+            backend_config: Configuration with optional quantum_processor_id,
+                as_qvm, and timeout options.
+
+        Returns:
+            Configured RigettiExecutor instance.
+        """
+        # Only forward keys present in backend_config and rely on
+        # RigettiExecutorConfig's own defaults otherwise, so factory and dataclass
+        # defaults can't drift apart. The processor id falls back to the slug.
+        config_kwargs: dict[str, Any] = {
+            "quantum_processor_id": backend_config.get("quantum_processor_id", backend_slug),
+        }
+        for key in (
+            "as_qvm",
+            "compiler_timeout_seconds",
+            "execution_timeout_seconds",
+            "timeout_seconds",
+        ):
+            if key in backend_config:
+                config_kwargs[key] = backend_config[key]
+
+        config = RigettiExecutorConfig(**config_kwargs)
+
+        return RigettiExecutor(config)
 
     @classmethod
     def _create_simulation_executor(
@@ -310,6 +361,7 @@ class ExecutorFactory:
             "IBM Quantum",
             "Azure Quantum",
             "IonQ Direct",
+            "Rigetti QCS",
             "Quantum Brilliance",
             "Local",
         ]

--- a/marqov/executors/rigetti.py
+++ b/marqov/executors/rigetti.py
@@ -1,0 +1,319 @@
+"""Rigetti QCS executor for running circuits on Rigetti QPUs and the local QVM.
+
+This module provides ``RigettiExecutor`` for executing quantum circuits through
+Rigetti's stack. Circuits are converted with ``circuit.to_pyquil()`` (already
+implemented in :mod:`marqov.circuits`), measurements are added for every qubit,
+the program is compiled with ``quilc`` and run on a ``QuantumComputer`` obtained
+from ``pyquil.get_qc``.
+
+The same code path targets two backends, selected by ``quantum_processor_id``:
+
+- A **local QVM** (a name ending in ``-qvm`` such as ``"2q-qvm"``). Rigetti's
+  Quantum Virtual Machine is fully open source and runs locally via Docker, so it
+  needs no cloud account or credits. This is the path the tests exercise.
+- A **real QCS QPU** (e.g. ``"Ankaa-3"``). ``QuantumComputer.run`` submits to QCS
+  and blocks until the job finishes, so the job lifecycle (queued, running,
+  completed) is handled internally by pyquil.
+
+Example:
+    >>> from marqov.circuits import bell_state
+    >>> from marqov.executors import RigettiExecutor, RigettiExecutorConfig
+    >>>
+    >>> config = RigettiExecutorConfig(quantum_processor_id="2q-qvm")
+    >>> executor = RigettiExecutor(config)
+    >>> result = await executor.execute(bell_state(), shots=1000)
+    >>> print(result.counts)  # {"00": ~500, "11": ~500}
+
+``pyquil`` is an optional dependency. Install it with ``pip install marqov[rigetti]``
+and follow ``CONTRIBUTING.md`` §4 to start the ``quilc`` and ``qvm`` containers
+before running against a local QVM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable
+
+from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
+
+if TYPE_CHECKING:
+    from marqov.circuits import Circuit
+
+
+@dataclass
+class RigettiExecutorConfig:
+    """Configuration for the Rigetti QCS executor.
+
+    Attributes:
+        quantum_processor_id: The pyquil quantum-computer name. Use a QVM name
+            ending in ``-qvm`` (e.g. ``"2q-qvm"``, ``"9q-square-qvm"``) for local
+            simulation, or a real QCS QPU id (e.g. ``"Ankaa-3"``) for hardware.
+        as_qvm: Force QVM execution (``True``) or QPU execution (``False``). When
+            ``None``, pyquil infers it from ``quantum_processor_id`` (names ending
+            in ``-qvm`` run on the QVM).
+        compiler_timeout_seconds: Timeout passed to ``quilc`` when compiling.
+        execution_timeout_seconds: Per-job execution timeout passed to pyquil.
+        timeout_seconds: Optional overall wall-clock budget for ``execute`` around
+            compilation and execution. ``None`` means no extra cap (the pyquil
+            timeouts above still apply).
+    """
+
+    quantum_processor_id: str = "2q-qvm"
+    as_qvm: bool | None = None
+    compiler_timeout_seconds: float = 30.0
+    execution_timeout_seconds: float = 30.0
+    timeout_seconds: float | None = None
+
+
+class RigettiExecutor(BaseExecutor):
+    """Execute circuits on Rigetti QPUs or the local QVM via pyquil.
+
+    Converts a circuit with ``to_pyquil()``, measures every qubit into a ``ro``
+    register, compiles with ``quilc`` and runs the program on a pyquil
+    ``QuantumComputer``. Counts use the SDK convention where qubit 0 is the
+    leftmost bit, matching :class:`~marqov.executors.local.LocalExecutor`.
+
+    A ``QuantumComputer`` may be injected for unit testing without a running QVM
+    or QCS credentials.
+
+    Example:
+        >>> config = RigettiExecutorConfig(quantum_processor_id="Ankaa-3")
+        >>> executor = RigettiExecutor(config)
+        >>> if (await executor.get_status()).status == "online":
+        ...     result = await executor.execute(circuit, shots=1000)
+    """
+
+    def __init__(
+        self,
+        config: RigettiExecutorConfig,
+        *,
+        qc: Any = None,
+        list_processors: Callable[[], Any] | None = None,
+    ) -> None:
+        """Initialize RigettiExecutor.
+
+        Args:
+            config: Executor configuration including the target processor id.
+            qc: Optional pyquil ``QuantumComputer`` (or a compatible test double
+                exposing ``compile(program)`` and ``run(executable)``). When
+                ``None``, it is created lazily on first use via ``pyquil.get_qc``.
+            list_processors: Optional zero-argument callable returning the live
+                list of available QCS quantum-processor ids, used by
+                ``get_status`` for real QPUs. When ``None``, it defaults to
+                ``qcs_sdk.qpu.list_quantum_processors``. Injecting it keeps
+                ``get_status`` testable without QCS credentials.
+        """
+        self.config = config
+        self._qc = qc
+        self._list_processors = list_processors
+
+    def _is_qvm(self) -> bool:
+        """Return whether this executor targets a local QVM.
+
+        Returns:
+            ``config.as_qvm`` when set, otherwise inferred from the processor id
+            (pyquil treats names ending in ``-qvm`` as QVMs).
+        """
+        if self.config.as_qvm is not None:
+            return self.config.as_qvm
+        return self.config.quantum_processor_id.endswith("-qvm")
+
+    def _get_qc_sync(self) -> Any:
+        """Get or lazily create the pyquil ``QuantumComputer`` (synchronous).
+
+        Returns:
+            The cached or newly created ``QuantumComputer``.
+        """
+        if self._qc is None:
+            from pyquil import get_qc
+
+            self._qc = get_qc(
+                self.config.quantum_processor_id,
+                as_qvm=self.config.as_qvm,
+                compiler_timeout=self.config.compiler_timeout_seconds,
+                execution_timeout=self.config.execution_timeout_seconds,
+            )
+        return self._qc
+
+    @staticmethod
+    def _build_measured_program(program: Any, num_qubits: int, shots: int) -> Any:
+        """Add a readout register, measurements and a shot loop to a program.
+
+        ``Circuit.to_pyquil()`` returns the gate sequence only, so the executor
+        appends a ``MEASURE`` of every qubit into a fresh ``ro`` register and wraps
+        the whole program in a ``shots`` loop, ready to compile and run.
+
+        Args:
+            program: The pyquil ``Program`` produced by ``to_pyquil()``.
+            num_qubits: Number of qubits to measure (qubit ``i`` -> ``ro[i]``).
+            shots: Number of shots to run.
+
+        Returns:
+            A new pyquil ``Program`` with declarations, gates, measurements and
+            the shot loop.
+        """
+        from pyquil import Program
+        from pyquil.gates import MEASURE
+
+        measured = Program()
+        ro = measured.declare("ro", "BIT", num_qubits)
+        measured += program
+        for qubit in range(num_qubits):
+            measured += MEASURE(qubit, ro[qubit])
+        measured.wrap_in_numshots_loop(shots)
+        return measured
+
+    @staticmethod
+    def _result_to_counts(result: Any, num_qubits: int) -> dict[str, int]:
+        """Convert a pyquil execution result into measurement counts.
+
+        Reads the ``ro`` register (a ``shots`` x ``num_qubits`` array of bits) and
+        bins the per-shot bitstrings. Qubit 0 is the leftmost character, matching
+        the SDK's :class:`~marqov.executors.local.LocalExecutor` convention.
+
+        Args:
+            result: The object returned by ``QuantumComputer.run`` (exposes
+                ``get_register_map()``).
+            num_qubits: Number of measured qubits, used only as a guard.
+
+        Returns:
+            Mapping of bitstrings to integer counts. Empty when there is no
+            readout data or no qubits.
+        """
+        if num_qubits == 0:
+            return {}
+
+        register_map = result.get_register_map()
+        readout = register_map.get("ro")
+        if readout is None:
+            return {}
+
+        counts: Counter[str] = Counter("".join(str(int(bit)) for bit in shot) for shot in readout)
+        return dict(counts)
+
+    async def execute(
+        self,
+        circuit: Circuit,
+        shots: int = 1000,
+        **kwargs: Any,
+    ) -> ExecutionResult:
+        """Execute a circuit on a Rigetti QPU or the local QVM.
+
+        Args:
+            circuit: The quantum circuit to execute.
+            shots: Number of measurement shots.
+            **kwargs: Additional backend-specific options (currently unused).
+
+        Returns:
+            ExecutionResult with measurement counts and metadata.
+
+        Raises:
+            RuntimeError: If compilation or execution fails on the backend.
+            TimeoutError: If execution exceeds ``config.timeout_seconds``.
+        """
+        circuit = self._validate_circuit(circuit)
+
+        loop = asyncio.get_running_loop()
+        start_time = time.perf_counter()
+
+        num_qubits = circuit.num_qubits
+
+        # An empty circuit has nothing to measure; return early without touching
+        # the backend so a missing QVM does not turn into a spurious failure.
+        if num_qubits == 0:
+            return ExecutionResult(
+                counts={},
+                backend=self.config.quantum_processor_id,
+                execution_time_ms=(time.perf_counter() - start_time) * 1000,
+                shots=shots,
+                raw_result=None,
+                metadata=self._metadata(0, shots, 0.0),
+            )
+
+        program = circuit.to_pyquil()  # type: ignore[no-untyped-call]
+        measured = self._build_measured_program(program, num_qubits, shots)
+
+        def _compile_and_run() -> Any:
+            qc = self._get_qc_sync()
+            executable = qc.compile(measured)
+            return qc.run(executable)
+
+        try:
+            coro = loop.run_in_executor(None, _compile_and_run)
+            if self.config.timeout_seconds is not None:
+                result = await asyncio.wait_for(coro, timeout=self.config.timeout_seconds)
+            else:
+                result = await coro
+        except asyncio.TimeoutError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - normalised to RuntimeError below
+            raise RuntimeError(
+                f"Rigetti execution failed on {self.config.quantum_processor_id}: {exc}"
+            ) from exc
+
+        wall_time = time.perf_counter() - start_time
+        counts = self._result_to_counts(result, num_qubits)
+
+        return ExecutionResult(
+            counts=counts,
+            backend=self.config.quantum_processor_id,
+            execution_time_ms=wall_time * 1000,
+            shots=shots,
+            raw_result=result,
+            metadata=self._metadata(num_qubits, shots, wall_time * 1000),
+        )
+
+    def _metadata(self, num_qubits: int, shots: int, wall_time_ms: float) -> dict[str, Any]:
+        """Build the ExecutionResult metadata for a run.
+
+        Args:
+            num_qubits: Number of qubits measured.
+            shots: Number of shots executed.
+            wall_time_ms: Measured wall time in milliseconds.
+
+        Returns:
+            Metadata dictionary.
+        """
+        return {
+            "provider": "rigetti",
+            "quantum_processor_id": self.config.quantum_processor_id,
+            "as_qvm": self._is_qvm(),
+            "num_qubits": num_qubits,
+            "shots": shots,
+            "wall_time_ms": wall_time_ms,
+        }
+
+    async def get_status(self) -> DeviceStatus:
+        """Get live device availability.
+
+        A local QVM is a simulator with no queue, so it always reports online. For
+        a real QCS QPU the live list of available processors is queried and the
+        target is reported online only when it appears in that list, offline
+        otherwise. Any error degrades to ``maintenance`` so callers can back off.
+        """
+        if self._is_qvm():
+            return DeviceStatus(status="online", queue_depth=0, queue_time_seconds=0)
+
+        try:
+            loop = asyncio.get_running_loop()
+            processors = await loop.run_in_executor(None, self._list_processors_or_default)
+            available = {str(processor) for processor in processors}
+            status = "online" if self.config.quantum_processor_id in available else "offline"
+            return DeviceStatus(status=status, queue_depth=None, queue_time_seconds=None)
+        except Exception:
+            return DeviceStatus(status="maintenance", queue_depth=None, queue_time_seconds=None)
+
+    def _list_processors_or_default(self) -> Any:
+        """Return the live QCS processor list via the injected or default source.
+
+        Returns:
+            Whatever the processor lister returns (iterable of processor ids).
+        """
+        if self._list_processors is not None:
+            return self._list_processors()
+        from qcs_sdk.qpu import list_quantum_processors
+
+        return list_quantum_processors()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ ionq = [
     "requests>=2.31.0",
     "qiskit>=1.0.0",
 ]
+rigetti = [
+    "pyquil>=4.0.0",
+]
 all = [
     "qiskit>=1.0.0",
     "qiskit-ibm-runtime>=0.20.0",
@@ -66,6 +69,7 @@ all = [
     "cirq-core>=1.0.0",
     "pennylane>=0.35.0",
     "requests>=2.31.0",
+    "pyquil>=4.0.0",
 ]
 
 [project.scripts]

--- a/tests/integration/test_rigetti_qvm.py
+++ b/tests/integration/test_rigetti_qvm.py
@@ -1,0 +1,71 @@
+"""End-to-end tests for the Rigetti executor against a real local QVM.
+
+These submit real programs through ``quilc`` and ``qvm``, so they are skipped
+unless ``MARQOV_QVM_AVAILABLE=1`` is set. Start the containers first
+(see ``CONTRIBUTING.md`` §4):
+
+    docker run -d -p 5555:5555 rigetti/quilc -R
+    docker run -d -p 5000:5000 rigetti/qvm -S
+
+then run:
+
+    MARQOV_QVM_AVAILABLE=1 pytest tests/integration/test_rigetti_qvm.py
+"""
+
+import os
+
+import pytest
+
+from marqov.circuits import bell_state, ghz_state
+from marqov.executors import RigettiExecutor
+from marqov.executors.rigetti import RigettiExecutorConfig
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.environ.get("MARQOV_QVM_AVAILABLE") != "1",
+        reason="Requires a local QVM + quilc (set MARQOV_QVM_AVAILABLE=1, see CONTRIBUTING.md §4)",
+    ),
+]
+
+
+@pytest.fixture
+def qvm_executor() -> RigettiExecutor:
+    """A RigettiExecutor wired to the local 2-qubit QVM."""
+    return RigettiExecutor(RigettiExecutorConfig(quantum_processor_id="2q-qvm"))
+
+
+@pytest.mark.asyncio
+async def test_bell_state_only_correlated_outcomes(qvm_executor: RigettiExecutor) -> None:
+    """A Bell state on the QVM produces only the correlated 00 and 11 outcomes."""
+    result = await qvm_executor.execute(bell_state(), shots=1000)
+
+    assert sum(result.counts.values()) == 1000
+    # An ideal Bell state never yields 01 or 10.
+    assert set(result.counts) <= {"00", "11"}
+    # Both correlated outcomes should appear with ~50/50 weight (loose bound).
+    assert result.counts.get("00", 0) > 250
+    assert result.counts.get("11", 0) > 250
+    assert result.backend == "2q-qvm"
+    assert result.metadata["provider"] == "rigetti"
+    assert result.metadata["num_qubits"] == 2
+
+
+@pytest.mark.asyncio
+async def test_ghz_state_only_correlated_outcomes() -> None:
+    """A 3-qubit GHZ state on the QVM produces only 000 and 111."""
+    executor = RigettiExecutor(RigettiExecutorConfig(quantum_processor_id="3q-qvm"))
+    result = await executor.execute(ghz_state(3), shots=1000)
+
+    assert sum(result.counts.values()) == 1000
+    assert set(result.counts) <= {"000", "111"}
+    assert result.counts.get("000", 0) > 250
+    assert result.counts.get("111", 0) > 250
+
+
+@pytest.mark.asyncio
+async def test_qvm_status_is_online(qvm_executor: RigettiExecutor) -> None:
+    """The QVM reports online with no queue."""
+    status = await qvm_executor.get_status()
+    assert status.status == "online"
+    assert status.queue_depth == 0

--- a/tests/test_rigetti_executor.py
+++ b/tests/test_rigetti_executor.py
@@ -1,0 +1,257 @@
+"""Tests for the Rigetti QCS executor.
+
+The unit tests here use an injected ``QuantumComputer`` double and an injected
+processor-list callable, so they never start a QVM, touch QCS or need credentials.
+They cover result normalisation, error handling, the empty-circuit path and the
+``get_status`` mapping. A real end-to-end QVM test lives in
+``tests/integration/test_rigetti_qvm.py``.
+"""
+
+from typing import Any
+
+import pytest
+
+from marqov.circuits import Circuit, bell_state
+from marqov.executors import ExecutionResult, ExecutorFactory, RigettiExecutor
+from marqov.executors.base import DeviceStatus
+from marqov.executors.rigetti import RigettiExecutorConfig
+
+
+class _FakeResult:
+    """Stand-in for a pyquil execution result exposing ``get_register_map``."""
+
+    def __init__(self, readout: list[list[int]]) -> None:
+        self._readout = readout
+
+    def get_register_map(self) -> dict[str, Any]:
+        return {"ro": self._readout}
+
+
+class _FakeQC:
+    """Stand-in QuantumComputer: ``compile`` is a no-op, ``run`` returns canned data."""
+
+    def __init__(self, result: Any = None, *, run_error: Exception | None = None) -> None:
+        self._result = result
+        self._run_error = run_error
+        self.compiled: Any = None
+
+    def compile(self, program: Any) -> Any:
+        self.compiled = program
+        return program
+
+    def run(self, executable: Any) -> Any:
+        if self._run_error is not None:
+            raise self._run_error
+        return self._result
+
+
+class TestRigettiExecutorConfig:
+    """Tests for RigettiExecutorConfig."""
+
+    def test_defaults(self) -> None:
+        """Config defaults to a local 2-qubit QVM."""
+        config = RigettiExecutorConfig()
+        assert config.quantum_processor_id == "2q-qvm"
+        assert config.as_qvm is None
+        assert config.compiler_timeout_seconds == 30.0
+        assert config.execution_timeout_seconds == 30.0
+        assert config.timeout_seconds is None
+
+
+class TestIsQvm:
+    """Tests for QVM vs QPU detection."""
+
+    def test_name_ending_in_qvm_is_qvm(self) -> None:
+        """A processor id ending in -qvm is treated as a QVM."""
+        executor = RigettiExecutor(RigettiExecutorConfig(quantum_processor_id="9q-square-qvm"))
+        assert executor._is_qvm() is True
+
+    def test_qpu_name_is_not_qvm(self) -> None:
+        """A bare QPU id is not treated as a QVM."""
+        executor = RigettiExecutor(RigettiExecutorConfig(quantum_processor_id="Ankaa-3"))
+        assert executor._is_qvm() is False
+
+    def test_as_qvm_override_wins(self) -> None:
+        """An explicit as_qvm overrides the name-based inference."""
+        executor = RigettiExecutor(
+            RigettiExecutorConfig(quantum_processor_id="Ankaa-3", as_qvm=True)
+        )
+        assert executor._is_qvm() is True
+
+
+class TestResultNormalisation:
+    """Tests for converting a register map into counts."""
+
+    def test_counts_qubit0_is_leftmost(self) -> None:
+        """Bitstrings put qubit 0 on the left, matching the SDK convention."""
+        # ro[0]=1, ro[1]=0 -> "10": qubit 0 measured 1, qubit 1 measured 0.
+        readout = [[1, 0], [1, 0], [1, 1]]
+        counts = RigettiExecutor._result_to_counts(_FakeResult(readout), 2)
+        assert counts == {"10": 2, "11": 1}
+
+    def test_counts_sum_to_shots(self) -> None:
+        """Every shot lands in exactly one bin."""
+        readout = [[0, 0], [1, 1], [0, 0], [1, 1], [0, 0]]
+        counts = RigettiExecutor._result_to_counts(_FakeResult(readout), 2)
+        assert sum(counts.values()) == 5
+        assert counts == {"00": 3, "11": 2}
+
+    def test_zero_qubits_returns_empty(self) -> None:
+        """A zero-qubit run has no counts."""
+        assert RigettiExecutor._result_to_counts(_FakeResult([]), 0) == {}
+
+    def test_missing_ro_register_returns_empty(self) -> None:
+        """A result without a ``ro`` register yields empty counts, not an error."""
+
+        class _NoRo:
+            def get_register_map(self) -> dict[str, Any]:
+                return {}
+
+        assert RigettiExecutor._result_to_counts(_NoRo(), 2) == {}
+
+
+class TestExecute:
+    """Tests for the execute() path with an injected QuantumComputer."""
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_normalised_result(self) -> None:
+        """execute() compiles, runs and normalises into an ExecutionResult."""
+        pytest.importorskip("pyquil")
+        result = _FakeResult([[0, 0], [1, 1], [0, 0], [1, 1]])
+        qc = _FakeQC(result)
+        executor = RigettiExecutor(RigettiExecutorConfig(quantum_processor_id="2q-qvm"), qc=qc)
+
+        out = await executor.execute(bell_state(), shots=4)
+
+        assert isinstance(out, ExecutionResult)
+        assert out.counts == {"00": 2, "11": 2}
+        assert out.backend == "2q-qvm"
+        assert out.shots == 4
+        assert out.raw_result is result
+        assert out.metadata["provider"] == "rigetti"
+        assert out.metadata["quantum_processor_id"] == "2q-qvm"
+        assert out.metadata["as_qvm"] is True
+        assert out.metadata["num_qubits"] == 2
+        # The program handed to the backend declares a readout and measures.
+        assert qc.compiled is not None
+        assert "MEASURE" in qc.compiled.out()
+        assert "DECLARE ro BIT[2]" in qc.compiled.out()
+
+    @pytest.mark.asyncio
+    async def test_execute_wraps_backend_error_in_runtimeerror(self) -> None:
+        """A backend failure is normalised to RuntimeError naming the processor."""
+        pytest.importorskip("pyquil")
+        qc = _FakeQC(run_error=ValueError("quilc down"))
+        executor = RigettiExecutor(RigettiExecutorConfig(quantum_processor_id="2q-qvm"), qc=qc)
+
+        with pytest.raises(RuntimeError, match="2q-qvm"):
+            await executor.execute(bell_state(), shots=10)
+
+    @pytest.mark.asyncio
+    async def test_execute_empty_circuit_returns_empty_counts(self) -> None:
+        """An empty circuit returns empty counts without touching the backend."""
+        # No qc injected and none created: the empty-circuit path must not need one.
+        executor = RigettiExecutor(RigettiExecutorConfig(quantum_processor_id="2q-qvm"))
+        out = await executor.execute(Circuit(), shots=100)
+        assert out.counts == {}
+        assert out.shots == 100
+        assert out.backend == "2q-qvm"
+
+    @pytest.mark.asyncio
+    async def test_execute_rejects_non_marqov_circuit(self) -> None:
+        """A non-Marqov circuit is rejected with a helpful TypeError."""
+        executor = RigettiExecutor(RigettiExecutorConfig(), qc=_FakeQC(_FakeResult([])))
+        with pytest.raises(TypeError):
+            await executor.execute("not a circuit", shots=10)  # type: ignore[arg-type]
+
+
+class TestGetStatus:
+    """Tests for device-availability reporting."""
+
+    @pytest.mark.asyncio
+    async def test_qvm_is_always_online(self) -> None:
+        """A QVM is a local simulator: always online, no queue."""
+        executor = RigettiExecutor(RigettiExecutorConfig(quantum_processor_id="2q-qvm"))
+        status = await executor.get_status()
+        assert status == DeviceStatus(status="online", queue_depth=0, queue_time_seconds=0)
+
+    @pytest.mark.asyncio
+    async def test_qpu_online_when_listed(self) -> None:
+        """A QPU present in the live processor list reports online."""
+        executor = RigettiExecutor(
+            RigettiExecutorConfig(quantum_processor_id="Ankaa-3"),
+            list_processors=lambda: ["Ankaa-3", "Aspen-M-3"],
+        )
+        status = await executor.get_status()
+        assert status.status == "online"
+
+    @pytest.mark.asyncio
+    async def test_qpu_offline_when_not_listed(self) -> None:
+        """A QPU missing from the live list reports offline."""
+        executor = RigettiExecutor(
+            RigettiExecutorConfig(quantum_processor_id="Ankaa-3"),
+            list_processors=lambda: ["Aspen-M-3"],
+        )
+        status = await executor.get_status()
+        assert status.status == "offline"
+
+    @pytest.mark.asyncio
+    async def test_qpu_maintenance_on_error(self) -> None:
+        """If the processor list cannot be fetched, degrade to maintenance."""
+
+        def _boom() -> list[str]:
+            raise ConnectionError("QCS unreachable")
+
+        executor = RigettiExecutor(
+            RigettiExecutorConfig(quantum_processor_id="Ankaa-3"),
+            list_processors=_boom,
+        )
+        status = await executor.get_status()
+        assert status.status == "maintenance"
+
+
+class TestFactoryRegistration:
+    """Tests that the factory knows about the Rigetti provider."""
+
+    def test_provider_is_supported(self) -> None:
+        """Rigetti QCS appears in the supported-provider list."""
+        assert "Rigetti QCS" in ExecutorFactory.get_supported_providers()
+        assert ExecutorFactory.is_provider_supported("Rigetti QCS") is True
+
+    def test_factory_creates_rigetti_executor(self) -> None:
+        """The factory builds a RigettiExecutor from a Rigetti QCS config."""
+        executor = ExecutorFactory.create_executor(
+            "2q-qvm",
+            {"provider": "Rigetti QCS"},
+        )
+        assert isinstance(executor, RigettiExecutor)
+        # Processor id falls back to the backend slug when not given.
+        assert executor.config.quantum_processor_id == "2q-qvm"
+
+    def test_factory_forwards_config_fields(self) -> None:
+        """Explicit config fields reach the executor config."""
+        executor = ExecutorFactory.create_executor(
+            "ankaa",
+            {
+                "provider": "Rigetti QCS",
+                "quantum_processor_id": "Ankaa-3",
+                "as_qvm": False,
+                "timeout_seconds": 12.0,
+            },
+        )
+        assert isinstance(executor, RigettiExecutor)
+        assert executor.config.quantum_processor_id == "Ankaa-3"
+        assert executor.config.as_qvm is False
+        assert executor.config.timeout_seconds == 12.0
+
+
+# Integration template (run against a real local QVM):
+#
+#   1. Start the containers (see CONTRIBUTING.md §4):
+#        docker run -d -p 5555:5555 rigetti/quilc -R
+#        docker run -d -p 5000:5000 rigetti/qvm -S
+#   2. Run the end-to-end test:
+#        MARQOV_QVM_AVAILABLE=1 pytest tests/integration/test_rigetti_qvm.py
+#
+# That test submits a real Bell program through quilc + qvm and asserts only the
+# correlated outcomes appear. See tests/integration/test_rigetti_qvm.py.


### PR DESCRIPTION
## Summary

Adds a Rigetti QCS executor (closes #2). `RigettiExecutor` and
`RigettiExecutorConfig` submit circuits through pyquil to a real QCS QPU or to a
local QVM, normalise the result into `ExecutionResult` and register as provider
`"Rigetti QCS"` in `ExecutorFactory`. The conversion layer (`Circuit.to_pyquil()`)
already existed, so this adds the executor that actually runs those programs.

How it works:

- `execute()` calls `circuit.to_pyquil()`, declares a `ro` register, measures every
  qubit (`MEASURE(i, ro[i])`), wraps the program in a shots loop, compiles it with
  `quilc` and runs it on a pyquil `QuantumComputer`. Counts use the SDK convention
  where qubit 0 is the leftmost bit, matching `LocalExecutor`.
- The same path targets two backends, picked by `quantum_processor_id`: a local QVM
  (a name ending in `-qvm`, e.g. `"2q-qvm"`) or a real QCS QPU (e.g. `"Ankaa-3"`).
  `QuantumComputer.run` handles the QCS job lifecycle internally.
- `get_status()` reports device-level availability: a QVM is a local simulator so it
  is always online with no queue, a real QPU is checked against the live QCS
  processor list (`qcs_sdk.qpu.list_quantum_processors`) and any error degrades to
  `maintenance`.
- `cancel()` is left as the `BaseExecutor` default, because pyquil's high-level
  `run()` does not expose a mid-flight cancel handle (per `CONTRIBUTING.md` §2, do
  not override `cancel` unless the provider supports it).
- Adds a `rigetti` optional dependency (`pyquil`) in `pyproject.toml`. pyquil is
  imported lazily inside the executor, so `import marqov.executors` still works
  without the extra installed.

## Type of change

- [ ] Bug fix
- [x] New executor
- [ ] Circuit format converter
- [ ] Documentation
- [ ] Other (describe):

## Testing

- [x] I ran `pytest tests/ -v` and tests pass
- [x] For new executors: tested against local simulator or QVM (describe below)
- [ ] For circuit converters: roundtrip test passes with known-correct reference circuit

**Test details:**

`tests/test_rigetti_executor.py` (19 unit tests): result normalisation (qubit-0
leftmost ordering, counts sum to shots, a missing `ro` register), error handling (a
backend failure is normalised to `RuntimeError` naming the processor), the
empty-circuit path, the `get_status` mapping (QVM online, QPU online/offline via an
injected processor list, maintenance on error) and factory registration. These
inject a `QuantumComputer` double, so they run with no QVM and no credentials. This
covers the result-normalisation and error-handling tests the issue asks for.

`tests/integration/test_rigetti_qvm.py` (end-to-end, gated on
`MARQOV_QVM_AVAILABLE=1`): a real Bell program is compiled through `quilc` and run on
`qvm`. Verified locally with the containers from `CONTRIBUTING.md` §4:

```
docker run -d -p 5555:5555 rigetti/quilc -R
docker run -d -p 5000:5000 rigetti/qvm -S
MARQOV_QVM_AVAILABLE=1 pytest tests/integration/test_rigetti_qvm.py
```

A Bell state over 1000 shots returns only the correlated outcomes (one run gave
`{"00": 516, "11": 484}`), GHZ-3 returns only `{"000", "111"}` and `get_status()`
reports online. `ruff check`, `ruff format --check` and `mypy --strict` are clean on
the new and changed files.

## Checklist

- [x] No hardcoded credentials or API keys
- [x] Handles the canonical gate set from `CONTRIBUTING.md §1` (if adding a circuit converter). Not applicable here, conversion uses the existing `to_pyquil()`

**For new executors only:**
- [x] Registered in `ExecutorFactory` per `CONTRIBUTING.md §3` (provider `"Rigetti QCS"`)
- [x] `get_status()` returns device-level availability (`"online"/"offline"/"maintenance"`), not job-level status

---

This change was implemented with substantial help from Claude (Anthropic), which
drafted the executor, the factory wiring and the tests. The design was set first and
reviewed line by line before submitting: mirror the existing IonQ and Braket
executors, route everything through the local QVM so the tests need no QCS account,
keep `get_status` device-level and import pyquil lazily so base installs are
unaffected. It was verified locally: the 19 unit tests, the real QVM end-to-end Bell
and GHZ run (quilc + qvm via Docker per `CONTRIBUTING.md` §4) and `ruff` +
`ruff format` + `mypy --strict` all pass. The design choices are written up above for
review.
