### PR TITLE
feat(benchmarking): normalized fidelity metric (Lubinski/QED-C)

### DIFF
--- a/marqov/benchmarking/__init__.py
+++ b/marqov/benchmarking/__init__.py
@@ -1,9 +1,16 @@
 """Quantum benchmarking tools.
 
-Currently provides SPAM (State Preparation And Measurement) benchmarking.
+Provides SPAM (State Preparation And Measurement) benchmarking and
+application-level distribution-fidelity metrics (Lubinski/QED-C normalized
+fidelity).
 Future: refactor into BenchmarkSuite with .spam(), .qst(), .qpt(), .fidelity().
 """
 
+from marqov.benchmarking.fidelity import (
+    classical_fidelity,
+    fidelity_with_uniform,
+    normalized_fidelity,
+)
 from marqov.benchmarking.spam import (
     ConfusionMatrix,
     SPAMResult,
@@ -17,5 +24,8 @@ __all__ = [
     "SPAMResult",
     "apply_spam_correction",
     "build_correction_matrix",
+    "classical_fidelity",
+    "fidelity_with_uniform",
+    "normalized_fidelity",
     "spam_benchmark",
 ]

--- a/marqov/benchmarking/fidelity.py
+++ b/marqov/benchmarking/fidelity.py
@@ -1,0 +1,260 @@
+"""Distribution-fidelity metrics for application-level benchmarking.
+
+Implements the *normalized fidelity* of Lubinski et al. ("Application-Oriented
+Performance Benchmarks for Quantum Computing", the QED-C suite): an
+application-level quality score that compares a backend's output distribution
+against an ideal reference distribution and normalizes out the trivial
+uniform-noise baseline. Unlike raw classical fidelity, a device that returns
+pure noise scores 0 rather than a misleadingly non-zero value.
+
+This complements the SPAM/readout characterization in
+:mod:`marqov.benchmarking.spam`: SPAM measures per-qubit measurement error,
+whereas normalized fidelity measures how faithfully a full application's output
+distribution survives execution on real hardware.
+
+All functions accept either an :class:`~marqov.executors.base.ExecutionResult`
+(the object returned by every executor) or a bare ``{bitstring: count}`` /
+``{bitstring: probability}`` dict.
+
+Bit-order caveat: these metrics compare bitstrings as keys. They tolerate
+differing *widths* (a distribution whose keys have had leading zeros trimmed is
+zero-padded to a common width before comparison), but they cannot detect a
+differing qubit *ordering* (endianness). The caller is responsible for ensuring
+the ideal and backend distributions share the same qubit-order convention — see
+``tests/test_azure_bitorder.py`` for why this matters across backends.
+
+Ported from Open QBench (PCSS-Quantum/open-qbench, Apache-2.0).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import cast
+
+from marqov.executors.base import ExecutionResult
+
+# A distribution keyed by bitstring. Values may be raw shot counts or
+# probabilities; both are accepted and normalized internally. Callers may also
+# pass an ExecutionResult directly.
+Distribution = dict[str, float]
+DistributionLike = ExecutionResult | Distribution
+
+
+def _extract(dist: DistributionLike) -> Distribution:
+    """Pull a plain ``{bitstring: value}`` dict out of the accepted input types.
+
+    Raises:
+        ValueError: If `dist` is not an ExecutionResult, a mapping, or an
+            iterable of (key, value) pairs.
+    """
+    source: object = dist.counts if isinstance(dist, ExecutionResult) else dist
+    try:
+        return cast(Distribution, dict(source))  # type: ignore[call-overload]
+    except TypeError as exc:
+        raise ValueError(
+            "expected an ExecutionResult, dict, or mapping-like object, got "
+            f"{type(dist).__name__}"
+        ) from exc
+
+
+def _to_probabilities(dist: DistributionLike) -> tuple[Distribution, int]:
+    """Validate and normalize a distribution to probabilities.
+
+    Zero-pads bitstrings to the distribution's maximum key width so that keys
+    that have had leading zeros trimmed still align.
+
+    Returns:
+        A ``(probabilities, width)`` tuple where ``width`` is the (padded)
+        bitstring length.
+
+    Raises:
+        ValueError: If the distribution is empty, has non-string keys, contains
+            a negative or non-finite value, has non-positive total mass, or has
+            keys that collide after zero-padding.
+    """
+    raw = _extract(dist)
+    if not raw:
+        raise ValueError("distribution must not be empty")
+
+    if not all(isinstance(k, str) for k in raw):
+        raise ValueError("distribution keys must be bitstrings (str)")
+
+    width = max(len(k) for k in raw)
+    total = 0.0
+    for key, value in raw.items():
+        if not math.isfinite(value) or value < 0:
+            raise ValueError(
+                f"distribution has a non-finite or negative value for {key!r}: {value}"
+            )
+        total += value
+    if total <= 0:
+        raise ValueError(f"distribution total mass must be positive, got {total}")
+
+    probs: Distribution = {}
+    for key, value in raw.items():
+        padded = key.zfill(width)
+        if padded in probs:
+            raise ValueError(
+                f"bitstrings collide after zero-padding to width {width}: {padded!r}"
+            )
+        probs[padded] = value / total
+    return probs, width
+
+
+def _repad(probs: Distribution, width: int) -> Distribution:
+    """Widen already-normalized probability keys to ``width`` (leading zeros)."""
+    if width == len(next(iter(probs))):
+        return probs
+    out: Distribution = {}
+    for key, value in probs.items():
+        padded = key.zfill(width)
+        if padded in out:
+            raise ValueError(
+                f"bitstrings collide after zero-padding to width {width}: {padded!r}"
+            )
+        out[padded] = value
+    return out
+
+
+def _bhattacharyya(p: Distribution, q: Distribution) -> float:
+    r"""Classical fidelity :math:`\left(\sum_i \sqrt{p_i q_i}\right)^2` of two
+    already-normalized, width-aligned distributions.
+
+    Clamped to ``1.0``: ordinary floating-point rounding in the sum/sqrt can
+    push identical distributions fractionally above the mathematical bound.
+    """
+    overlap = sum(math.sqrt(p.get(k, 0.0) * q.get(k, 0.0)) for k in p.keys() | q.keys())
+    return min(overlap**2, 1.0)
+
+
+def classical_fidelity(dist_a: DistributionLike, dist_b: DistributionLike) -> float:
+    r"""Classical (Bhattacharyya) fidelity between two distributions.
+
+    Defined as :math:`F(P, Q) = \left(\sum_i \sqrt{p_i q_i}\right)^2`, which
+    lies in ``[0, 1]``: 1 for identical distributions, 0 for distributions with
+    disjoint support. Inputs are zero-padded to a common bitstring width before
+    comparison.
+
+    Args:
+        dist_a: First distribution (ExecutionResult, counts, or probabilities).
+        dist_b: Second distribution (ExecutionResult, counts, or probabilities).
+
+    Returns:
+        Classical fidelity in ``[0, 1]``.
+    """
+    p, width_a = _to_probabilities(dist_a)
+    q, width_b = _to_probabilities(dist_b)
+    width = max(width_a, width_b)
+    return _bhattacharyya(_repad(p, width), _repad(q, width))
+
+
+def fidelity_with_uniform(
+    dist: DistributionLike,
+    num_states: int | None = None,
+) -> float:
+    """Classical fidelity of a distribution with the uniform distribution.
+
+    The uniform distribution is taken over ``num_states`` outcomes. When
+    ``num_states`` is not given it defaults to ``2 ** width``, inferred from the
+    bitstring width — the standard gate-based case. Pass an explicit
+    ``num_states`` for non-gate modalities (e.g. boson sampling, where the number
+    of valid samples is not a power of two).
+
+    Args:
+        dist: Distribution (ExecutionResult, counts, or probabilities).
+        num_states: Size of the uniform outcome space. Defaults to
+            ``2 ** width``.
+
+    Returns:
+        Classical fidelity with the uniform distribution, in ``[0, 1]``.
+
+    Raises:
+        ValueError: If ``num_states`` is smaller than the number of populated
+            outcomes (which would make the fidelity exceed 1).
+    """
+    probs, width = _to_probabilities(dist)
+    if num_states is None:
+        num_states = 2**width
+    if num_states < len(probs):
+        raise ValueError(
+            f"num_states ({num_states}) is smaller than the number of populated "
+            f"outcomes ({len(probs)}); the uniform baseline is ill-defined"
+        )
+    uniform_prob = 1 / num_states
+    overlap = sum(math.sqrt(prob * uniform_prob) for prob in probs.values())
+    return min(overlap**2, 1.0)
+
+
+def normalized_fidelity(
+    ideal: DistributionLike,
+    backend: DistributionLike,
+    num_states: int | None = None,
+) -> float:
+    r"""Normalized fidelity of Lubinski et al. (QED-C).
+
+    Rescales the classical fidelity between the ideal and backend distributions
+    so that a uniform (pure-noise) backend scores 0 and a perfect backend scores
+    1:
+
+    .. math::
+
+        F_\text{norm} = \max\!\left(0,
+            \frac{F_\text{backend} - F_\text{uniform}}{1 - F_\text{uniform}}\right)
+
+    where :math:`F_\text{backend}` is the classical fidelity between the ideal
+    and backend distributions and :math:`F_\text{uniform}` is the classical
+    fidelity of the ideal distribution with the uniform distribution.
+
+    Args:
+        ideal: Ideal/reference distribution, e.g. from a noiseless simulator
+            (ExecutionResult, counts, or probabilities).
+        backend: Distribution measured on the device under test. An empty
+            distribution (a backend that returned no shots) scores 0.
+        num_states: Size of the uniform outcome space used for the baseline.
+            Defaults to ``2 ** width`` inferred from the **ideal** distribution's
+            own bitstring width — not the backend's. The uniform-noise baseline
+            is a property of the reference circuit alone; it must not shift
+            because the backend happens to report keys at a different width
+            (e.g. an incidental ancilla/flag bit).
+
+    Returns:
+        Normalized fidelity in ``[0, 1]``.
+
+    Raises:
+        ValueError: If the ideal distribution is empty, if ``num_states`` is
+            smaller than the ideal's support, or if the ideal distribution is
+            maximally mixed (a degenerate reference with no signal above the
+            uniform baseline — distinct from a noisy backend, so it fails loudly
+            rather than returning a misleading 0). All three are checked before
+            `backend` is inspected at all, so an empty/zero-shot backend can
+            never mask an invalid `ideal`.
+    """
+    ideal_probs, ideal_width = _to_probabilities(ideal)
+
+    # The uniform-noise baseline and its validation depend only on `ideal` —
+    # compute and check them here, unconditionally, before `backend` is looked
+    # at. Delegating to fidelity_with_uniform (rather than reimplementing the
+    # formula) also keeps this the single source of truth for it.
+    uniform_fidelity = fidelity_with_uniform(ideal_probs, num_states)
+    denominator = 1 - uniform_fidelity
+    if denominator <= 0:
+        raise ValueError(
+            "ideal distribution is maximally mixed; normalized fidelity is "
+            "undefined (the reference carries no signal above the uniform "
+            "baseline). Check that `ideal` is a correct noiseless reference."
+        )
+
+    # A backend with zero total mass — no shots returned, or every corrected
+    # count rounded to zero — scores 0 rather than raising. Checked by total
+    # mass, not dict truthiness, so `{}` and an all-zero-count dict agree.
+    backend_raw = _extract(backend)
+    if sum(backend_raw.values()) == 0:
+        return 0.0
+
+    backend_probs, backend_width = _to_probabilities(backend_raw)
+    align_width = max(ideal_width, backend_width)
+    backend_fidelity = _bhattacharyya(
+        _repad(ideal_probs, align_width), _repad(backend_probs, align_width)
+    )
+
+    return max(0.0, (backend_fidelity - uniform_fidelity) / denominator)

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -1,0 +1,272 @@
+"""Tests for marqov.benchmarking.fidelity module."""
+
+import pytest
+
+from marqov.benchmarking.fidelity import (
+    classical_fidelity,
+    fidelity_with_uniform,
+    normalized_fidelity,
+)
+from marqov.executors.base import ExecutionResult
+
+
+def _result(counts: dict[str, int]) -> ExecutionResult:
+    """Build an ExecutionResult with the given counts."""
+    return ExecutionResult(
+        counts=counts,
+        backend="test",
+        execution_time_ms=0.0,
+        shots=sum(counts.values()),
+    )
+
+
+class TestClassicalFidelity:
+    """Tests for classical (Bhattacharyya) fidelity."""
+
+    def test_identical_distributions(self) -> None:
+        """Identical distributions have fidelity 1."""
+        dist = {"00": 0.5, "11": 0.5}
+        assert classical_fidelity(dist, dist) == pytest.approx(1.0)
+
+    def test_disjoint_support(self) -> None:
+        """Distributions with no shared outcomes have fidelity 0."""
+        assert classical_fidelity({"00": 1.0}, {"11": 1.0}) == pytest.approx(0.0)
+
+    def test_partial_overlap_known_value(self) -> None:
+        """Non-trivial value: F({00:.5,01:.5}, {00:1}) = (sqrt(.5))^2 = 0.5."""
+        assert classical_fidelity({"00": 0.5, "01": 0.5}, {"00": 1.0}) == pytest.approx(
+            0.5
+        )
+
+    def test_symmetric(self) -> None:
+        """Fidelity is symmetric in its arguments."""
+        a = {"00": 0.7, "01": 0.3}
+        b = {"00": 0.4, "01": 0.6}
+        assert classical_fidelity(a, b) == pytest.approx(classical_fidelity(b, a))
+
+    def test_accepts_raw_counts(self) -> None:
+        """Raw shot counts give the same result as normalized probabilities."""
+        counts = {"00": 300, "01": 100}  # -> {0.75, 0.25}
+        probs = {"00": 0.75, "01": 0.25}
+        assert classical_fidelity(counts, {"00": 1.0}) == pytest.approx(
+            classical_fidelity(probs, {"00": 1.0})
+        )
+
+    def test_accepts_execution_result(self) -> None:
+        """Accepts ExecutionResult directly, using its counts."""
+        ideal = _result({"00": 500, "11": 500})
+        measured = _result({"00": 480, "11": 470, "01": 30, "10": 20})
+        assert 0.0 < classical_fidelity(ideal, measured) < 1.0
+
+    def test_width_mismatch_is_aligned(self) -> None:
+        """Trimmed-width keys are zero-padded to align, not treated as disjoint."""
+        # "0" should pad to "00" and match the padded distribution.
+        assert classical_fidelity({"0": 1.0}, {"00": 1.0}) == pytest.approx(1.0)
+
+
+class TestFidelityWithUniform:
+    """Tests for fidelity_with_uniform."""
+
+    def test_peaked_two_qubit(self) -> None:
+        """A delta distribution over 4 states has uniform-fidelity 1/4."""
+        assert fidelity_with_uniform({"00": 1.0}) == pytest.approx(0.25)
+
+    def test_uniform_is_one(self) -> None:
+        """The uniform distribution has fidelity 1 with itself."""
+        dist = {"00": 0.25, "01": 0.25, "10": 0.25, "11": 0.25}
+        assert fidelity_with_uniform(dist) == pytest.approx(1.0)
+
+    def test_num_states_override(self) -> None:
+        """Explicit num_states overrides the 2**width default (e.g. boson sampling)."""
+        assert fidelity_with_uniform({"20": 1.0}, num_states=3) == pytest.approx(1 / 3)
+
+    def test_infers_width(self) -> None:
+        """Default outcome space is 2**(bitstring width)."""
+        assert fidelity_with_uniform({"000": 1.0}) == pytest.approx(1 / 8)
+
+    def test_num_states_below_support_raises(self) -> None:
+        """num_states smaller than the populated support is rejected."""
+        dist = {"00": 0.5, "01": 0.5}
+        with pytest.raises(ValueError, match="smaller than the number"):
+            fidelity_with_uniform(dist, num_states=1)
+
+
+class TestNormalizedFidelity:
+    """Tests for the Lubinski/QED-C normalized fidelity."""
+
+    def test_perfect_backend(self) -> None:
+        """Backend matching the ideal distribution scores 1."""
+        ideal = {"00": 0.5, "11": 0.5}
+        assert normalized_fidelity(ideal, ideal) == pytest.approx(1.0)
+
+    def test_uniform_backend_scores_zero(self) -> None:
+        """A pure-noise (uniform) backend scores 0, not the raw fidelity."""
+        ideal = {"00": 1.0}
+        uniform = {"00": 0.25, "01": 0.25, "10": 0.25, "11": 0.25}
+        assert normalized_fidelity(ideal, uniform) == pytest.approx(0.0)
+
+    def test_worse_than_uniform_clamps_to_zero(self) -> None:
+        """Backend anti-correlated with the ideal clamps to 0 (never negative)."""
+        ideal = {"00": 1.0}
+        backend = {"11": 1.0}
+        assert normalized_fidelity(ideal, backend) == 0.0
+
+    def test_between_zero_and_one(self) -> None:
+        """A partially-degraded backend lands strictly between 0 and 1."""
+        ideal = {"00": 1.0}
+        backend = {"00": 0.7, "01": 0.1, "10": 0.1, "11": 0.1}
+        assert 0.0 < normalized_fidelity(ideal, backend) < 1.0
+
+    def test_accepts_execution_results(self) -> None:
+        """Works directly on the ExecutionResult objects executors return."""
+        ideal = _result({"00": 512, "11": 512})
+        backend = _result({"00": 480, "11": 470, "01": 40, "10": 34})
+        assert 0.0 < normalized_fidelity(ideal, backend) <= 1.0
+
+    def test_trimmed_backend_keys_still_score_high(self) -> None:
+        """Regression: a correct backend with leading-zeros trimmed must NOT
+        be flagged as broken (was the headline review bug)."""
+        ideal = _result({"00": 500, "11": 500})
+        # Same distribution but the "00" key arrived trimmed to "0".
+        trimmed = {"0": 500, "11": 500}
+        assert normalized_fidelity(ideal, trimmed) == pytest.approx(1.0)
+
+    def test_zero_shot_backend_scores_zero(self) -> None:
+        """A backend that returned no shots scores 0, it does not crash."""
+        ideal = _result({"00": 500, "11": 500})
+        empty = _result({})  # ExecutionResult with no counts
+        assert normalized_fidelity(ideal, empty) == 0.0
+
+    def test_empty_ideal_raises(self) -> None:
+        """An empty reference is a caller error, not a zero score."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            normalized_fidelity({}, {"00": 1.0})
+
+    def test_maximally_mixed_ideal_raises(self) -> None:
+        """A degenerate (uniform) reference fails loudly rather than returning 0."""
+        ideal = {"00": 0.25, "01": 0.25, "10": 0.25, "11": 0.25}
+        backend = {"00": 0.5, "11": 0.5}
+        with pytest.raises(ValueError, match="maximally mixed"):
+            normalized_fidelity(ideal, backend)
+
+    def test_num_states_below_support_raises(self) -> None:
+        """num_states below the ideal's support is rejected, not silently zeroed."""
+        ideal = {"00": 0.5, "11": 0.5}
+        backend = {"00": 0.5, "11": 0.5}
+        with pytest.raises(ValueError, match="smaller than the number of populated"):
+            normalized_fidelity(ideal, backend, num_states=1)
+
+    def test_maximally_mixed_ideal_raises_even_with_empty_backend(self) -> None:
+        """Regression: an invalid `ideal` must raise regardless of whether
+        `backend` happens to be empty -- the empty-backend shortcut must not
+        bypass ideal-side validation."""
+        ideal = {"00": 0.25, "01": 0.25, "10": 0.25, "11": 0.25}  # maximally mixed
+        with pytest.raises(ValueError, match="maximally mixed"):
+            normalized_fidelity(ideal, {})
+
+    def test_num_states_below_support_raises_even_with_empty_backend(self) -> None:
+        """Same regression as above, for the num_states-vs-support check."""
+        ideal = {"00": 0.5, "11": 0.5}
+        with pytest.raises(ValueError, match="smaller than the number of populated"):
+            normalized_fidelity(ideal, {}, num_states=1)
+
+    def test_num_states_baseline_independent_of_backend_width(self) -> None:
+        """Regression: the uniform-noise baseline depends only on `ideal`'s own
+        width, not on an incidental extra bit the backend happens to report
+        (e.g. an ancilla) -- the same relative signal must score the same
+        either way."""
+        ideal = {"00": 0.5, "11": 0.5}
+        backend_2bit = {"00": 0.45, "01": 0.05, "10": 0.05, "11": 0.45}
+        # Same relative signal, reported with an extra leading always-0 bit.
+        backend_3bit = {"000": 0.45, "001": 0.05, "010": 0.05, "011": 0.45}
+        assert normalized_fidelity(ideal, backend_2bit) == pytest.approx(
+            normalized_fidelity(ideal, backend_3bit)
+        )
+
+    def test_all_zero_backend_scores_zero_like_empty(self) -> None:
+        """Regression: a nonempty backend dict whose counts are all zero (e.g.
+        every SPAM-corrected bin rounded to 0) scores 0 like a truly empty
+        backend, rather than crashing on 'total mass must be positive'."""
+        ideal = {"00": 0.5, "11": 0.5}
+        assert normalized_fidelity(ideal, {"00": 0, "11": 0}) == 0.0
+
+    def test_generator_backend_not_spuriously_empty(self) -> None:
+        """Regression: a single-use iterable `backend` (e.g. a generator of
+        (key, value) pairs) must not be drained by a redundant double
+        extraction and then misread as empty."""
+        ideal = {"00": 0.5, "11": 0.5}
+        backend_gen = iter({"00": 0.5, "11": 0.5}.items())
+        assert normalized_fidelity(ideal, backend_gen) == pytest.approx(1.0)
+
+    def test_matches_reference_formula(self) -> None:
+        """Result equals the explicit (F_b - F_u)/(1 - F_u) computation."""
+        ideal = {"00": 0.5, "11": 0.5}
+        backend = {"00": 0.45, "11": 0.4, "01": 0.1, "10": 0.05}
+        f_backend = classical_fidelity(ideal, backend)
+        f_uniform = fidelity_with_uniform(ideal)
+        expected = max((f_backend - f_uniform) / (1 - f_uniform), 0.0)
+        assert normalized_fidelity(ideal, backend) == pytest.approx(expected)
+
+
+class TestValidation:
+    """Input validation."""
+
+    def test_empty_distribution_raises(self) -> None:
+        """An empty distribution is rejected."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            classical_fidelity({}, {"0": 1.0})
+
+    def test_zero_mass_raises(self) -> None:
+        """A distribution with no positive mass is rejected."""
+        with pytest.raises(ValueError, match="positive"):
+            fidelity_with_uniform({"0": 0.0, "1": 0.0})
+
+    def test_negative_value_raises(self) -> None:
+        """A negative count/probability is rejected before it reaches sqrt."""
+        with pytest.raises(ValueError, match="negative"):
+            classical_fidelity({"0": 2.0, "1": -1.0}, {"0": 1.0})
+
+    def test_padding_collision_raises(self) -> None:
+        """Keys that collide after zero-padding are a real ambiguity -> error."""
+        with pytest.raises(ValueError, match="collide"):
+            fidelity_with_uniform({"1": 0.5, "01": 0.5})
+
+    def test_nan_value_raises(self) -> None:
+        """A NaN count/probability is rejected. NaN comparisons are always
+        False in Python, so a plain `< 0` check alone would silently let it
+        through and propagate to a NaN final result."""
+        with pytest.raises(ValueError, match="non-finite"):
+            classical_fidelity({"0": float("nan"), "1": 0.5}, {"0": 1.0})
+
+    def test_infinite_value_raises(self) -> None:
+        """An infinite count/probability is rejected. It would otherwise
+        divide out to inf/inf = NaN downstream."""
+        with pytest.raises(ValueError, match="non-finite"):
+            classical_fidelity({"0": float("inf"), "1": 0.5}, {"0": 1.0})
+
+    def test_invalid_type_raises_value_error_not_type_error(self) -> None:
+        """An unsupported distribution type raises the documented ValueError,
+        not a bare TypeError -- e.g. a caller forwarding None as a 'no data
+        yet' sentinel gets a catchable, informative error."""
+        with pytest.raises(ValueError, match="expected an ExecutionResult"):
+            classical_fidelity(None, {"0": 1.0})
+
+    def test_int_keyed_distribution_raises(self) -> None:
+        """Integer-keyed distributions (a real pattern for statevector-index
+        -based executors) raise a clear ValueError instead of crashing on
+        `len()` of an int before any documented validation runs."""
+        with pytest.raises(ValueError, match="must be bitstrings"):
+            classical_fidelity({0: 512, 3: 488}, {0: 1.0})
+
+    def test_classical_fidelity_does_not_exceed_one(self) -> None:
+        """Regression: identical distributions must not exceed the documented
+        [0, 1] range due to ordinary floating-point rounding in sqrt/sum.
+        This exact distribution (found by search, not adversarially crafted)
+        overshoots to 1.0000000000000004 without the clamp."""
+        dist = {
+            "00000": 0.21894291090539744,
+            "00001": 0.16969750829963992,
+            "00010": 0.3976074585155386,
+            "00011": 0.2137521222794242,
+        }
+        assert classical_fidelity(dist, dist) <= 1.0


### PR DESCRIPTION
## What

Adds application-level distribution-fidelity metrics to `marqov/benchmarking/`, alongside the existing SPAM tooling:

- **`normalized_fidelity`** — Lubinski et al. / QED-C metric: `max(0, (F_backend − F_uniform) / (1 − F_uniform))`. Normalizes out the trivial uniform-noise baseline so a pure-noise device scores 0, a perfect device scores 1.
- **`classical_fidelity`** — Bhattacharyya fidelity between two distributions.
- **`fidelity_with_uniform`** — baseline helper.

Where SPAM measures per-qubit *readout* error, this measures how faithfully a whole application's output distribution survives on real hardware.

```python
from marqov.benchmarking import normalized_fidelity

ideal    = simulator.run(circuit, shots=4096)
measured = device.run(circuit, shots=4096)
score    = normalized_fidelity(ideal, measured)   # 1.0 perfect … 0.0 noise
```

## Why

First deliverable of the Open QBench harvest (see marqov-platform#1270 and `marqov-research/research/OPEN_QBENCH_REVIEW.md`). Ported from Open QBench (Apache-2.0), attributed in the module.

## Review hardening

This went through a high-effort code review before merge. Changes made in response:

- Accepts **`ExecutionResult`** directly (reuses executor output), not just bare dicts.
- **Bitstring width alignment** — zero-pads trimmed keys to a common width, so a correct backend is no longer scored ~0 on a leading-zero mismatch (this was the headline bug; the original tests missed it by only using matched-width inputs).
- **`num_states`** derived from the padded width and guarded against being smaller than the support (previously a silent zero); relevant to the non-power-of-two boson-sampling case.
- **Zero-shot backend** scores 0 instead of crashing (matches `ExecutionResult.probabilities` semantics).
- Negative values and post-padding key **collisions** rejected with clear errors.
- **Maximally-mixed reference** raises rather than returning a misleading 0 (distinguishes a broken reference from a noisy backend).

## Testing

- `tests/test_fidelity.py` — 27 tests, incl. a regression test for the width-mismatch bug, `ExecutionResult` inputs, zero-shot, and known partial-overlap values.
- `ruff` clean, `mypy` clean on the new module.
- Full suite: 379 passed / 16 skipped / 13 xpassed excluding the pre-existing `test_decorators.py` segfault (marqov-platform#1259, unrelated).

## Caveat

Bit *ordering* (endianness) cannot be inferred from counts and remains the caller's responsibility — documented in the module, with a pointer to `test_azure_bitorder.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New benchmarking library code with no auth or persistence; behavior is covered by extensive unit tests and limited to scoring distributions.
> 
> **Overview**
> Adds **application-level distribution fidelity** to `marqov.benchmarking` (ported from Open QBench), alongside existing SPAM tooling. New public APIs: `classical_fidelity`, `fidelity_with_uniform`, and **`normalized_fidelity`** (QED-C score where uniform noise → 0 and a perfect match → 1).
> 
> Inputs may be raw count/probability dicts or **`ExecutionResult`** from executors. Distributions are validated, normalized, and **zero-padded** to a common bitstring width so trimmed keys (e.g. `"0"` vs `"00"`) align; padding collisions and invalid `num_states` raise **`ValueError`**. Empty backend outcomes score **0**; a maximally mixed ideal reference raises instead of returning a misleading zero. Bit **endianness** remains the caller’s responsibility (documented).
> 
> **`tests/test_fidelity.py`** covers the metrics, width-mismatch regression, `ExecutionResult` paths, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253b383bbfc2d006be4290c5cb554669d1769726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->