### PR TITLE
test: import qiskit eagerly in conftest to fix test_simulation isolation failures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,17 @@
 """Pytest configuration for test suite."""
+
+# Import qiskit eagerly, once, at collection time — before any test enters a
+# ``patch.dict("sys.modules", ...)`` block. qiskit imports its standard-gate
+# library lazily; if that first import happens *inside* a patched sys.modules
+# context, patch.dict deletes the freshly-added qiskit submodule entries on
+# exit, leaving qiskit half-initialized. Subsequent qiskit use then raises
+# (e.g. ``TypeError: invalid input: Instruction(name='rcccx_dg', ...)``) when
+# tests are run in isolation. Loading qiskit here makes that first import a
+# clean no-op everywhere downstream. See issue #47.
+try:
+    import qiskit  # noqa: F401
+    from qiskit import qasm2, qasm3  # noqa: F401
+except ImportError:
+    # qiskit is an optional dependency; tests that need it will skip/fail on
+    # their own terms rather than being blocked by this safeguard.
+    pass


### PR DESCRIPTION
## Summary

Fixes the qiskit half of #47: `tests/test_simulation.py` fails 2 tests when the file is run **in isolation** (e.g. `pytest tests/test_simulation.py`), while passing in full-suite runs. (The full-suite **segfault** part of #47 was a separate native-reload bug, already fixed by #46.)

## Root cause

`TestSimulationExecutor` runs `execute()` inside `patch.dict("sys.modules", {"qristal": ..., "qristal.core": ...})`. Inside that block, `circuit.to_openqasm()` triggers qiskit's **first** import (`from qiskit import qasm2, qasm3`). qiskit loads its standard-gate library lazily, so a batch of `qiskit.*` submodules get added to `sys.modules` during the block — and `patch.dict` **deletes them on exit** because they weren't in the entry snapshot. qiskit is left half-initialized, so the next gate-class construction fails:

```
TypeError: invalid input: Instruction(name='rcccx_dg', num_qubits=4, num_clbits=0, params=[])
```

In full-suite runs an earlier file imports qiskit cleanly first, so the in-block import is a no-op and the failure is masked — which is why it only shows up in isolation.

## Fix

Import qiskit once at collection time in `tests/conftest.py`, before any test can enter a patched `sys.modules` context. Guarded with `try/except ImportError` since qiskit is an optional dependency.

## Verification

- `pytest tests/test_simulation.py` (isolation): **2 failed → 39 passed**
- `pytest tests/` (full suite): **414 passed, 16 skipped, exit 0** (unchanged; no regression)

Closes #47.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only collection-time import with optional-dependency guard; no production or security impact.
> 
> **Overview**
> Fixes **isolated** failures in `tests/test_simulation.py` (issue #47) by **eagerly importing** `qiskit` and `qasm2`/`qasm3` at pytest **collection time** in `tests/conftest.py`.
> 
> When `SimulationExecutor` tests run inside `patch.dict("sys.modules", ...)`, a **first-time** lazy qiskit import can add submodules that `patch.dict` **removes on exit**, leaving qiskit half-initialized and causing gate/`Instruction` errors on later use. Full-suite runs often mask this because another test imports qiskit first.
> 
> The new imports are wrapped in `try/except ImportError` so optional qiskit absence does not break collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 382ce45c2917ea098266e946dc605e110f0d327f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->