### PR TITLE
fix(workflows): defer @task serialization off decoration (Approach A, #1259)

### DIFF
--- a/marqov/workflows/decorators.py
+++ b/marqov/workflows/decorators.py
@@ -124,9 +124,27 @@ def task(
             timeout_seconds=timeout,
         )
 
-        # Serialize the function once
-        func_bytes = cloudpickle.dumps(fn)
-        func_ref = base64.b64encode(func_bytes).decode("utf-8")
+        # Serialize the function LAZILY — only when a task actually builds a graph
+        # node, and cache the result so it is computed at most once per task.
+        #
+        # Serializing eagerly here (at decoration time) was an import-time landmine
+        # (marqov-platform#1259): cloudpickle serializes local/closure functions BY
+        # VALUE, walking the function's referenced globals and closure by hand. In a
+        # heavy-import environment that deep traversal can overflow the recursion
+        # limit — a catchable RecursionError on Linux, a hard C-stack segfault on
+        # macOS / musl — and it fired for EVERY @task the moment its module was
+        # imported, whether or not the task was ever dispatched. Deferring to
+        # graph-build means importing a module full of @task functions pickles
+        # nothing; the cost (and the residual by-value risk for genuinely local
+        # functions) moves to the point a workflow graph is actually built.
+        _func_ref_cache: list[str] = []
+
+        def _func_ref() -> str:
+            if not _func_ref_cache:
+                _func_ref_cache.append(
+                    base64.b64encode(cloudpickle.dumps(fn)).decode("utf-8")
+                )
+            return _func_ref_cache[0]
 
         @wraps(fn)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -140,7 +158,7 @@ def task(
                 node = TaskNode(
                     id=generate_node_id(),
                     func_name=fn.__name__,
-                    func_ref=func_ref,
+                    func_ref=_func_ref(),
                     args=list(_serialize_arg(arg) for arg in args),
                     kwargs={k: _serialize_arg(v) for k, v in kwargs.items()},
                     config=config,
@@ -152,10 +170,12 @@ def task(
                 # Outside lattice: execute directly
                 return fn(*args, **kwargs)
 
-        # Mark as task for introspection
+        # Mark as task for introspection.
+        # NB: no eager `_task_func_ref` attribute — it was write-only (zero readers
+        # in the SDK or the platform) and computing it here would defeat the lazy
+        # serialization above. Dropped per marqov-platform#1259.
         wrapper._is_task = True  # type: ignore
         wrapper._task_config = config  # type: ignore
-        wrapper._task_func_ref = func_ref  # type: ignore
 
         return wrapper  # type: ignore
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -4,17 +4,17 @@ import pytest
 from marqov import task, workflow
 from marqov.workflows import TransportGraph, TaskProxy
 
-# KNOWN PRE-EXISTING ISSUE (marqov-platform#1259): @task serializes the function
-# with cloudpickle.dumps() at DECORATION time. These tests decorate *local*
-# functions, which cloudpickle must pickle by value; under the full suite (with
-# the [all] heavy backends imported) that overflows into a RecursionError
-# (segfault on macOS). It is not caused by the PyPI-publishing work — the same 13
-# fail on unmodified main — and the real fix is architectural (don't pickle at
-# decoration; reference functions by name / defer to dispatch). Marked xfail so
-# CI is honest while it's tracked. strict=False: they pass when this file is run
-# in isolation, so an unexpected pass must not fail the run.
+# KNOWN PRE-EXISTING ISSUE (marqov-platform#1259). Approach A has landed: @task no
+# longer cloudpickles at DECORATION time (that import-time landmine is fixed — see
+# tests/test_task_serialization.py, which enforces it). What remains is the RESIDUAL
+# case this marker guards: these tests decorate *local* functions and then build a
+# workflow graph, so the by-value cloudpickle now happens at GRAPH-BUILD; under the
+# full suite (with the [all] heavy backends imported) that can still overflow into a
+# RecursionError (segfault on macOS/musl). Fully removing this needs the by-reference
+# work (require importable/module-level task functions; see the alignment spec).
+# strict=False: they pass in isolation, so an unexpected pass must not fail the run.
 pytestmark = pytest.mark.xfail(
-    reason="cloudpickle recursion at @task decoration under heavy imports; see marqov-platform#1259",
+    reason="cloudpickle by-value recursion at graph-build for LOCAL @task fns under heavy imports; see marqov-platform#1259",
     strict=False,
 )
 

--- a/tests/test_task_serialization.py
+++ b/tests/test_task_serialization.py
@@ -1,0 +1,96 @@
+"""Approach A (marqov-platform#1259): @task must not serialize at decoration time.
+
+These lock in the contract that cloudpickle runs LAZILY at graph-build, never at
+decoration/import — the import-time landmine that overflowed the recursion limit
+(RecursionError on Linux, hard segfault on macOS/musl) under heavy imports.
+
+Robustness note: the tests that let *real* cloudpickle run at graph-build pickle a
+MODULE-LEVEL function (`_plain_add`), which cloudpickle serializes by reference
+(cheap — no deep traversal). The tests that assert decoration does NOT pickle use
+local functions (the exact fragile #1259 case) but mock ``cloudpickle.dumps``, so
+no local is ever actually serialized. Net: deterministic and safe to run under the
+full ``[all]`` suite that surfaces the underlying bug.
+"""
+from unittest.mock import patch
+
+import cloudpickle
+
+from marqov import task, workflow
+
+
+def _plain_add(x, y):
+    """Module-level (importable) function → cloudpickle serializes it by reference."""
+    return x + y
+
+
+def test_decoration_does_not_serialize():
+    """@task must NOT call cloudpickle at decoration time — the #1259 landmine."""
+    with patch("marqov.workflows.decorators.cloudpickle.dumps") as dumps:
+
+        @task
+        def add(x, y):  # a LOCAL function — the exact fragile case
+            return x + y
+
+        dumps.assert_not_called()
+
+
+def test_direct_call_never_serializes():
+    """A task called outside a workflow executes directly and never pickles."""
+    with patch("marqov.workflows.decorators.cloudpickle.dumps") as dumps:
+
+        @task
+        def add(x, y):
+            return x + y
+
+        assert add(1, 2) == 3
+        dumps.assert_not_called()
+
+
+def test_serialization_deferred_to_graph_build():
+    """Serialization happens when a task builds a graph node inside @workflow."""
+    add = task(_plain_add)  # fresh wrapper (fresh cache); pickles by reference
+
+    with patch(
+        "marqov.workflows.decorators.cloudpickle.dumps", wraps=cloudpickle.dumps
+    ) as dumps:
+
+        @workflow
+        def compute():
+            return add(1, 2)
+
+        dispatch = compute()
+        dumps.assert_called()  # pickled at graph-build, not before
+
+    node = next(iter(dispatch.graph.nodes.values()))
+    assert node.func_ref  # populated and non-empty
+
+
+def test_func_ref_computed_once_and_cached():
+    """Repeated builds / multiple nodes reuse the cached func_ref (pickle once)."""
+    add = task(_plain_add)  # fresh wrapper so this test's cache starts empty
+
+    with patch(
+        "marqov.workflows.decorators.cloudpickle.dumps", wraps=cloudpickle.dumps
+    ) as dumps:
+
+        @workflow
+        def compute():
+            a = add(1, 2)
+            b = add(a, 3)  # same task, a second node in the same graph
+            return b
+
+        compute()
+        compute()  # build the whole graph a second time
+
+        assert dumps.call_count == 1  # cached across every node and every build
+
+
+def test_eager_func_ref_attribute_removed():
+    """The write-only `_task_func_ref` attribute is gone (would defeat laziness)."""
+
+    @task
+    def add(x, y):
+        return x + y
+
+    assert add._is_task is True
+    assert not hasattr(add, "_task_func_ref")


### PR DESCRIPTION
Interim fix for the `@task` eager-serialization bug (marqov-dev/marqov-platform#1259).

## Problem

`@task` called `cloudpickle.dumps(fn)` at **decoration time** — so importing any module with `@task` functions serialized every one of them, by value, at import. For local/closure functions in a heavy-import environment (the `[all]` extra), cloudpickle's by-value deep traversal overflows the recursion limit: a catchable `RecursionError` on Linux, a hard C-stack **segfault** on macOS/musl. It fired whether or not the task was ever dispatched.

## Fix (Approach A)

Move the cloudpickle into a **lazy, cached** helper that runs only when a task actually builds a graph node inside a `@workflow`. Importing `@task` modules now serializes nothing. Also drop the write-only `_task_func_ref` attribute (verified zero readers in this repo and in the platform; computing it eagerly would defeat the laziness).

This is the **interim** fix. The durable realignment — referencing importable functions by name instead of shipping pickled bytes (which is what Temporal, Prefect, and Celery all do) — is specced separately for team review.

## What this does and doesn't fix

- ✅ **Import-time landmine gone** — decorating/importing `@task` functions never pickles.
- ✅ Direct calls (task outside a workflow) never pickle.
- ⚠️ **Residual:** a *local/closure* task function still pickles by value at graph-build, so it can still overflow under heavy imports. The 13 `test_decorators.py` cases decorate `<locals>` and stay `xfail(strict=False)` with an updated reason. Module-level task functions are unaffected (they pickle cheaply, by reference).

## Tests

`tests/test_task_serialization.py` (new) locks in the contract deterministically — it **spies on `cloudpickle.dumps`** rather than trying to reproduce the environment-dependent overflow: decoration never serializes, direct calls never serialize, serialization is deferred to graph-build, `func_ref` is cached (pickled once), and `_task_func_ref` is gone. The graph-build cases pickle a **module-level** function (by reference), so they're safe to run under the `[all]` suite that surfaces the underlying bug.

Verified locally: the 5 contract tests pass; 73 workflow-subsystem tests pass; the 13 `test_decorators.py` cases xpass in isolation. (The full `[all]` suite segfaults on macOS — that's the bug — so its verification is CI's job on Linux.)

Refs marqov-dev/marqov-platform#1259.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how task functions are serialized for workflow dispatch; behavior for module-level tasks should match, but local/closure tasks still pickle by value at graph-build with the same overflow risk as before.
> 
> **Overview**
> **`@task` no longer runs `cloudpickle` at decoration/import time** — the fix for marqov-platform#1259’s import-time recursion/segfault under heavy imports.
> 
> Serialization moves into a **lazy, per-task cached** `_func_ref()` that runs only when a task registers a graph node inside `@workflow`. Direct calls outside a workflow still execute the function and never pickle. The unused **`_task_func_ref`** wrapper attribute is removed so nothing re-introduces eager pickling.
> 
> **Tests:** New `tests/test_task_serialization.py` spies on `cloudpickle.dumps` to lock in that contract. `tests/test_decorators.py` stays `xfail` for **local** tasks at graph-build (residual by-value risk); the marker reason is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 126bf2bcd391738fea8bf10cb822bb7e8dbab0a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->