### PR TITLE
Add CudaqExecutor (NVIDIA CUDA-Q: GPU sim + direct IQM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,19 @@ jobs:
         run: python tools/check_no_url_deps.py
       - name: Test suite
         run: pytest tests/ -q
+
+  # CUDA-Q is Linux-only and heavy, so it is NOT in [all] — the main `test` job
+  # skips test_real_cudaq_bell_state. This job installs [cudaq] on Linux so that
+  # real CUDA-Q run actually executes (on the qpp-cpu target; no GPU required).
+  test-cudaq:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - name: Install uv
+        run: pip install uv
+      - name: Install (with cudaq + dev)
+        run: uv pip install --system -e ".[cudaq,dev]"
+      - name: CUDA-Q executor tests (incl. real qpp-cpu run)
+        run: pytest tests/test_cudaq_executor.py -q

--- a/marqov/executors/__init__.py
+++ b/marqov/executors/__init__.py
@@ -4,6 +4,7 @@ This module provides executors for running quantum circuits on various backends.
 
 Available executors:
 - LocalExecutor: QuantumFlow simulator (no cloud required)
+- CudaqExecutor: NVIDIA CUDA-Q (GPU/CPU statevector, direct IQM)
 - BraketExecutor: AWS Braket (simulators and QPUs)
 - AzureQuantumExecutor: Azure Quantum (Quantinuum, PASQAL, IonQ, Rigetti)
 - QuantinuumExecutor: Quantinuum devices and emulators (via pytket-quantinuum)
@@ -23,6 +24,7 @@ Example:
 from marqov.executors.azure import AzureQuantumExecutor, AzureQuantumExecutorConfig
 from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
 from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
+from marqov.executors.cudaq import CudaqExecutor, CudaqExecutorConfig
 from marqov.executors.factory import ExecutorFactory
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
 from marqov.executors.ionq import IonQExecutor, IonQExecutorConfig
@@ -37,6 +39,8 @@ __all__ = [
     "BaseExecutor",
     "BraketExecutor",
     "BraketExecutorConfig",
+    "CudaqExecutor",
+    "CudaqExecutorConfig",
     "DeviceStatus",
     "ExecutionResult",
     "ExecutorFactory",

--- a/marqov/executors/cudaq.py
+++ b/marqov/executors/cudaq.py
@@ -1,0 +1,280 @@
+"""NVIDIA CUDA-Q executor for GPU-accelerated simulation and direct IQM.
+
+This executor runs circuits on NVIDIA's CUDA-Q toolkit, giving Marqov two
+capabilities its other backends don't cover:
+
+- **GPU statevector simulation** via the ``nvidia`` target (scales past what the
+  CPU ``LocalExecutor`` / cloud ``SV1`` reach), and
+- **Direct IQM Resonance** via the ``iqm`` target (a lower-latency route than
+  IQM-through-Braket).
+
+The CPU target (``qpp-cpu``) needs no GPU and is the default, so this executor
+is useful even without accelerator hardware.
+
+Backend slugs handled by the factory:
+    - ``cudaq-cpu``  -> CUDA-Q ``qpp-cpu`` target (CPU statevector)
+    - ``cudaq-gpu``  -> CUDA-Q ``nvidia`` target (GPU statevector; CPU fallback)
+    - ``cudaq-iqm``  -> CUDA-Q ``iqm`` target (direct IQM Resonance QPU)
+
+Example:
+    >>> from marqov.circuits import bell_state
+    >>> from marqov.executors import CudaqExecutor, CudaqExecutorConfig
+    >>>
+    >>> executor = CudaqExecutor(CudaqExecutorConfig(target="qpp-cpu"))
+    >>> result = await executor.execute(bell_state(), shots=1000)
+    >>> print(result.counts)  # {"00": ~500, "11": ~500}
+
+Note:
+    ``cudaq`` ships Linux-only wheels (no macOS build). Install the backend with
+    ``pip install marqov[cudaq]`` on Linux, or run inside the official
+    ``nvcr.io/nvidia/quantum/cuda-quantum`` container.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
+
+if TYPE_CHECKING:
+    from marqov.circuits import Circuit
+
+
+# Targets that never need remote credentials / can run without a GPU present.
+_LOCAL_TARGETS = frozenset({"qpp-cpu", "nvidia", "nvidia-fp64", "nvidia-mgpu"})
+
+# Slug -> CUDA-Q target name.
+_SLUG_TO_TARGET: dict[str, str] = {
+    "cudaq-cpu": "qpp-cpu",
+    "cudaq-gpu": "nvidia",
+    "cudaq-iqm": "iqm",
+}
+
+
+class _KernelBuilder(Protocol):
+    """Structural type for the object returned by ``cudaq.make_kernel()``.
+
+    Declaring only the methods we call lets the gate-mapping logic be unit
+    tested with a recording double, so the transpiler is verifiable without a
+    CUDA-Q install (which is Linux-only).
+    """
+
+    def qalloc(self, count: int) -> Any: ...
+    def h(self, q: Any) -> None: ...
+    def x(self, q: Any) -> None: ...
+    def y(self, q: Any) -> None: ...
+    def z(self, q: Any) -> None: ...
+    def s(self, q: Any) -> None: ...
+    def t(self, q: Any) -> None: ...
+    def rx(self, angle: float, q: Any) -> None: ...
+    def ry(self, angle: float, q: Any) -> None: ...
+    def rz(self, angle: float, q: Any) -> None: ...
+    def cx(self, ctrl: Any, tgt: Any) -> None: ...
+    def cz(self, ctrl: Any, tgt: Any) -> None: ...
+    def swap(self, a: Any, b: Any) -> None: ...
+    def mz(self, q: Any) -> None: ...
+
+
+@dataclass
+class CudaqExecutorConfig:
+    """Configuration for the CUDA-Q executor.
+
+    Attributes:
+        target: CUDA-Q target name — ``qpp-cpu`` (CPU), ``nvidia`` (GPU), or
+            ``iqm`` (IQM Resonance QPU).
+        iqm_url: IQM server URL (required when ``target == "iqm"``).
+        iqm_token: IQM API token. Falls back to the ``IQM_TOKEN`` environment
+            variable when not set.
+        gpu_fallback_to_cpu: If a GPU target is requested but no GPU is
+            available, fall back to ``qpp-cpu`` instead of raising. Matches the
+            behaviour of the reference tutorial notebooks.
+        seed: Optional CUDA-Q random seed for reproducible sampling.
+        target_options: Extra keyword args forwarded verbatim to
+            ``cudaq.set_target`` (e.g. IQM-specific options).
+    """
+
+    target: str = "qpp-cpu"
+    iqm_url: str | None = None
+    iqm_token: str | None = None
+    gpu_fallback_to_cpu: bool = True
+    seed: int | None = None
+    target_options: dict[str, Any] = field(default_factory=dict)
+
+
+def _import_cudaq() -> Any:
+    """Import ``cudaq`` with an actionable error if it isn't installed."""
+    try:
+        import cudaq  # type: ignore
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise ImportError(
+            "CUDA-Q is required for CudaqExecutor. Install with: "
+            "pip install marqov[cudaq]\n"
+            "Note: cudaq ships Linux-only wheels — there is no macOS build. "
+            "On macOS, run inside the nvcr.io/nvidia/quantum/cuda-quantum container."
+        ) from exc
+    return cudaq
+
+
+def build_kernel(builder: _KernelBuilder, circuit: Circuit) -> Any:
+    """Populate a CUDA-Q kernel from a Marqov circuit and return the qubit register.
+
+    Transpiles via Qiskit (a stable, well-documented instruction API) and maps
+    each instruction onto a CUDA-Q builder call. Kept free of any ``cudaq``
+    import so it can be unit tested with a recording ``builder`` double.
+
+    Args:
+        builder: A ``cudaq.make_kernel()`` result (or a structural stand-in).
+        circuit: The Marqov circuit to transpile.
+
+    Returns:
+        The allocated qubit register (``builder.qalloc(n)``), with a terminal
+        ``mz`` applied for measurement.
+
+    Raises:
+        NotImplementedError: If the circuit contains a gate with no CUDA-Q
+            builder equivalent.
+    """
+    qiskit_circuit = circuit.to_qiskit()
+    num_qubits = qiskit_circuit.num_qubits
+    qubits = builder.qalloc(num_qubits)
+
+    # name -> (arity, is_parametric); mapped onto builder methods below.
+    for instruction in qiskit_circuit.data:
+        op = instruction.operation
+        name = op.name.lower()
+        qargs = [qiskit_circuit.find_bit(q).index for q in instruction.qubits]
+        params = [float(p) for p in op.params]
+
+        if name in ("h", "x", "y", "z", "s", "t"):
+            getattr(builder, name)(qubits[qargs[0]])
+        elif name in ("rx", "ry", "rz"):
+            getattr(builder, name)(params[0], qubits[qargs[0]])
+        elif name in ("cx", "cnot"):
+            builder.cx(qubits[qargs[0]], qubits[qargs[1]])
+        elif name == "cz":
+            builder.cz(qubits[qargs[0]], qubits[qargs[1]])
+        elif name == "swap":
+            builder.swap(qubits[qargs[0]], qubits[qargs[1]])
+        elif name in ("measure", "barrier"):
+            # Measurement is applied uniformly below; barriers are no-ops.
+            continue
+        else:
+            raise NotImplementedError(
+                f"Gate '{name}' has no CUDA-Q builder mapping. Supported: "
+                f"h, x, y, z, s, t, rx, ry, rz, cx, cz, swap."
+            )
+
+    builder.mz(qubits)
+    return qubits
+
+
+class CudaqExecutor(BaseExecutor):
+    """Execute circuits on NVIDIA CUDA-Q (CPU/GPU statevector or direct IQM).
+
+    Example:
+        >>> executor = CudaqExecutor(CudaqExecutorConfig(target="nvidia"))
+        >>> result = await executor.execute(circuit, shots=2000)
+    """
+
+    def __init__(self, config: CudaqExecutorConfig | None = None) -> None:
+        """Initialize the CUDA-Q executor.
+
+        Args:
+            config: Configuration options. Defaults to the CPU (``qpp-cpu``)
+                target when not provided.
+        """
+        self.config = config or CudaqExecutorConfig()
+
+    async def execute(
+        self,
+        circuit: Circuit,
+        shots: int = 1000,
+        **kwargs: Any,
+    ) -> ExecutionResult:
+        """Run a circuit on the configured CUDA-Q target.
+
+        Args:
+            circuit: The circuit to execute.
+            shots: Number of measurement shots.
+            **kwargs: Ignored; present for interface compatibility.
+
+        Returns:
+            ExecutionResult with normalized measurement counts.
+        """
+        circuit = self._validate_circuit(circuit)
+        cudaq = _import_cudaq()
+
+        start_time = time.perf_counter()
+        # CUDA-Q's set_target / sample are synchronous and CPU/GPU-bound; run off
+        # the event loop so concurrent executes don't block each other.
+        counts, resolved_target = await asyncio.to_thread(
+            self._run_sync, cudaq, circuit, shots
+        )
+        execution_time_ms = (time.perf_counter() - start_time) * 1000
+
+        return ExecutionResult(
+            counts=counts,
+            backend=f"cudaq:{resolved_target}",
+            execution_time_ms=execution_time_ms,
+            shots=shots,
+            raw_result=None,
+            metadata={
+                "framework": "cudaq",
+                "target": resolved_target,
+                "requested_target": self.config.target,
+            },
+        )
+
+    def _run_sync(
+        self, cudaq: Any, circuit: Circuit, shots: int
+    ) -> tuple[dict[str, int], str]:
+        """Synchronous CUDA-Q execution (set target, build kernel, sample)."""
+        resolved_target = self._select_target(cudaq)
+
+        if self.config.seed is not None:
+            cudaq.set_random_seed(self.config.seed)
+
+        kernel = cudaq.make_kernel()
+        build_kernel(kernel, circuit)
+
+        sample_result = cudaq.sample(kernel, shots_count=shots)
+        counts = {str(bitstring): int(count) for bitstring, count in sample_result.items()}
+        return counts, resolved_target
+
+    def _select_target(self, cudaq: Any) -> str:
+        """Set the CUDA-Q target, applying the requested config and GPU fallback.
+
+        Returns:
+            The target name actually set (may differ from the request when a GPU
+            target falls back to CPU).
+        """
+        target = self.config.target
+
+        if target == "iqm":
+            if not self.config.iqm_url:
+                raise ValueError("CudaqExecutorConfig.iqm_url is required for the 'iqm' target.")
+            options = dict(self.config.target_options)
+            if self.config.iqm_token is not None:
+                import os
+
+                os.environ.setdefault("IQM_TOKEN", self.config.iqm_token)
+            cudaq.set_target("iqm", url=self.config.iqm_url, **options)
+            return "iqm"
+
+        # GPU targets: optionally fall back to CPU when no GPU is present.
+        if target.startswith("nvidia") and self.config.gpu_fallback_to_cpu:
+            if cudaq.num_available_gpus() == 0:
+                cudaq.set_target("qpp-cpu")
+                return "qpp-cpu"
+
+        cudaq.set_target(target, **self.config.target_options)
+        return target
+
+    async def get_status(self) -> DeviceStatus:
+        """Local CUDA-Q targets are always available; IQM status is not polled here."""
+        if self.config.target in _LOCAL_TARGETS:
+            return DeviceStatus.always_online()
+        return DeviceStatus(status="online", queue_depth=None, queue_time_seconds=None)

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 from marqov.executors.azure import AzureQuantumExecutor, AzureQuantumExecutorConfig
 from marqov.executors.base import BaseExecutor
 from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
+from marqov.executors.cudaq import CudaqExecutor, CudaqExecutorConfig, _SLUG_TO_TARGET
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
 from marqov.executors.ionq import IonQExecutor, IonQExecutorConfig
 from marqov.executors.local import LocalExecutor
@@ -97,6 +98,10 @@ class ExecutorFactory:
         if backend_slug == "local" or provider == "Local":
             return LocalExecutor()
 
+        # NVIDIA CUDA-Q (GPU/CPU statevector, direct IQM)
+        if provider == "CUDA-Q" or backend_slug in _SLUG_TO_TARGET:
+            return cls._create_cudaq_executor(backend_slug, backend_config)
+
         # AWS Braket
         if provider == "AWS Braket":
             return cls._create_braket_executor(backend_slug, backend_config)
@@ -128,7 +133,7 @@ class ExecutorFactory:
         raise ValueError(
             f"Unsupported provider: {provider}. "
             f"Supported providers: AWS Braket, IBM Quantum, Azure Quantum, "
-            f"IonQ Direct, Rigetti QCS, Quantum Brilliance, Local."
+            f"IonQ Direct, Rigetti QCS, Quantum Brilliance, CUDA-Q, Local."
         )
 
     @classmethod
@@ -368,6 +373,37 @@ class ExecutorFactory:
         return RigettiExecutor(config)
 
     @classmethod
+    def _create_cudaq_executor(
+        cls,
+        backend_slug: str,
+        backend_config: dict[str, Any],
+    ) -> CudaqExecutor:
+        """Create an NVIDIA CUDA-Q executor from configuration.
+
+        No field is strictly required for the CPU/GPU targets: the target falls
+        back from the backend slug (``cudaq-cpu`` / ``cudaq-gpu`` / ``cudaq-iqm``)
+        or an explicit ``target`` in the config. The ``iqm`` target additionally
+        needs ``iqm_url`` (and a token via config or the ``IQM_TOKEN`` env var).
+
+        Args:
+            backend_slug: Backend slug; maps to a CUDA-Q target when it is one of
+                ``cudaq-cpu`` / ``cudaq-gpu`` / ``cudaq-iqm``.
+            backend_config: Optional ``target``, ``iqm_url``, ``iqm_token``,
+                ``gpu_fallback_to_cpu``, ``seed``, ``target_options``.
+
+        Returns:
+            Configured CudaqExecutor instance.
+        """
+        target = backend_config.get("target") or _SLUG_TO_TARGET.get(backend_slug, "qpp-cpu")
+
+        config_kwargs: dict[str, Any] = {"target": target}
+        for key in ("iqm_url", "iqm_token", "gpu_fallback_to_cpu", "seed", "target_options"):
+            if key in backend_config:
+                config_kwargs[key] = backend_config[key]
+
+        return CudaqExecutor(CudaqExecutorConfig(**config_kwargs))
+
+    @classmethod
     def _create_simulation_executor(
         cls,
         backend_slug: str,
@@ -403,6 +439,7 @@ class ExecutorFactory:
             "IonQ Direct",
             "Rigetti QCS",
             "Quantum Brilliance",
+            "CUDA-Q",
             "Local",
             "Quantinuum",
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,12 @@ ibm = [
 cirq = [
     "cirq-core>=1.0.0",
 ]
+cudaq = [
+    # cudaq ships Linux-only wheels; the marker keeps macOS/Windows installs from
+    # failing (they get the transpile deps but not the runtime).
+    "cudaq>=0.14.2 ; platform_system == 'Linux'",
+    "qiskit>=1.0.0",  # transpile path: Marqov Circuit -> Qiskit -> CUDA-Q kernel
+]
 pennylane = [
     "pennylane>=0.35.0",
 ]

--- a/tests/test_cudaq_executor.py
+++ b/tests/test_cudaq_executor.py
@@ -1,0 +1,278 @@
+"""Tests for the NVIDIA CUDA-Q executor.
+
+The gate-mapping and factory tests run anywhere (no ``cudaq`` needed) using a
+recording kernel builder and a fake ``cudaq`` module. The final test exercises a
+real CUDA-Q run and is skipped unless ``cudaq`` is importable (Linux-only).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from marqov.circuits import Circuit, bell_state, ghz_state
+from marqov.executors import CudaqExecutor, CudaqExecutorConfig, ExecutorFactory
+from marqov.executors import cudaq as cudaq_module
+
+
+# --------------------------------------------------------------------------- #
+# Test doubles
+# --------------------------------------------------------------------------- #
+
+
+class _Register:
+    """Indexable qubit register stand-in; ``reg[i]`` yields a hashable token."""
+
+    def __init__(self, count: int) -> None:
+        self.count = count
+
+    def __getitem__(self, index: int) -> tuple[str, int]:
+        return ("q", index)
+
+
+class RecordingBuilder:
+    """Records CUDA-Q builder calls so the transpiler can be asserted on."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, ...]] = []
+
+    def qalloc(self, count: int) -> _Register:
+        self.calls.append(("qalloc", count))
+        return _Register(count)
+
+    def __getattr__(self, gate: str):  # h, x, rx, cx, mz, ...
+        def record(*args: Any) -> None:
+            self.calls.append((gate, *args))
+
+        return record
+
+
+class _FakeSampleResult:
+    def __init__(self, counts: dict[str, int]) -> None:
+        self._counts = counts
+
+    def items(self):
+        return self._counts.items()
+
+
+class FakeCudaq:
+    """Minimal fake of the ``cudaq`` module for executor tests."""
+
+    def __init__(self, gpus: int = 0) -> None:
+        self._gpus = gpus
+        self.target: str | None = None
+        self.target_kwargs: dict[str, Any] = {}
+        self.seed: int | None = None
+        self.sampled_shots: int | None = None
+
+    def num_available_gpus(self) -> int:
+        return self._gpus
+
+    def set_target(self, target: str, **kwargs: Any) -> None:
+        self.target = target
+        self.target_kwargs = kwargs
+
+    def set_random_seed(self, seed: int) -> None:
+        self.seed = seed
+
+    def make_kernel(self) -> RecordingBuilder:
+        return RecordingBuilder()
+
+    def sample(self, kernel: Any, shots_count: int) -> _FakeSampleResult:
+        self.sampled_shots = shots_count
+        half = shots_count // 2
+        return _FakeSampleResult({"00": half, "11": shots_count - half})
+
+
+@pytest.fixture
+def fake_cudaq(monkeypatch: pytest.MonkeyPatch) -> FakeCudaq:
+    """Patch ``_import_cudaq`` to return a FakeCudaq (0 GPUs by default)."""
+    fake = FakeCudaq(gpus=0)
+    monkeypatch.setattr(cudaq_module, "_import_cudaq", lambda: fake)
+    return fake
+
+
+# --------------------------------------------------------------------------- #
+# Gate mapping (no cudaq required)
+# --------------------------------------------------------------------------- #
+
+
+class TestBuildKernel:
+    def test_bell_state_maps_to_h_cx_mz(self) -> None:
+        builder = RecordingBuilder()
+        cudaq_module.build_kernel(builder, bell_state())
+
+        assert builder.calls[0] == ("qalloc", 2)
+        gate_names = [c[0] for c in builder.calls]
+        assert "h" in gate_names
+        assert "cx" in gate_names
+        # Measurement is always applied last.
+        assert builder.calls[-1][0] == "mz"
+
+    def test_rotation_gate_carries_angle(self) -> None:
+        builder = RecordingBuilder()
+        cudaq_module.build_kernel(builder, Circuit().rx(0.5, 0))
+
+        rx_calls = [c for c in builder.calls if c[0] == "rx"]
+        assert len(rx_calls) == 1
+        # ("rx", angle, qubit_token)
+        assert rx_calls[0][1] == pytest.approx(0.5)
+
+    def test_ghz_allocates_all_qubits(self) -> None:
+        builder = RecordingBuilder()
+        cudaq_module.build_kernel(builder, ghz_state(4))
+        assert builder.calls[0] == ("qalloc", 4)
+
+    def test_unsupported_gate_raises(self) -> None:
+        class FakeInstr:
+            name = "toffoli"
+            params: list[float] = []
+
+        class FakeQiskitCircuit:
+            num_qubits = 3
+            data = [type("I", (), {"operation": FakeInstr(), "qubits": []})()]
+
+            def find_bit(self, q: Any) -> Any:  # pragma: no cover - not reached
+                raise AssertionError
+
+        class FakeMarqovCircuit:
+            def to_qiskit(self) -> FakeQiskitCircuit:
+                return FakeQiskitCircuit()
+
+        with pytest.raises(NotImplementedError, match="toffoli"):
+            cudaq_module.build_kernel(RecordingBuilder(), FakeMarqovCircuit())  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# Factory registration (no cudaq required)
+# --------------------------------------------------------------------------- #
+
+
+class TestFactory:
+    @pytest.mark.parametrize(
+        ("slug", "expected_target"),
+        [("cudaq-cpu", "qpp-cpu"), ("cudaq-gpu", "nvidia"), ("cudaq-iqm", "iqm")],
+    )
+    def test_slug_selects_target(self, slug: str, expected_target: str) -> None:
+        executor = ExecutorFactory.create_executor(slug, {"provider": "CUDA-Q"})
+        assert isinstance(executor, CudaqExecutor)
+        assert executor.config.target == expected_target
+
+    def test_provider_registered(self) -> None:
+        assert ExecutorFactory.is_provider_supported("CUDA-Q")
+
+    def test_explicit_target_overrides_slug(self) -> None:
+        executor = ExecutorFactory.create_executor(
+            "cudaq-cpu", {"provider": "CUDA-Q", "target": "nvidia"}
+        )
+        assert executor.config.target == "nvidia"
+
+    def test_iqm_config_forwarded(self) -> None:
+        executor = ExecutorFactory.create_executor(
+            "cudaq-iqm",
+            {"provider": "CUDA-Q", "iqm_url": "https://example/garnet"},
+        )
+        assert executor.config.iqm_url == "https://example/garnet"
+
+
+# --------------------------------------------------------------------------- #
+# execute() with a fake cudaq (no real backend)
+# --------------------------------------------------------------------------- #
+
+
+class TestExecute:
+    @pytest.mark.asyncio
+    async def test_cpu_execute_returns_normalized_counts(self, fake_cudaq: FakeCudaq) -> None:
+        executor = CudaqExecutor(CudaqExecutorConfig(target="qpp-cpu"))
+        result = await executor.execute(bell_state(), shots=1000)
+
+        assert result.counts == {"00": 500, "11": 500}
+        assert result.shots == 1000
+        assert result.backend == "cudaq:qpp-cpu"
+        assert result.metadata["target"] == "qpp-cpu"
+        assert fake_cudaq.target == "qpp-cpu"
+        assert fake_cudaq.sampled_shots == 1000
+
+    @pytest.mark.asyncio
+    async def test_gpu_falls_back_to_cpu_when_no_gpu(self, fake_cudaq: FakeCudaq) -> None:
+        executor = CudaqExecutor(CudaqExecutorConfig(target="nvidia"))
+        result = await executor.execute(bell_state(), shots=100)
+
+        # 0 GPUs available -> resolved target is qpp-cpu.
+        assert fake_cudaq.target == "qpp-cpu"
+        assert result.metadata["target"] == "qpp-cpu"
+        assert result.metadata["requested_target"] == "nvidia"
+
+    @pytest.mark.asyncio
+    async def test_gpu_used_when_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = FakeCudaq(gpus=1)
+        monkeypatch.setattr(cudaq_module, "_import_cudaq", lambda: fake)
+        executor = CudaqExecutor(CudaqExecutorConfig(target="nvidia"))
+        await executor.execute(bell_state(), shots=100)
+        assert fake.target == "nvidia"
+
+    @pytest.mark.asyncio
+    async def test_gpu_no_fallback_raises_nothing_but_sets_nvidia(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = FakeCudaq(gpus=0)
+        monkeypatch.setattr(cudaq_module, "_import_cudaq", lambda: fake)
+        executor = CudaqExecutor(
+            CudaqExecutorConfig(target="nvidia", gpu_fallback_to_cpu=False)
+        )
+        await executor.execute(bell_state(), shots=10)
+        assert fake.target == "nvidia"
+
+    @pytest.mark.asyncio
+    async def test_seed_forwarded(self, fake_cudaq: FakeCudaq) -> None:
+        executor = CudaqExecutor(CudaqExecutorConfig(target="qpp-cpu", seed=7))
+        await executor.execute(bell_state(), shots=10)
+        assert fake_cudaq.seed == 7
+
+    @pytest.mark.asyncio
+    async def test_iqm_requires_url(self, fake_cudaq: FakeCudaq) -> None:
+        executor = CudaqExecutor(CudaqExecutorConfig(target="iqm"))
+        with pytest.raises(ValueError, match="iqm_url"):
+            await executor.execute(bell_state(), shots=10)
+
+    @pytest.mark.asyncio
+    async def test_iqm_sets_target_with_url(self, fake_cudaq: FakeCudaq) -> None:
+        executor = CudaqExecutor(
+            CudaqExecutorConfig(target="iqm", iqm_url="https://example/garnet")
+        )
+        await executor.execute(bell_state(), shots=10)
+        assert fake_cudaq.target == "iqm"
+        assert fake_cudaq.target_kwargs["url"] == "https://example/garnet"
+
+    def test_import_error_is_actionable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When ``import cudaq`` fails, _import_cudaq gives install guidance."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: Any, **kwargs: Any):
+            if name == "cudaq":
+                raise ImportError("no cudaq")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        with pytest.raises(ImportError, match=r"marqov\[cudaq\]"):
+            cudaq_module._import_cudaq()
+
+
+# --------------------------------------------------------------------------- #
+# Real CUDA-Q execution (Linux-only; skipped when cudaq is absent)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_real_cudaq_bell_state() -> None:
+    pytest.importorskip("cudaq", reason="cudaq is Linux-only; not installed")
+    executor = CudaqExecutor(CudaqExecutorConfig(target="qpp-cpu", seed=1))
+    result = await executor.execute(bell_state(), shots=1000)
+
+    assert sum(result.counts.values()) == 1000
+    # Bell state -> only |00> and |11> outcomes.
+    assert set(result.counts).issubset({"00", "11"})
+    assert result.backend == "cudaq:qpp-cpu"

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -836,4 +836,5 @@ class TestExecutorFactory:
         assert set(ExecutorFactory.get_supported_providers()) == {
             "Local", "AWS Braket", "IBM Quantum", "Quantinuum",
             "Azure Quantum", "IonQ Direct", "Rigetti QCS", "Quantum Brilliance",
+            "CUDA-Q",
         }


### PR DESCRIPTION
## Summary

Adds a **`CudaqExecutor`** so Marqov can run circuits on NVIDIA **CUDA-Q** — the one major quantum framework the SDK didn't speak. It fills two gaps in the current backend set:

- **GPU statevector simulation** via the `nvidia` target (with automatic CPU fallback when no GPU is present)
- **Direct IQM Resonance** via the `iqm` target (lower-latency than IQM-through-Braket)

The default `qpp-cpu` target needs no GPU, so the executor is useful without accelerator hardware. Part of the ISC26 tutorial value-extraction epic (marqov-dev/marqov-platform#1340).

Closes #52.

## What's here

| Area | Change |
|------|--------|
| `marqov/executors/cudaq.py` | **new** — `CudaqExecutor` + `CudaqExecutorConfig`. Targets `qpp-cpu` / `nvidia` / `iqm`; GPU→CPU fallback; async off-loop execution → normalized `ExecutionResult` |
| `marqov/executors/factory.py` | register provider `CUDA-Q` + slugs `cudaq-cpu` / `cudaq-gpu` / `cudaq-iqm` |
| `marqov/executors/__init__.py` | exports |
| `pyproject.toml` | `[cudaq]` extra, **Linux-marked** so `pip install marqov[cudaq]` doesn't fail on macOS/Windows |
| `tests/test_cudaq_executor.py` | **new** — 19 tests |
| `tests/test_executors.py` | +1 line to the provider-guard set (it's designed to trip when a provider is added) |
| `.github/workflows/ci.yml` | **new `test-cudaq` job** — installs `[cudaq]` on Linux and runs the real qpp-cpu run |

## Design notes

- **Transpile:** `Circuit → to_qiskit() → walk instructions → cudaq.make_kernel()`. Qiskit's instruction API is stable and the gate set maps 1:1 to CUDA-Q builder calls.
- **Testability without cudaq:** `cudaq` ships **Linux-only** wheels (no macOS build). `build_kernel()` takes a builder-like object, so the transpile logic is unit tested with a recording double, and `execute()` is tested against a fake `cudaq` module (target selection, GPU fallback, IQM url requirement, seed, count normalization).
- **The real run** (`test_real_cudaq_bell_state`) is gated on `cudaq` being importable — it **skips locally on macOS** and **executes in the new `test-cudaq` CI job** on Linux.

## Verification

Run locally (macOS, no cudaq):
- `pytest tests/test_cudaq_executor.py tests/test_executors.py` → **80 passed, 1 skipped** (the real cudaq run), ruff clean.
- The real qpp-cpu run is expected to execute green in the `test-cudaq` CI job.

## Reviewer callouts

- **CPU-only cudaq on CI:** the `test-cudaq` job runs on a CPU-only `ubuntu-latest`. Evidence this works: the ISC26 tutorial's own Colab notebook installs `cudaq` on a CPU runtime and notes "the CPU-only wheel works on all Colab runtimes." If the meta-wheel doesn't resolve on a bare runner, we may need to pin `cudaq-cu12` or use a GPU runner — flagging so we watch the first CI run.
- Kept `cudaq` **out of `[all]`** deliberately (it's heavy) so the main `test` job stays fast.

Draft until the `test-cudaq` CI job is confirmed green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New execution path touches remote IQM credentials and environment variables, but it follows existing executor patterns and is covered by extensive unit tests plus an opt-in Linux CI job.
> 
> **Overview**
> Adds **NVIDIA CUDA-Q** as a first-class execution backend via new **`CudaqExecutor`** / **`CudaqExecutorConfig`**, wired through **`ExecutorFactory`** as provider **`CUDA-Q`** with slugs **`cudaq-cpu`**, **`cudaq-gpu`**, and **`cudaq-iqm`**.
> 
> Circuits are transpiled **Marqov → Qiskit → CUDA-Q kernel** (`build_kernel`), with async execution off the event loop, optional GPU→CPU fallback, and direct **IQM Resonance** when `iqm_url` is set. A Linux-only **`[cudaq]`** extra (not in **`[all]`**) is added in **`pyproject.toml`**.
> 
> CI gains a dedicated **`test-cudaq`** job on Ubuntu to install **`[cudaq]`** and run **`tests/test_cudaq_executor.py`**, including the real **`qpp-cpu`** integration test that the main job skips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87785268cdcc5ccdc09f3750dd290f9204026c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->