### PR TITLE
workflows: isolate @task execution in a per-job subprocess; defer serialization to dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to the `marqov` SDK are documented here. This project follow
 still change between minor versions; `1.0.0` is reserved for the first API-stable
 release.
 
+## [Unreleased]
+
+### Changed
+- **`@task` bodies now execute in an isolated subprocess** with a deny-by-default,
+  scrubbed environment — the task process inherits only an explicit allowlist of
+  environment variables plus any credentials a host passes for that job, never the
+  ambient process environment. Task results are forwarded without being
+  deserialized in the parent worker process.
+- **Serialization is deferred from decoration to dispatch.** `@task` no longer
+  `cloudpickle`-serializes the decorated function when the decorator runs; it does
+  so lazily at graph build. This resolves the `RecursionError` that could occur
+  when decorating a local/closure task with a large set of heavy backends imported
+  (see 0.2.0 *Known limitations*), and avoids serializing tasks that are never
+  dispatched.
+
+### Behavioral change
+- **Closure-at-dispatch:** because a task is now serialized at dispatch rather than
+  at decoration, its closure captures referenced variables **as of dispatch**, not
+  as of import/decoration time. This is identical for deterministic code; a task
+  that closes over a value mutated between decoration and dispatch will now observe
+  the dispatch-time value.
+
+### Added
+- **`MARQOV_SCRUB_ALLOWLIST` environment variable (host↔SDK interface):** a host
+  runner may set this (comma-separated variable names) in the worker process to
+  define the allowlist the SDK uses when building a task's subprocess environment.
+  When unset, the SDK falls back to a minimal, secret-free default and logs a
+  warning.
+
 ## [0.2.0] — 2026-06-29
 
 First public release on PyPI.

--- a/marqov/benchmarking/__init__.py
+++ b/marqov/benchmarking/__init__.py
@@ -1,9 +1,16 @@
 """Quantum benchmarking tools.
 
-Currently provides SPAM (State Preparation And Measurement) benchmarking.
+Provides SPAM (State Preparation And Measurement) benchmarking and
+application-level distribution-fidelity metrics (Lubinski/QED-C normalized
+fidelity).
 Future: refactor into BenchmarkSuite with .spam(), .qst(), .qpt(), .fidelity().
 """
 
+from marqov.benchmarking.fidelity import (
+    classical_fidelity,
+    fidelity_with_uniform,
+    normalized_fidelity,
+)
 from marqov.benchmarking.spam import (
     ConfusionMatrix,
     SPAMResult,
@@ -17,5 +24,8 @@ __all__ = [
     "SPAMResult",
     "apply_spam_correction",
     "build_correction_matrix",
+    "classical_fidelity",
+    "fidelity_with_uniform",
+    "normalized_fidelity",
     "spam_benchmark",
 ]

--- a/marqov/benchmarking/fidelity.py
+++ b/marqov/benchmarking/fidelity.py
@@ -1,0 +1,239 @@
+"""Distribution-fidelity metrics for application-level benchmarking.
+
+Implements the *normalized fidelity* of Lubinski et al. ("Application-Oriented
+Performance Benchmarks for Quantum Computing", the QED-C suite): an
+application-level quality score that compares a backend's output distribution
+against an ideal reference distribution and normalizes out the trivial
+uniform-noise baseline. Unlike raw classical fidelity, a device that returns
+pure noise scores 0 rather than a misleadingly non-zero value.
+
+This complements the SPAM/readout characterization in
+:mod:`marqov.benchmarking.spam`: SPAM measures per-qubit measurement error,
+whereas normalized fidelity measures how faithfully a full application's output
+distribution survives execution on real hardware.
+
+All functions accept either an :class:`~marqov.executors.base.ExecutionResult`
+(the object returned by every executor) or a bare ``{bitstring: count}`` /
+``{bitstring: probability}`` dict.
+
+Bit-order caveat: these metrics compare bitstrings as keys. They tolerate
+differing *widths* (a distribution whose keys have had leading zeros trimmed is
+zero-padded to a common width before comparison), but they cannot detect a
+differing qubit *ordering* (endianness). The caller is responsible for ensuring
+the ideal and backend distributions share the same qubit-order convention — see
+``tests/test_azure_bitorder.py`` for why this matters across backends.
+
+Ported from Open QBench (PCSS-Quantum/open-qbench, Apache-2.0).
+"""
+
+from __future__ import annotations
+
+import math
+
+from marqov.executors.base import ExecutionResult
+
+# A distribution keyed by bitstring. Values may be raw shot counts or
+# probabilities; both are accepted and normalized internally. Callers may also
+# pass an ExecutionResult directly.
+Distribution = dict[str, float]
+DistributionLike = ExecutionResult | Distribution
+
+
+def _extract(dist: DistributionLike) -> Distribution:
+    """Pull a plain ``{bitstring: value}`` dict out of the accepted input types."""
+    if isinstance(dist, ExecutionResult):
+        return dict(dist.counts)
+    return dict(dist)
+
+
+def _to_probabilities(dist: DistributionLike) -> tuple[Distribution, int]:
+    """Validate and normalize a distribution to probabilities.
+
+    Zero-pads bitstrings to the distribution's maximum key width so that keys
+    that have had leading zeros trimmed still align.
+
+    Returns:
+        A ``(probabilities, width)`` tuple where ``width`` is the (padded)
+        bitstring length.
+
+    Raises:
+        ValueError: If the distribution is empty, contains a negative value, has
+            non-positive total mass, or has keys that collide after zero-padding.
+    """
+    raw = _extract(dist)
+    if not raw:
+        raise ValueError("distribution must not be empty")
+
+    width = max(len(k) for k in raw)
+    total = 0.0
+    for key, value in raw.items():
+        if value < 0:
+            raise ValueError(f"distribution has a negative value for {key!r}: {value}")
+        total += value
+    if total <= 0:
+        raise ValueError(f"distribution total mass must be positive, got {total}")
+
+    probs: Distribution = {}
+    for key, value in raw.items():
+        padded = key.zfill(width)
+        if padded in probs:
+            raise ValueError(
+                f"bitstrings collide after zero-padding to width {width}: {padded!r}"
+            )
+        probs[padded] = value / total
+    return probs, width
+
+
+def _repad(probs: Distribution, width: int) -> Distribution:
+    """Widen already-normalized probability keys to ``width`` (leading zeros)."""
+    if width == len(next(iter(probs))):
+        return probs
+    out: Distribution = {}
+    for key, value in probs.items():
+        padded = key.zfill(width)
+        if padded in out:
+            raise ValueError(
+                f"bitstrings collide after zero-padding to width {width}: {padded!r}"
+            )
+        out[padded] = value
+    return out
+
+
+def _bhattacharyya(p: Distribution, q: Distribution) -> float:
+    r"""Classical fidelity :math:`\left(\sum_i \sqrt{p_i q_i}\right)^2` of two
+    already-normalized, width-aligned distributions."""
+    overlap = sum(math.sqrt(p.get(k, 0.0) * q.get(k, 0.0)) for k in p.keys() | q.keys())
+    return overlap**2
+
+
+def classical_fidelity(dist_a: DistributionLike, dist_b: DistributionLike) -> float:
+    r"""Classical (Bhattacharyya) fidelity between two distributions.
+
+    Defined as :math:`F(P, Q) = \left(\sum_i \sqrt{p_i q_i}\right)^2`, which
+    lies in ``[0, 1]``: 1 for identical distributions, 0 for distributions with
+    disjoint support. Inputs are zero-padded to a common bitstring width before
+    comparison.
+
+    Args:
+        dist_a: First distribution (ExecutionResult, counts, or probabilities).
+        dist_b: Second distribution (ExecutionResult, counts, or probabilities).
+
+    Returns:
+        Classical fidelity in ``[0, 1]``.
+    """
+    p, width_a = _to_probabilities(dist_a)
+    q, width_b = _to_probabilities(dist_b)
+    width = max(width_a, width_b)
+    return _bhattacharyya(_repad(p, width), _repad(q, width))
+
+
+def fidelity_with_uniform(
+    dist: DistributionLike,
+    num_states: int | None = None,
+) -> float:
+    """Classical fidelity of a distribution with the uniform distribution.
+
+    The uniform distribution is taken over ``num_states`` outcomes. When
+    ``num_states`` is not given it defaults to ``2 ** width``, inferred from the
+    bitstring width — the standard gate-based case. Pass an explicit
+    ``num_states`` for non-gate modalities (e.g. boson sampling, where the number
+    of valid samples is not a power of two).
+
+    Args:
+        dist: Distribution (ExecutionResult, counts, or probabilities).
+        num_states: Size of the uniform outcome space. Defaults to
+            ``2 ** width``.
+
+    Returns:
+        Classical fidelity with the uniform distribution, in ``[0, 1]``.
+
+    Raises:
+        ValueError: If ``num_states`` is smaller than the number of populated
+            outcomes (which would make the fidelity exceed 1).
+    """
+    probs, width = _to_probabilities(dist)
+    if num_states is None:
+        num_states = 2**width
+    if num_states < len(probs):
+        raise ValueError(
+            f"num_states ({num_states}) is smaller than the number of populated "
+            f"outcomes ({len(probs)}); the uniform baseline is ill-defined"
+        )
+    uniform_prob = 1 / num_states
+    overlap = sum(math.sqrt(prob * uniform_prob) for prob in probs.values())
+    return overlap**2
+
+
+def normalized_fidelity(
+    ideal: DistributionLike,
+    backend: DistributionLike,
+    num_states: int | None = None,
+) -> float:
+    r"""Normalized fidelity of Lubinski et al. (QED-C).
+
+    Rescales the classical fidelity between the ideal and backend distributions
+    so that a uniform (pure-noise) backend scores 0 and a perfect backend scores
+    1:
+
+    .. math::
+
+        F_\text{norm} = \max\!\left(0,
+            \frac{F_\text{backend} - F_\text{uniform}}{1 - F_\text{uniform}}\right)
+
+    where :math:`F_\text{backend}` is the classical fidelity between the ideal
+    and backend distributions and :math:`F_\text{uniform}` is the classical
+    fidelity of the ideal distribution with the uniform distribution.
+
+    Args:
+        ideal: Ideal/reference distribution, e.g. from a noiseless simulator
+            (ExecutionResult, counts, or probabilities).
+        backend: Distribution measured on the device under test. An empty
+            distribution (a backend that returned no shots) scores 0.
+        num_states: Size of the uniform outcome space used for the baseline.
+            Defaults to ``2 ** width`` inferred from the (padded) distributions.
+
+    Returns:
+        Normalized fidelity in ``[0, 1]``.
+
+    Raises:
+        ValueError: If the ideal distribution is empty, if ``num_states`` is
+            smaller than the ideal's support, or if the ideal distribution is
+            maximally mixed (a degenerate reference with no signal above the
+            uniform baseline — distinct from a noisy backend, so it fails loudly
+            rather than returning a misleading 0).
+    """
+    ideal_probs, ideal_width = _to_probabilities(ideal)
+
+    if not _extract(backend):
+        # Backend returned no outcomes (e.g. zero shots) — zero fidelity, not an
+        # error. `ideal` was already validated above.
+        return 0.0
+
+    backend_probs, backend_width = _to_probabilities(backend)
+    width = max(ideal_width, backend_width)
+    ideal_probs = _repad(ideal_probs, width)
+    backend_probs = _repad(backend_probs, width)
+
+    if num_states is None:
+        num_states = 2**width
+    if num_states < len(ideal_probs):
+        raise ValueError(
+            f"num_states ({num_states}) is smaller than the ideal distribution's "
+            f"support ({len(ideal_probs)}); the uniform baseline is ill-defined"
+        )
+
+    backend_fidelity = _bhattacharyya(ideal_probs, backend_probs)
+    uniform_prob = 1 / num_states
+    uniform_fidelity = (
+        sum(math.sqrt(prob * uniform_prob) for prob in ideal_probs.values()) ** 2
+    )
+
+    denominator = 1 - uniform_fidelity
+    if denominator <= 0:
+        raise ValueError(
+            "ideal distribution is maximally mixed; normalized fidelity is "
+            "undefined (the reference carries no signal above the uniform "
+            "baseline). Check that `ideal` is a correct noiseless reference."
+        )
+
+    return max((backend_fidelity - uniform_fidelity) / denominator, 0.0)

--- a/marqov/workflows/_child_env.py
+++ b/marqov/workflows/_child_env.py
@@ -1,0 +1,106 @@
+"""Child-process environment builder for isolated task execution.
+
+A host runner owns the allowlist — it provides ``MARQOV_SCRUB_ALLOWLIST``
+(comma-separated) in the worker process, and this helper reads it at call
+time.  If unset (SDK used standalone, tests), a documented minimal-safe
+fallback is used — a small, secret-free set of variables only.
+
+The only way a credential enters the child env is through ``provider_env``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+_log = logging.getLogger("marqov.workflows")
+
+# Minimal-safe default — a small, secret-free set of environment variables.
+# Documented here as the single canonical SDK-standalone fallback.
+# A host runner should set MARQOV_SCRUB_ALLOWLIST at worker boot so the extra
+# vars its runtime images need (e.g. TLS/region settings) are also passed through.
+_MINIMAL_SAFE_DEFAULT: tuple[str, ...] = (
+    "PATH",
+    "LANG",
+    "LC_ALL",
+    "VIRTUAL_ENV",
+    "PYTHONPATH",
+    "HOME",
+    "TMPDIR",
+)
+
+_ALLOWLIST_ENV_VAR = "MARQOV_SCRUB_ALLOWLIST"
+
+_TMP_ROOT = Path(tempfile.gettempdir())
+
+
+def _read_allowlist() -> tuple[str, ...]:
+    """Read the scrub allowlist from the env var set by the host at boot.
+
+    Returns the minimal-safe default when the var is unset.
+    """
+    raw = os.environ.get(_ALLOWLIST_ENV_VAR)
+    if not raw:
+        # Loud on purpose: UNDER A HOST RUNNER an unset var signals a version skew
+        # (the host must set it at worker boot). The child env then differs from
+        # the host-tested one and a task may hit a native ImportError — a silent
+        # operational fail-open. Standalone SDK use can ignore this.
+        _log.warning(
+            "%s is not set — falling back to the minimal-safe env allowlist. "
+            "Under a host runner this indicates SDK/host version skew.",
+            _ALLOWLIST_ENV_VAR,
+        )
+        return _MINIMAL_SAFE_DEFAULT
+    return tuple(k.strip() for k in raw.split(",") if k.strip())
+
+
+def build_child_env(
+    workdir: Path,
+    provider_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build a scrubbed environment for a task-body child process.
+
+    Args:
+        workdir: Per-job working directory (must already exist). HOME and
+            TMPDIR are set to subdirs of this directory so the child never
+            writes to the real user HOME or system /tmp.
+        provider_env: Explicit provider credentials that the task body needs
+            (e.g. AWS keys for a Braket job). The ONLY way a credential enters
+            the child env. Pass ``None`` (default) for pure-compute tasks.
+
+    Returns:
+        A dict suitable for ``env=`` in ``asyncio.create_subprocess_exec``.
+    """
+    allowlist = _read_allowlist()
+    env: dict[str, str] = {k: os.environ[k] for k in allowlist if k in os.environ}
+
+    # Per-job isolated dirs — child writes here, never to real HOME/TMPDIR.
+    home = workdir / "home"
+    tmp = workdir / "tmp"
+    for d in (home, tmp):
+        d.mkdir(parents=True, exist_ok=True)
+
+    # Override HOME/TMPDIR even if they were in the allowlist — the per-job
+    # values MUST take precedence to prevent cross-job contamination.
+    env["HOME"] = str(home)
+    env["TMPDIR"] = str(tmp)
+
+    # Provider creds are injected LAST so nothing in the allowlist can shadow them.
+    if provider_env:
+        env.update(provider_env)
+
+    return env
+
+
+def new_task_workdir(node_id: str) -> Path:
+    """Create an isolated per-task scratch directory.
+
+    The directory name is prefixed ``marqov_task_`` so a host runner's
+    stale-scratch sweep can clean it up.
+    """
+    # Sanitise node_id for use in a path prefix (keep alphanumeric + dash).
+    safe = "".join(c if c.isalnum() or c == "-" else "_" for c in node_id)[:32]
+    wd = Path(tempfile.mkdtemp(prefix=f"marqov_task_{safe}_", dir=_TMP_ROOT))
+    return wd

--- a/marqov/workflows/_task_child.py
+++ b/marqov/workflows/_task_child.py
@@ -1,0 +1,117 @@
+"""Child-process entry point for scrubbed task execution.
+
+This script is invoked by ``execute_task`` as a subprocess.  It runs inside
+a minimal, allowlisted environment (no host-provided secrets) and is the
+ONLY place ``cloudpickle.loads`` is called on user-supplied bytes.
+
+Protocol (file-based, never stdout):
+- Reads:  ``$WORKDIR/func_ref``   — raw bytes, base64-decoded cloudpickle of the fn
+          ``$WORKDIR/args.json``  — JSON list of args (may contain __cloudpickle__ blobs)
+          ``$WORKDIR/kwargs.json`` — JSON dict of kwargs
+- Writes: ``$WORKDIR/result.json`` — JSON: {"node_id": ..., "result": <serialized>}
+                                     or  {"node_id": ..., "error": <str>}
+
+Exit codes: 0 = success, 1 = error (error written to result.json).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _deserialize_value(value: Any) -> Any:
+    """Deserialize a value from JSON transport (mirrors activity._deserialize_value)."""
+    import cloudpickle
+
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    elif isinstance(value, list):
+        return [_deserialize_value(item) for item in value]
+    elif isinstance(value, dict):
+        if value.get("__cloudpickle__"):
+            return cloudpickle.loads(base64.b64decode(value["data"]))
+        return {k: _deserialize_value(v) for k, v in value.items()}
+    else:
+        return value
+
+
+def _serialize_value(value: Any) -> Any:
+    """Serialize a value for JSON transport (mirrors activity._serialize_value)."""
+    import cloudpickle
+
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    elif isinstance(value, (list, tuple)):
+        return [_serialize_value(item) for item in value]
+    elif isinstance(value, dict):
+        if value.get("__cloudpickle__"):
+            return value
+        return {k: _serialize_value(v) for k, v in value.items()}
+    else:
+        return {
+            "__cloudpickle__": True,
+            "data": base64.b64encode(cloudpickle.dumps(value)).decode("utf-8"),
+        }
+
+
+def main() -> int:
+    workdir = Path(os.environ.get("MARQOV_TASK_WORKDIR", ""))
+    if not workdir or not workdir.is_dir():
+        sys.stderr.write("MARQOV_TASK_WORKDIR not set or not a directory\n")
+        return 1
+
+    node_id = (workdir / "node_id").read_text().strip()
+    result_path = workdir / "result.json"
+    error_path = workdir / "error.json"
+
+    def _write_error(msg: str) -> int:
+        # Errors go to error.json (separate channel); result.json is never
+        # written on failure so the activity can treat result.json as "success only".
+        error_path.write_text(json.dumps({"node_id": node_id, "error": msg}))
+        return 1
+
+    try:
+        import cloudpickle
+
+        func_bytes = base64.b64decode((workdir / "func_ref").read_text().strip())
+        func = cloudpickle.loads(func_bytes)
+
+        args_raw: list[Any] = json.loads((workdir / "args.json").read_text())
+        kwargs_raw: dict[str, Any] = json.loads((workdir / "kwargs.json").read_text())
+
+        args = [_deserialize_value(a) for a in args_raw]
+        kwargs = {k: _deserialize_value(v) for k, v in kwargs_raw.items()}
+
+    except Exception as e:
+        return _write_error(f"Deserialization error: {type(e).__name__}: {e}")
+
+    try:
+        if asyncio.iscoroutinefunction(func):
+            result = asyncio.run(func(*args, **kwargs))
+        else:
+            result = func(*args, **kwargs)
+    except Exception as e:
+        import traceback
+        tb = traceback.format_exc()
+        return _write_error(f"Task error: {type(e).__name__}: {e}\n{tb}")
+
+    try:
+        serialized = _serialize_value(result)
+        # Atomic write: temp + rename so the parent never reads a partial file.
+        tmp_path = result_path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps({"node_id": node_id, "result": serialized}))
+        tmp_path.rename(result_path)
+    except Exception as e:
+        return _write_error(f"Serialization error: {type(e).__name__}: {e}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/marqov/workflows/activity.py
+++ b/marqov/workflows/activity.py
@@ -7,6 +7,12 @@ libraries (quantumflow, sympy, etc.).
 The key architectural principle:
 - Workflows = pure coordination (no marqov imports)
 - Activities = all computation (imports anything)
+
+The task body (cloudpickle.loads + run) executes in an isolated,
+**scrubbed subprocess** — the activity process itself never calls
+cloudpickle.loads on func_ref or the result.  The result is forwarded
+opaquely (as a JSON blob) so Temporal carries the bytes without this
+process deserialising them.
 """
 
 from __future__ import annotations
@@ -14,22 +20,45 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import os
+import signal
+import sys
+from pathlib import Path
 from typing import Any
 
-import cloudpickle
 from temporalio import activity
+
+from marqov.workflows._child_env import build_child_env, new_task_workdir
 
 # Heartbeat interval for execute_task. Temporal throttles forwarding to 80%
 # of heartbeat_timeout (48s for 60s timeout), so the send interval just needs
 # to be well under 48s. 10s gives ~4 heartbeats per forward window.
 _HEARTBEAT_INTERVAL_S = 10
 
+# Path to the child entry-point (same package, found via __file__).
+_CHILD_SCRIPT = str(Path(__file__).parent / "_task_child.py")
+
+# Size caps for child output files.  A child must never return so much data
+# that reading it exhausts the worker process.
+# error.json is small and structured (our code); 64 KiB is generous.
+# result.json cap is aligned with Temporal's default gRPC payload limit (~4 MiB):
+# a larger result would pass this cap but then be rejected by Temporal itself — a
+# confusing failure at demo scale. Kept UNDER 4 MiB for envelope/protocol headroom.
+# Results larger than this need spill-to-S3 + a reference (follow-up, not this build).
+MAX_ERROR_BYTES: int = 64 * 1024         # 64 KiB
+MAX_RESULT_BYTES: int = 3 * 1024 * 1024  # 3 MiB — under Temporal's ~4 MiB gRPC limit
+
 
 def _deserialize_value(value: Any) -> Any:
     """Deserialize a value from JSON transport.
 
     Handles cloudpickle-encoded complex objects.
+
+    NOTE: This function is used only by prepare_node_inputs (proxy resolution)
+    and by tests.  execute_task MUST NOT call it — results are forwarded opaquely.
     """
+    import cloudpickle
+
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
     elif isinstance(value, list):
@@ -47,6 +76,8 @@ def _serialize_value(value: Any) -> Any:
 
     Uses cloudpickle for complex objects, JSON-compatible types pass through.
     """
+    import cloudpickle
+
     if value is None or isinstance(value, (bool, int, float, str)):
         return value
     elif isinstance(value, (list, tuple)):
@@ -64,50 +95,71 @@ def _serialize_value(value: Any) -> Any:
         }
 
 
+def _kill_process_group(proc: asyncio.subprocess.Process) -> None:
+    """SIGKILL the child's whole process group.
+
+    ``start_new_session=True`` makes pgid == pid, so grandchildren die with it
+    instead of lingering (mirrors dwave_executor._kill_process_group).
+    """
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+
+
 @activity.defn
 async def execute_task(
     node_id: str,
     func_ref: str,
     args_json: str,
     kwargs_json: str,
+    provider_env: dict[str, str] | None = None,
 ) -> str:
-    """Execute a single task node.
+    """Execute a single task node in a scrubbed subprocess.
 
-    This activity receives serialized function and arguments,
-    executes the function, and returns the serialized result.
-
-    All marqov imports happen here, inside the activity,
-    which is NOT subject to Temporal's workflow sandbox.
+    The activity process NEVER calls cloudpickle.loads on func_ref, args, or
+    the result — all deserialization happens inside a scrubbed child process.
+    The result is returned **opaquely** as a JSON string containing the raw
+    serialized blob produced by the child.
 
     Args:
         node_id: Unique identifier for this node.
         func_ref: Base64-encoded cloudpickle of the function.
         args_json: JSON-encoded list of arguments.
         kwargs_json: JSON-encoded dict of keyword arguments.
+        provider_env: Optional provider credentials to inject into the child env
+            (e.g. AWS keys for a Braket task).  Never inherited from the parent
+            process env — only what is explicitly passed here enters the child.
 
     Returns:
-        JSON-encoded result with node_id and serialized value.
+        JSON-encoded result with node_id and opaque result blob.
     """
-    # Deserialize the function
-    func_bytes = base64.b64decode(func_ref)
-    func = cloudpickle.loads(func_bytes)
+    workdir = new_task_workdir(node_id)
+    result_path = workdir / "result.json"
 
-    # Deserialize arguments
-    args_raw = json.loads(args_json)
-    kwargs_raw = json.loads(kwargs_json)
+    # Write inputs for the child.  func_ref is base64-encoded; write the text
+    # so the child can decode it (writing decoded bytes would require the child
+    # to know the encoding; keeping b64 is simpler and avoids double-decode).
+    (workdir / "node_id").write_text(node_id)
+    (workdir / "func_ref").write_text(func_ref)
+    (workdir / "args.json").write_text(args_json)
+    (workdir / "kwargs.json").write_text(kwargs_json)
 
-    args = [_deserialize_value(arg) for arg in args_raw]
-    kwargs = {k: _deserialize_value(v) for k, v in kwargs_raw.items()}
+    child_env = build_child_env(workdir, provider_env=provider_env)
+    # The child needs to know its workdir.
+    child_env["MARQOV_TASK_WORKDIR"] = str(workdir)
 
-    # Run user code in a separate thread for complete event loop isolation.
-    # Libraries like PennyLane's Braket plugin call asyncio.run() internally,
-    # which conflicts with Temporal's event loop. A separate thread gets its
-    # own clean event loop, avoiding any interference. (#728)
-    #
-    # Heartbeat every 10s so Temporal can deliver CancelledError when the
-    # workflow is cancelled. The thread itself is NOT interruptible — we
-    # abandon it and let it finish in the background. The important thing
-    # is that the activity reports cancellation immediately.
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        _CHILD_SCRIPT,
+        stdout=asyncio.subprocess.DEVNULL,  # child logs go to stderr; don't mix
+        stderr=asyncio.subprocess.PIPE,
+        env=child_env,
+        start_new_session=True,
+    )
 
     async def _heartbeat_loop() -> None:
         """Send heartbeats to Temporal until cancelled."""
@@ -115,40 +167,78 @@ async def execute_task(
             await asyncio.sleep(_HEARTBEAT_INTERVAL_S)
             activity.heartbeat(f"executing {node_id}")
 
-    if asyncio.iscoroutinefunction(func):
-        def _run_async() -> Any:
-            return asyncio.run(func(*args, **kwargs))
-        task = asyncio.create_task(asyncio.to_thread(_run_async))
-    else:
-        task = asyncio.create_task(asyncio.to_thread(func, *args, **kwargs))
-
     heartbeat_task = asyncio.create_task(_heartbeat_loop())
+    child_task = asyncio.create_task(proc.wait())
 
     try:
-        result = await task
+        await child_task
     except asyncio.CancelledError:
-        # Workflow was cancelled via Temporal.
-        # The thread is still running but we report cancellation immediately.
-        activity.logger.warning(
-            "Activity cancelled for node %s",
-            node_id,
-        )
+        # Activity was cancelled by Temporal — kill the child and propagate.
+        _kill_process_group(proc)
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            pass
+        activity.logger.warning("Activity cancelled for node %s — child killed", node_id)
         raise
     finally:
         heartbeat_task.cancel()
         try:
             await heartbeat_task
         except (asyncio.CancelledError, Exception):
-            # CancelledError is the normal case (we just cancelled it).
-            # Other exceptions (e.g. heartbeat SDK error) should not
-            # mask the main task's result or error.
             pass
 
-    # Serialize and return result
-    return json.dumps({
-        "node_id": node_id,
-        "result": _serialize_value(result),
-    })
+    # --- Separate error channel -------------------------------------------
+    # The child writes failures to error.json and successes to result.json.
+    # Reading error.json is safe: it's small, structured, and written by our
+    # own child wrapper code (not by user task code).
+    # The success path forwards result.json OPAQUELY (bytes → string) without
+    # ever calling json.loads on the result content.
+    error_path = workdir / "error.json"
+    if error_path.exists():
+        error_size = error_path.stat().st_size
+        if error_size > MAX_ERROR_BYTES:
+            raise RuntimeError(
+                f"Task {node_id} error.json size {error_size} exceeds limit "
+                f"{MAX_ERROR_BYTES} bytes."
+            )
+        error_data = json.loads(error_path.read_text())
+        raise RuntimeError(
+            f"Task {node_id} failed in child process: {error_data.get('error', '(no message)')}"
+        )
+
+    if result_path.exists():
+        result_size = result_path.stat().st_size
+        if result_size > MAX_RESULT_BYTES:
+            raise RuntimeError(
+                f"Task {node_id} result.json size {result_size} exceeds the "
+                f"{MAX_RESULT_BYTES}-byte limit (aligned with Temporal's ~4 MiB gRPC "
+                f"payload limit). Large results must spill to S3 + pass a reference "
+                f"(follow-up); returning multi-MiB results inline is unsupported."
+            )
+        # Forward result.json content OPAQUELY as a raw string — do NOT
+        # json.loads the result value here. The activity wraps it in an
+        # envelope so the caller can extract node_id and the opaque blob.
+        result_text = result_path.read_text()
+        # We need the node_id in the envelope but must not parse result content.
+        # Produce the envelope by string construction, not json.loads+json.dumps.
+        # result_text is already valid JSON: {"node_id": ..., "result": <blob>}
+        # We just forward it directly — the schema matches what callers expect.
+        return result_text
+
+    # No result file — child crashed before writing anything.
+    rc = proc.returncode
+    stderr_bytes = b""
+    if proc.stderr is not None:
+        try:
+            stderr_bytes = await asyncio.wait_for(proc.stderr.read(), timeout=2)
+        except (asyncio.TimeoutError, Exception):
+            pass
+    stderr_snippet = stderr_bytes.decode(errors="replace")[-2000:] if stderr_bytes else ""
+    raise RuntimeError(
+        f"Task {node_id} child exited with code {rc} and no result.\n"
+        f"Stderr: {stderr_snippet}"
+    )
 
 
 @activity.defn
@@ -160,6 +250,10 @@ async def prepare_node_inputs(
 
     This activity resolves proxy references in arguments by looking up
     results from previously completed nodes.
+
+    Upstream results are kept **opaque** — they are passed through as-is
+    (still in their __cloudpickle__ envelope) without deserialization.
+    The child process for the next execute_task call will deserialize them.
 
     Args:
         node_data_json: JSON with node's args, kwargs, and dependency info.
@@ -177,6 +271,7 @@ async def prepare_node_inputs(
             node_id = arg["node_id"]
             if node_id not in completed:
                 raise ValueError(f"Dependency {node_id} not yet computed")
+            # Pass the upstream result through opaquely — do NOT deserialize.
             return completed[node_id]
         elif isinstance(arg, list):
             return [resolve_arg(item) for item in arg]

--- a/marqov/workflows/decorators.py
+++ b/marqov/workflows/decorators.py
@@ -124,9 +124,18 @@ def task(
             timeout_seconds=timeout,
         )
 
-        # Serialize the function once
-        func_bytes = cloudpickle.dumps(fn)
-        func_ref = base64.b64encode(func_bytes).decode("utf-8")
+        # Defer cloudpickle.dumps OUT of decoration time. Eagerly pickling a
+        # local/closure fn by value at import — for EVERY @task whether or not it is
+        # ever dispatched — is what overflows the recursion budget under a deep
+        # ambient import stack (e.g. a full heavy-backend test suite, or a host
+        # worker process). Compute func_ref lazily (cached), only when a graph node
+        # actually needs it. This also eliminates all pickling of never-dispatched tasks.
+        _func_ref_cache: dict[str, str] = {}
+
+        def _func_ref() -> str:
+            if "v" not in _func_ref_cache:
+                _func_ref_cache["v"] = base64.b64encode(cloudpickle.dumps(fn)).decode("utf-8")
+            return _func_ref_cache["v"]
 
         @wraps(fn)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -140,7 +149,7 @@ def task(
                 node = TaskNode(
                     id=generate_node_id(),
                     func_name=fn.__name__,
-                    func_ref=func_ref,
+                    func_ref=_func_ref(),
                     args=list(_serialize_arg(arg) for arg in args),
                     kwargs={k: _serialize_arg(v) for k, v in kwargs.items()},
                     config=config,
@@ -155,7 +164,7 @@ def task(
         # Mark as task for introspection
         wrapper._is_task = True  # type: ignore
         wrapper._task_config = config  # type: ignore
-        wrapper._task_func_ref = func_ref  # type: ignore
+        wrapper._task_func_ref_fn = _func_ref  # type: ignore  # lazy accessor (was eager _task_func_ref; unread internally)
 
         return wrapper  # type: ignore
 

--- a/tests/test_activity_heartbeat.py
+++ b/tests/test_activity_heartbeat.py
@@ -1,11 +1,12 @@
 """Tests for activity heartbeating and cancellation handling.
 
-The project conftest.py stubs heavy dependencies (cloudpickle, temporalio)
-with mock modules. This test needs the real packages, so we restore them
-from the actual installed packages before importing the activity module.
+conftest.py is empty — no stubs to restore.  Import real packages directly.
+(The module-level _restore_real_module pattern was left over from an earlier
+phase when conftest.py stubbed heavy deps; it is now removed because it
+corrupts cloudpickle's C extension when collected alongside other test files.)
 """
 import asyncio
-import importlib
+import base64
 import json
 import sys
 import time
@@ -13,27 +14,9 @@ import time
 import pytest
 from unittest.mock import patch, MagicMock
 
-
-def _restore_real_module(name: str) -> None:
-    """Remove mock module and all sub-modules, then import the real one."""
-    keys_to_remove = [k for k in sys.modules if k == name or k.startswith(name + ".")]
-    for k in keys_to_remove:
-        del sys.modules[k]
-    importlib.import_module(name)
-
-
-# Restore real cloudpickle and temporalio before importing activity module.
-_restore_real_module("cloudpickle")
-_restore_real_module("temporalio")
-
-# Now we can safely import - these will use real packages.
-import base64
 import cloudpickle
 from temporalio import activity
 
-# Re-import activity module so it picks up real cloudpickle/temporalio.
-if "marqov.workflows.activity" in sys.modules:
-    del sys.modules["marqov.workflows.activity"]
 from marqov.workflows.activity import execute_task
 
 

--- a/tests/test_activity_subprocess_isolation.py
+++ b/tests/test_activity_subprocess_isolation.py
@@ -1,0 +1,570 @@
+"""Boundary-2 isolation tests for execute_task.
+
+SP2 Task 2 invariant: the activity process itself NEVER calls
+``cloudpickle.loads`` on user bytes during ``execute_task``.  All
+deserialization happens inside the scrubbed child subprocess.
+
+Tests:
+1. Zero cloudpickle.loads calls in the activity process during execute_task.
+2. The child env lacks arbitrary host secrets (HOST_* vars).
+3. A result that is a __cloudpickle__ blob is forwarded opaquely (not
+   deserialized in the activity process).
+4. prepare_node_inputs keeps upstream results opaque.
+5. Heartbeat fires during a slow task (subprocess version).
+6. Activity cancel kills the child process group.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The project conftest.py is empty — no stubs to restore.
+# Import the real modules directly.
+import cloudpickle  # noqa: E402
+from marqov.workflows.activity import execute_task, prepare_node_inputs, _deserialize_value  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_activity_ctx():
+    """Minimal Temporal activity context mock."""
+    mock_info = MagicMock()
+    mock_info.workflow_id = "test-workflow"
+    mock_info.activity_id = "test-activity"
+    with (
+        patch("temporalio.activity.heartbeat") as mock_hb,
+        patch("temporalio.activity.info", return_value=mock_info),
+        patch("temporalio.activity.logger"),
+    ):
+        yield mock_hb
+
+
+def _enc(fn: Any) -> str:
+    return base64.b64encode(cloudpickle.dumps(fn)).decode()
+
+
+# ---------------------------------------------------------------------------
+# 1. Zero cloudpickle.loads calls in the activity process
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_cloudpickle_loads_in_activity_process(mock_activity_ctx):
+    """Activity process must NOT call cloudpickle.loads during execute_task.
+
+    We patch cloudpickle.loads at the module level (the canonical location)
+    so any caller — the activity, a helper it imports, or a lazy ``import
+    cloudpickle`` inside a function body — is caught.  The loads must happen
+    ONLY in the child subprocess (which sees the real module, not the mock).
+    """
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    func_ref = _enc(add)
+    args_json = json.dumps([3, 4])
+    kwargs_json = json.dumps({})
+
+    loads_calls: list = []
+    real_loads = cloudpickle.loads
+
+    def spy_loads(data: bytes, *args: Any, **kwargs: Any) -> Any:
+        loads_calls.append(data[:16])  # record prefix for debugging
+        return real_loads(data, *args, **kwargs)
+
+    # Patch at the cloudpickle module level.  Because _deserialize_value does
+    # `import cloudpickle` lazily inside the function body, the patch must
+    # target sys.modules["cloudpickle"].loads (which is what the lazy import
+    # will resolve to at call time).
+    with patch.object(cloudpickle, "loads", side_effect=spy_loads):
+        result_json = await execute_task("node-spy", func_ref, args_json, kwargs_json)
+
+    result = json.loads(result_json)
+    assert result["node_id"] == "node-spy"
+    assert result["result"] == 7
+
+    assert len(loads_calls) == 0, (
+        f"cloudpickle.loads was called {len(loads_calls)} time(s) in the activity process. "
+        f"First call data prefix: {loads_calls[0] if loads_calls else 'n/a'}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Child env lacks secrets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_child_env_lacks_secrets(mock_activity_ctx, tmp_path):
+    """The scrubbed child env must not contain arbitrary host secrets (HOST_* vars)."""
+    # Inject fake secrets into the PARENT env to verify they don't leak.
+    fake_secrets = {
+        "HOST_SECRET_TOKEN": "fake-secret-value",
+        "HOST_API_KEY": "fake-api-key",
+        "HOST_NAMESPACE": "example",
+    }
+    child_env_capture: dict[str, str] = {}
+
+    from marqov.workflows import _child_env as ce
+
+    original_build = ce.build_child_env
+
+    def capturing_build(workdir: Path, provider_env=None):
+        env = original_build(workdir, provider_env=provider_env)
+        child_env_capture.update(env)
+        return env
+
+    with patch.dict(os.environ, fake_secrets):
+        with patch("marqov.workflows.activity.build_child_env", side_effect=capturing_build):
+
+            def simple_fn() -> int:
+                return 99
+
+            func_ref = _enc(simple_fn)
+            result_json = await execute_task(
+                "node-secret", func_ref, json.dumps([]), json.dumps({})
+            )
+
+    # The captured env (what the child actually receives) must not contain secrets.
+    assert "HOST_SECRET_TOKEN" not in child_env_capture, (
+        "HOST_SECRET_TOKEN leaked into child env!"
+    )
+    for key in child_env_capture:
+        assert not key.startswith("HOST_"), (
+            f"HOST_* key leaked into child env: {key}"
+        )
+
+    result = json.loads(result_json)
+    assert result["result"] == 99
+
+
+# ---------------------------------------------------------------------------
+# 3. Result forwarded opaquely — no in-process deserialization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_complex_result_forwarded_opaquely(mock_activity_ctx):
+    """A __cloudpickle__ result blob must be forwarded without in-process loads."""
+
+    class _MyResult:
+        def __init__(self, val: int) -> None:
+            self.val = val
+
+    def create_result() -> _MyResult:
+        return _MyResult(42)
+
+    func_ref = _enc(create_result)
+    args_json = json.dumps([])
+    kwargs_json = json.dumps({})
+
+    real_loads = cloudpickle.loads
+    loads_in_activity: list = []
+
+    import marqov.workflows.activity as activity_mod
+    original_dv = activity_mod._deserialize_value
+
+    def spy_dv(value: Any) -> Any:
+        # _deserialize_value calls cloudpickle.loads internally when it sees
+        # a __cloudpickle__ marker.  Count calls at this level.
+        result = original_dv(value)
+        return result
+
+    # We spy at the file-read level: after the child returns, does the activity
+    # call _deserialize_value on the result? It must NOT.
+    dv_calls: list = []
+
+    def tracking_dv(value: Any) -> Any:
+        dv_calls.append(value)
+        return original_dv(value)
+
+    with patch.object(activity_mod, "_deserialize_value", side_effect=tracking_dv):
+        result_json = await execute_task("node-opaque", func_ref, args_json, kwargs_json)
+
+    result = json.loads(result_json)
+    assert result["node_id"] == "node-opaque"
+
+    # The result should be a __cloudpickle__ envelope (complex object).
+    assert isinstance(result["result"], dict), "Expected a serialized envelope"
+    assert result["result"].get("__cloudpickle__"), "Expected __cloudpickle__ marker in result"
+
+    # _deserialize_value must NOT have been called with the result blob.
+    # (It may have been called with other things like args — but NOT with a
+    # __cloudpickle__ result from the child.)
+    result_blob = result["result"]
+    assert result_blob not in dv_calls, (
+        "Activity called _deserialize_value on the result blob — boundary violated!"
+    )
+
+    # Confirm the value is recoverable downstream (but NOT done by the activity).
+    recovered = _deserialize_value(result_blob)
+    assert recovered.val == 42
+
+
+# ---------------------------------------------------------------------------
+# 4. prepare_node_inputs keeps results opaque
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prepare_node_inputs_opaque(mock_activity_ctx):
+    """prepare_node_inputs must pass __cloudpickle__ blobs through without loading."""
+    # Simulate a completed result that is a cloudpickle blob.
+    blob = {
+        "__cloudpickle__": True,
+        "data": base64.b64encode(cloudpickle.dumps(lambda x: x + 1)).decode(),
+    }
+    node_data = {
+        "node_id": "task-B",
+        "func_ref": "dummy",
+        "args": [{"__proxy__": True, "node_id": "task-A"}],
+        "kwargs": {},
+    }
+    completed = {"task-A": blob}
+
+    import marqov.workflows.activity as activity_mod
+    dv_calls_with_blob: list = []
+    original_dv = activity_mod._deserialize_value
+
+    def spy_dv(value: Any) -> Any:
+        if isinstance(value, dict) and value.get("__cloudpickle__"):
+            dv_calls_with_blob.append(value)
+        return original_dv(value)
+
+    with patch.object(activity_mod, "_deserialize_value", side_effect=spy_dv):
+        result_json = await prepare_node_inputs(
+            json.dumps(node_data), json.dumps(completed)
+        )
+
+    result = json.loads(result_json)
+    # The blob must have passed through unchanged.
+    assert result["args"] == [blob]
+    # _deserialize_value must not have been called on the blob itself.
+    assert dv_calls_with_blob == [], (
+        "prepare_node_inputs called _deserialize_value on an upstream __cloudpickle__ result!"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Heartbeat fires while child runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_fires_during_child(mock_activity_ctx):
+    """Heartbeat task fires at least once while blocking on the child subprocess."""
+    mock_hb = mock_activity_ctx
+
+    # A function that sleeps long enough for a heartbeat to fire.
+    def slow_fn() -> int:
+        import time
+        time.sleep(0.3)
+        return 7
+
+    func_ref = _enc(slow_fn)
+    args_json = json.dumps([])
+    kwargs_json = json.dumps({})
+
+    import marqov.workflows.activity as activity_mod
+    original_interval = activity_mod._HEARTBEAT_INTERVAL_S
+    activity_mod._HEARTBEAT_INTERVAL_S = 0.05  # fire every 50ms
+    try:
+        result_json = await execute_task("node-hb", func_ref, args_json, kwargs_json)
+    finally:
+        activity_mod._HEARTBEAT_INTERVAL_S = original_interval
+
+    result = json.loads(result_json)
+    assert result["result"] == 7
+    assert mock_hb.call_count >= 1, (
+        f"Expected at least 1 heartbeat during child execution, got {mock_hb.call_count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Cancel kills the child process group
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_kills_child(mock_activity_ctx):
+    """When the activity task is cancelled, the child process group is killed."""
+    killed_pids: list[int] = []
+    real_killpg = os.killpg
+
+    def spy_killpg(pgid: int, sig: int) -> None:
+        killed_pids.append(pgid)
+        try:
+            real_killpg(pgid, sig)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+    def very_slow_fn() -> int:
+        import time
+        time.sleep(60)
+        return 0
+
+    func_ref = _enc(very_slow_fn)
+    args_json = json.dumps([])
+    kwargs_json = json.dumps({})
+
+    with patch("marqov.workflows.activity.os.killpg", side_effect=spy_killpg):
+        task = asyncio.create_task(
+            execute_task("node-cancel", func_ref, args_json, kwargs_json)
+        )
+        # Give the child time to start
+        await asyncio.sleep(0.5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert len(killed_pids) >= 1, (
+        "Expected os.killpg to be called when activity was cancelled"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Separate error channel: child writes error.json; activity surfaces it as
+#    RuntimeError WITHOUT reading result.json
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_failure_surfaces_via_error_json(mock_activity_ctx):
+    """A task that raises must produce error.json; activity raises RuntimeError from it.
+
+    Hardening: errors travel via error.json, NOT result.json.
+    result.json must NOT exist when the task fails.
+    """
+
+    def always_fails() -> int:
+        raise ValueError("intentional test failure")
+
+    func_ref = _enc(always_fails)
+    args_json = json.dumps([])
+    kwargs_json = json.dumps({})
+
+    with pytest.raises(RuntimeError, match="intentional test failure"):
+        await execute_task("node-fail", func_ref, args_json, kwargs_json)
+
+
+@pytest.mark.asyncio
+async def test_error_json_exists_result_json_absent_on_failure(mock_activity_ctx, tmp_path):
+    """On child failure, error.json must exist and result.json must NOT exist."""
+    from marqov.workflows import _child_env as ce
+
+    workdir_capture: list[Path] = []
+    original_ntw = ce.new_task_workdir
+
+    def capturing_ntw(node_id: str) -> Path:
+        wd = original_ntw(node_id)
+        workdir_capture.append(wd)
+        return wd
+
+    def always_fails() -> int:
+        raise RuntimeError("channel test failure")
+
+    func_ref = _enc(always_fails)
+
+    with patch("marqov.workflows.activity.new_task_workdir", side_effect=capturing_ntw):
+        with pytest.raises(RuntimeError, match="channel test failure"):
+            await execute_task("node-chan", func_ref, json.dumps([]), json.dumps({}))
+
+    assert workdir_capture, "new_task_workdir was never called"
+    workdir = workdir_capture[0]
+    error_path = workdir / "error.json"
+    result_path = workdir / "result.json"
+
+    assert error_path.exists(), "error.json must exist when the child task fails"
+    assert not result_path.exists(), "result.json must NOT exist when the child task fails"
+
+    # error.json must be valid, structured JSON with an "error" key.
+    error_data = json.loads(error_path.read_text())
+    assert "error" in error_data, "error.json must contain an 'error' key"
+    assert "channel test failure" in error_data["error"]
+
+
+# ---------------------------------------------------------------------------
+# 8. Success path: json.loads is NEVER called on result.json content by the
+#    activity. result.json bytes are forwarded opaquely.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_path_never_json_loads_result_content(mock_activity_ctx):
+    """On success, the activity must forward result.json bytes WITHOUT calling
+    json.loads on the result content.
+
+    We spy on json.loads inside the activity module.  The activity is
+    permitted to call json.loads on error.json (to check for errors), but
+    MUST NOT call it on the content of result.json.
+    """
+    import marqov.workflows.activity as activity_mod
+
+    def returns_data() -> dict:
+        return {"answer": 42}
+
+    func_ref = _enc(returns_data)
+    args_json = json.dumps([])
+    kwargs_json = json.dumps({})
+
+    json_loads_calls: list[str] = []
+    real_json_loads = json.loads
+
+    def spy_json_loads(s, *args, **kwargs):
+        json_loads_calls.append(str(s)[:80])
+        return real_json_loads(s, *args, **kwargs)
+
+    with patch.object(activity_mod.json, "loads", side_effect=spy_json_loads):
+        result_raw = await execute_task("node-success", func_ref, args_json, kwargs_json)
+
+    # The outer envelope is expected to be parsed by the caller, not the activity.
+    # Check: the activity must not have parsed result.json content (only possibly
+    # error.json, which is small and structured and ours).
+    # result.json contains {"node_id": ..., "result": <blob>} — the "result" field
+    # value (the blob itself) must not be json.loads'd by the activity.
+    outer = real_json_loads(result_raw)
+    assert outer["node_id"] == "node-success"
+    # Confirm the activity never tried to json.loads the result content bytes.
+    # (It's acceptable for the activity to read result.json as bytes/text and
+    # forward it — but NOT to json.loads the result field inside it.)
+    result_blob_str = json.dumps(outer["result"])
+    for call_arg in json_loads_calls:
+        assert result_blob_str not in call_arg, (
+            "Activity called json.loads on the result content — boundary violated!\n"
+            f"json.loads was called with: {call_arg!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 9. Size cap: oversized child output is rejected before being read into the
+#    worker process.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oversized_result_is_rejected(mock_activity_ctx):
+    """result.json larger than MAX_RESULT_BYTES must be rejected with RuntimeError."""
+    import marqov.workflows.activity as activity_mod
+
+    # Confirm the constant exists and is reasonable.
+    assert hasattr(activity_mod, "MAX_RESULT_BYTES"), (
+        "activity.py must define MAX_RESULT_BYTES constant"
+    )
+    cap = activity_mod.MAX_RESULT_BYTES
+    assert 1024 * 1024 <= cap <= 256 * 1024 * 1024, (
+        f"MAX_RESULT_BYTES={cap} is outside the expected range [1 MiB, 256 MiB]"
+    )
+
+    # Simulate a child that writes a result.json exceeding the cap.
+    from marqov.workflows import _child_env as ce
+
+    workdir_capture: list[Path] = []
+    original_ntw = ce.new_task_workdir
+
+    def capturing_ntw(node_id: str) -> Path:
+        wd = original_ntw(node_id)
+        workdir_capture.append(wd)
+        return wd
+
+    def normal_fn() -> int:
+        return 1
+
+    func_ref = _enc(normal_fn)
+
+    # We need the child to write a file that exceeds the cap.  Instead of
+    # running a real task that produces huge output (slow), we intercept after
+    # the child exits and replace result.json with an oversized stub.
+    original_path_stat = Path.stat
+
+    def patched_stat(self, *args, **kwargs):
+        st = original_path_stat(self, *args, **kwargs)
+        # For any result.json inside a marqov_task_ workdir, lie about the size.
+        if self.name == "result.json" and "marqov_task_" in str(self.parent):
+            import os
+            import stat as stat_mod
+            # Return a stat_result with st_size beyond the cap.
+            fake_size = cap + 1
+            # stat_result is a named tuple-like; rebuild from os.stat_result
+            fields = list(st)
+            fields[6] = fake_size  # index 6 = st_size
+            return os.stat_result(fields)
+        return st
+
+    with patch("marqov.workflows.activity.new_task_workdir", side_effect=capturing_ntw):
+        with patch.object(Path, "stat", patched_stat):
+            with pytest.raises(RuntimeError, match="[Ss]ize|[Ll]imit|[Tt]oo large|[Oo]versized|[Cc]ap"):
+                await execute_task("node-big", func_ref, json.dumps([]), json.dumps({}))
+
+
+@pytest.mark.asyncio
+async def test_oversized_error_json_is_rejected(mock_activity_ctx):
+    """error.json larger than MAX_ERROR_BYTES must be rejected (not read in full)."""
+    import marqov.workflows.activity as activity_mod
+
+    assert hasattr(activity_mod, "MAX_ERROR_BYTES"), (
+        "activity.py must define MAX_ERROR_BYTES constant"
+    )
+    cap = activity_mod.MAX_ERROR_BYTES
+    assert 1024 <= cap <= 1024 * 1024, (
+        f"MAX_ERROR_BYTES={cap} is outside the expected range [1 KiB, 1 MiB]"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10. Fail-closed fallback: build_child_env with no MARQOV_SCRUB_ALLOWLIST set
+#     must NOT copy os.environ wholesale — it uses the minimal-safe allowlist.
+# ---------------------------------------------------------------------------
+
+
+def test_build_child_env_fail_closed_no_allowlist_env_var():
+    """With MARQOV_SCRUB_ALLOWLIST unset, build_child_env uses the minimal-safe
+    allowlist and never includes arbitrary parent-env vars.
+
+    This asserts the fail-closed invariant: an absent var must not cause the
+    function to fall back to os.environ.copy() or similar.
+    """
+    import tempfile
+    from marqov.workflows._child_env import build_child_env, _MINIMAL_SAFE_DEFAULT
+
+    # Inject a unique canary into the parent env.
+    canary_key = "MARQOV_CANARY_SECRET_XYZ"
+    canary_val = "should-never-reach-child"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workdir = Path(tmpdir)
+        with patch.dict(os.environ, {canary_key: canary_val}, clear=False):
+            # Ensure the allowlist var itself is NOT set.
+            env_without_allowlist = {
+                k: v for k, v in os.environ.items()
+                if k != "MARQOV_SCRUB_ALLOWLIST"
+            }
+            with patch.dict(os.environ, env_without_allowlist, clear=True):
+                child_env = build_child_env(workdir)
+
+    # The canary must not be in the child env.
+    assert canary_key not in child_env, (
+        f"build_child_env leaked parent-env key {canary_key!r} into child env "
+        "when MARQOV_SCRUB_ALLOWLIST was unset — this is NOT fail-closed!"
+    )
+
+    # Only keys from the minimal-safe allowlist (plus HOME/TMPDIR overrides) should be present.
+    allowed_keys = set(_MINIMAL_SAFE_DEFAULT) | {"HOME", "TMPDIR", "MARQOV_TASK_WORKDIR"}
+    unexpected = {k for k in child_env if k not in allowed_keys}
+    assert not unexpected, (
+        f"build_child_env included unexpected keys when using minimal-safe fallback: "
+        f"{unexpected}"
+    )

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -4,19 +4,10 @@ import pytest
 from marqov import task, workflow
 from marqov.workflows import TransportGraph, TaskProxy
 
-# KNOWN PRE-EXISTING ISSUE (marqov-platform#1259): @task serializes the function
-# with cloudpickle.dumps() at DECORATION time. These tests decorate *local*
-# functions, which cloudpickle must pickle by value; under the full suite (with
-# the [all] heavy backends imported) that overflows into a RecursionError
-# (segfault on macOS). It is not caused by the PyPI-publishing work — the same 13
-# fail on unmodified main — and the real fix is architectural (don't pickle at
-# decoration; reference functions by name / defer to dispatch). Marked xfail so
-# CI is honest while it's tracked. strict=False: they pass when this file is run
-# in isolation, so an unexpected pass must not fail the run.
-pytestmark = pytest.mark.xfail(
-    reason="cloudpickle recursion at @task decoration under heavy imports; see marqov-platform#1259",
-    strict=False,
-)
+# Regression guard: @task no longer pickles the function at DECORATION time —
+# cloudpickle.dumps is deferred (lazily, cached) to graph build, so decorating a
+# local fn under a deep ambient import stack + heavy backends can no longer overflow
+# the recursion budget. Was previously xfail'd; now asserted to pass.
 
 
 class TestTaskDecorator:

--- a/tests/test_e2e_workflow_isolation.py
+++ b/tests/test_e2e_workflow_isolation.py
@@ -1,0 +1,242 @@
+"""E2e workflow isolation test — SP2 Task 3 (criterion 3).
+
+ONE bell-state @workflow end-to-end through the Temporal test framework:
+
+  WorkflowDispatch._prepare_workflow_input()
+    → JobWorkflow (real temporalio Worker)
+      → prepare_node_inputs activity (real, in-process)
+      → execute_task activity (real, each task body in a scrubbed subprocess)
+
+Keystone assertions (criterion 3):
+  a. Results flow back correctly — bell-state tasks produce expected counts.
+  b. cloudpickle.loads spy: ZERO in-process calls in the worker/activity process
+     during the entire e2e run.  (loads happens only inside the child subprocesses.)
+  c. Both task subprocesses' envs lack arbitrary host secrets (HOST_* vars).
+
+Harness measurement:
+  - Uses WorkflowEnvironment.start_time_skipping() — temporalio's in-process
+    ephemeral test server.  The binary is already cached at
+    /var/folders/.../temporal-test-server-sdk-python-1.27.2 (downloaded
+    previously; ~61 MB arm64 binary).
+  - No Docker, no real Temporal cluster needed.
+  - env start < 5 s in CI (measured: sub-second on warm machine).
+  - Verdict: LIGHT harness.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import cloudpickle
+import pytest
+
+from marqov.workflows.activity import execute_task, prepare_node_inputs
+from marqov.workflows.temporal_workflow import JobWorkflow
+from marqov.workflows.decorators import task, workflow
+
+
+# ---------------------------------------------------------------------------
+# Bell-state tasks (simple noiseless simulation — no hardware required)
+# ---------------------------------------------------------------------------
+# We use numpy for the simulation so the result is a dict (non-primitive),
+# forcing the cloudpickle envelope path through the subprocess boundary.
+
+
+@task
+def run_bell_circuit() -> dict[str, int]:
+    """Simulate a bell-state circuit and return measurement counts.
+
+    Returns {'00': N, '11': N} with equal probability.  We use a fixed seed
+    so the test is deterministic.
+    """
+    import numpy as np
+
+    rng = np.random.default_rng(seed=42)
+    n_shots = 100
+    # Bell state |Φ+⟩: perfect 50/50 between 00 and 11.
+    outcomes = rng.choice([0, 1], size=n_shots)  # 0 → '00', 1 → '11'
+    counts: dict[str, int] = {"00": int((outcomes == 0).sum()), "11": int((outcomes == 1).sum())}
+    return counts
+
+
+@task
+def validate_counts(counts: dict[str, int]) -> dict[str, Any]:
+    """Validate that counts are consistent with a bell state.
+
+    Checks:
+    - Only '00' and '11' outcomes (no '01' or '10').
+    - Total shots = 100.
+    - Both '00' and '11' have > 0 counts.
+    """
+    valid_keys = {"00", "11"}
+    unexpected = set(counts.keys()) - valid_keys
+    total = sum(counts.values())
+    ok = (
+        len(unexpected) == 0
+        and total == 100
+        and counts.get("00", 0) > 0
+        and counts.get("11", 0) > 0
+    )
+    return {
+        "valid": ok,
+        "counts": counts,
+        "total_shots": total,
+        "unexpected_outcomes": sorted(unexpected),
+    }
+
+
+@workflow
+def bell_state_workflow() -> Any:
+    """Bell-state workflow: simulate → validate."""
+    counts = run_bell_circuit()
+    result = validate_counts(counts)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_worker(client: Any) -> Any:
+    """Build a Worker registered with the real activities and workflow.
+
+    We use UnsandboxedWorkflowRunner to avoid the Temporal sandbox's proxy
+    restrictions firing on modules (e.g. numpy) that were already imported in
+    the test process.  The sandbox is a production concern; for the spike
+    measurement the unsandboxed runner gives a clean read of the two subprocess
+    boundaries without sandbox noise.
+    """
+    from temporalio.worker import Worker, UnsandboxedWorkflowRunner
+
+    return Worker(
+        client,
+        task_queue="marqov-workflows",
+        workflows=[JobWorkflow],
+        activities=[execute_task, prepare_node_inputs],
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+
+
+async def _run_bell_state_e2e(client: Any) -> dict[str, Any]:
+    """Drive the full e2e run and return the final result dict."""
+    from marqov.workflows.decorators import WorkflowDispatch
+
+    dispatch: WorkflowDispatch = bell_state_workflow()
+    workflow_input = dispatch._prepare_workflow_input()
+
+    import uuid
+    workflow_id = f"bell-e2e-{uuid.uuid4().hex[:8]}"
+
+    async with _make_worker(client):
+        handle = await client.start_workflow(
+            JobWorkflow.run,
+            args=[workflow_input],
+            id=workflow_id,
+            task_queue="marqov-workflows",
+        )
+        result_json: str = await handle.result()
+
+    parsed = json.loads(result_json)
+    # Unwrap the enriched format: {"result": ..., "_workflow_metadata": ...}
+    if isinstance(parsed, dict) and "result" in parsed:
+        return parsed["result"]
+    return parsed
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e2e_bell_state_no_privileged_loads() -> None:
+    """E2e bell-state workflow through both boundaries — no privileged loads.
+
+    Criterion 3:
+      a. results flow back (bell-state → validate passes).
+      b. ZERO cloudpickle.loads calls in the activity/worker process.
+      c. child envs lack arbitrary host secrets (HOST_* vars).
+
+    Harness weight: WorkflowEnvironment.start_time_skipping() — light
+    (uses the cached temporal-test-server binary; no Docker required).
+    """
+    from temporalio.testing import WorkflowEnvironment
+
+    # --- spy setup ---
+    loads_calls: list[bytes] = []
+    real_loads = cloudpickle.loads
+
+    def spy_loads(data: bytes, *args: Any, **kwargs: Any) -> Any:
+        loads_calls.append(data[:16])  # record prefix for debugging
+        return real_loads(data, *args, **kwargs)
+
+    # Child env capture (assertion c)
+    child_envs_captured: list[dict[str, str]] = []
+
+    from marqov.workflows import _child_env as ce
+
+    original_build = ce.build_child_env
+
+    def capturing_build(workdir: Path, provider_env: dict[str, str] | None = None) -> dict[str, str]:
+        env = original_build(workdir, provider_env=provider_env)
+        child_envs_captured.append(dict(env))
+        return env
+
+    # Inject fake host secrets into PARENT env to verify they don't leak.
+    fake_secrets = {
+        "HOST_SECRET_TOKEN": "fake-e2e-secret",
+        "HOST_API_KEY": "fake-e2e-api-key",
+        "HOST_NAMESPACE": "example",
+    }
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        client = env.client
+
+        with patch.object(cloudpickle, "loads", side_effect=spy_loads):
+            with patch.dict(os.environ, fake_secrets):
+                with patch("marqov.workflows.activity.build_child_env", side_effect=capturing_build):
+                    result = await _run_bell_state_e2e(client)
+
+    # --- assertion a: results correct ---
+    assert isinstance(result, dict), f"Expected dict result, got {type(result)}: {result!r}"
+    assert result.get("valid") is True, (
+        f"Bell-state validation failed: {result!r}"
+    )
+    counts = result.get("counts", {})
+    assert "00" in counts and "11" in counts, f"Unexpected counts keys: {counts}"
+    assert counts["00"] + counts["11"] == 100, f"Wrong total shots: {counts}"
+    assert counts["00"] > 0 and counts["11"] > 0, f"Zero counts in one outcome: {counts}"
+
+    # --- assertion b: ZERO cloudpickle.loads in the worker/activity process ---
+    assert len(loads_calls) == 0, (
+        f"cloudpickle.loads was called {len(loads_calls)} time(s) IN the worker process "
+        f"during the e2e run.  No-privileged-loads invariant VIOLATED.\n"
+        f"First call data prefix: {loads_calls[0] if loads_calls else 'n/a'}"
+    )
+
+    # --- assertion c: child envs lack host secrets ---
+    # Two task nodes → two execute_task calls → two child envs captured.
+    assert len(child_envs_captured) >= 1, (
+        "No child envs were captured — build_child_env patch not exercised?"
+    )
+    for i, child_env in enumerate(child_envs_captured):
+        assert "HOST_SECRET_TOKEN" not in child_env, (
+            f"HOST_SECRET_TOKEN leaked into child env #{i}!"
+        )
+        host_keys = [k for k in child_env if k.startswith("HOST_")]
+        assert host_keys == [], (
+            f"HOST_* keys leaked into child env #{i}: {host_keys}"
+        )
+
+    # Sanity: we captured exactly 2 child envs (one per task node).
+    assert len(child_envs_captured) == 2, (
+        f"Expected 2 child env captures (2 task nodes), got {len(child_envs_captured)}"
+    )

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -1,0 +1,190 @@
+"""Tests for marqov.benchmarking.fidelity module."""
+
+import pytest
+
+from marqov.benchmarking.fidelity import (
+    classical_fidelity,
+    fidelity_with_uniform,
+    normalized_fidelity,
+)
+from marqov.executors.base import ExecutionResult
+
+
+def _result(counts: dict[str, int]) -> ExecutionResult:
+    """Build an ExecutionResult with the given counts."""
+    return ExecutionResult(
+        counts=counts,
+        backend="test",
+        execution_time_ms=0.0,
+        shots=sum(counts.values()),
+    )
+
+
+class TestClassicalFidelity:
+    """Tests for classical (Bhattacharyya) fidelity."""
+
+    def test_identical_distributions(self) -> None:
+        """Identical distributions have fidelity 1."""
+        dist = {"00": 0.5, "11": 0.5}
+        assert classical_fidelity(dist, dist) == pytest.approx(1.0)
+
+    def test_disjoint_support(self) -> None:
+        """Distributions with no shared outcomes have fidelity 0."""
+        assert classical_fidelity({"00": 1.0}, {"11": 1.0}) == pytest.approx(0.0)
+
+    def test_partial_overlap_known_value(self) -> None:
+        """Non-trivial value: F({00:.5,01:.5}, {00:1}) = (sqrt(.5))^2 = 0.5."""
+        assert classical_fidelity({"00": 0.5, "01": 0.5}, {"00": 1.0}) == pytest.approx(
+            0.5
+        )
+
+    def test_symmetric(self) -> None:
+        """Fidelity is symmetric in its arguments."""
+        a = {"00": 0.7, "01": 0.3}
+        b = {"00": 0.4, "01": 0.6}
+        assert classical_fidelity(a, b) == pytest.approx(classical_fidelity(b, a))
+
+    def test_accepts_raw_counts(self) -> None:
+        """Raw shot counts give the same result as normalized probabilities."""
+        counts = {"00": 300, "01": 100}  # -> {0.75, 0.25}
+        probs = {"00": 0.75, "01": 0.25}
+        assert classical_fidelity(counts, {"00": 1.0}) == pytest.approx(
+            classical_fidelity(probs, {"00": 1.0})
+        )
+
+    def test_accepts_execution_result(self) -> None:
+        """Accepts ExecutionResult directly, using its counts."""
+        ideal = _result({"00": 500, "11": 500})
+        measured = _result({"00": 480, "11": 470, "01": 30, "10": 20})
+        assert 0.0 < classical_fidelity(ideal, measured) < 1.0
+
+    def test_width_mismatch_is_aligned(self) -> None:
+        """Trimmed-width keys are zero-padded to align, not treated as disjoint."""
+        # "0" should pad to "00" and match the padded distribution.
+        assert classical_fidelity({"0": 1.0}, {"00": 1.0}) == pytest.approx(1.0)
+
+
+class TestFidelityWithUniform:
+    """Tests for fidelity_with_uniform."""
+
+    def test_peaked_two_qubit(self) -> None:
+        """A delta distribution over 4 states has uniform-fidelity 1/4."""
+        assert fidelity_with_uniform({"00": 1.0}) == pytest.approx(0.25)
+
+    def test_uniform_is_one(self) -> None:
+        """The uniform distribution has fidelity 1 with itself."""
+        dist = {"00": 0.25, "01": 0.25, "10": 0.25, "11": 0.25}
+        assert fidelity_with_uniform(dist) == pytest.approx(1.0)
+
+    def test_num_states_override(self) -> None:
+        """Explicit num_states overrides the 2**width default (e.g. boson sampling)."""
+        assert fidelity_with_uniform({"20": 1.0}, num_states=3) == pytest.approx(1 / 3)
+
+    def test_infers_width(self) -> None:
+        """Default outcome space is 2**(bitstring width)."""
+        assert fidelity_with_uniform({"000": 1.0}) == pytest.approx(1 / 8)
+
+    def test_num_states_below_support_raises(self) -> None:
+        """num_states smaller than the populated support is rejected."""
+        dist = {"00": 0.5, "01": 0.5}
+        with pytest.raises(ValueError, match="smaller than the number"):
+            fidelity_with_uniform(dist, num_states=1)
+
+
+class TestNormalizedFidelity:
+    """Tests for the Lubinski/QED-C normalized fidelity."""
+
+    def test_perfect_backend(self) -> None:
+        """Backend matching the ideal distribution scores 1."""
+        ideal = {"00": 0.5, "11": 0.5}
+        assert normalized_fidelity(ideal, ideal) == pytest.approx(1.0)
+
+    def test_uniform_backend_scores_zero(self) -> None:
+        """A pure-noise (uniform) backend scores 0, not the raw fidelity."""
+        ideal = {"00": 1.0}
+        uniform = {"00": 0.25, "01": 0.25, "10": 0.25, "11": 0.25}
+        assert normalized_fidelity(ideal, uniform) == pytest.approx(0.0)
+
+    def test_worse_than_uniform_clamps_to_zero(self) -> None:
+        """Backend anti-correlated with the ideal clamps to 0 (never negative)."""
+        ideal = {"00": 1.0}
+        backend = {"11": 1.0}
+        assert normalized_fidelity(ideal, backend) == 0.0
+
+    def test_between_zero_and_one(self) -> None:
+        """A partially-degraded backend lands strictly between 0 and 1."""
+        ideal = {"00": 1.0}
+        backend = {"00": 0.7, "01": 0.1, "10": 0.1, "11": 0.1}
+        assert 0.0 < normalized_fidelity(ideal, backend) < 1.0
+
+    def test_accepts_execution_results(self) -> None:
+        """Works directly on the ExecutionResult objects executors return."""
+        ideal = _result({"00": 512, "11": 512})
+        backend = _result({"00": 480, "11": 470, "01": 40, "10": 34})
+        assert 0.0 < normalized_fidelity(ideal, backend) <= 1.0
+
+    def test_trimmed_backend_keys_still_score_high(self) -> None:
+        """Regression: a correct backend with leading-zeros trimmed must NOT
+        be flagged as broken (was the headline review bug)."""
+        ideal = _result({"00": 500, "11": 500})
+        # Same distribution but the "00" key arrived trimmed to "0".
+        trimmed = {"0": 500, "11": 500}
+        assert normalized_fidelity(ideal, trimmed) == pytest.approx(1.0)
+
+    def test_zero_shot_backend_scores_zero(self) -> None:
+        """A backend that returned no shots scores 0, it does not crash."""
+        ideal = _result({"00": 500, "11": 500})
+        empty = _result({})  # ExecutionResult with no counts
+        assert normalized_fidelity(ideal, empty) == 0.0
+
+    def test_empty_ideal_raises(self) -> None:
+        """An empty reference is a caller error, not a zero score."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            normalized_fidelity({}, {"00": 1.0})
+
+    def test_maximally_mixed_ideal_raises(self) -> None:
+        """A degenerate (uniform) reference fails loudly rather than returning 0."""
+        ideal = {"00": 0.25, "01": 0.25, "10": 0.25, "11": 0.25}
+        backend = {"00": 0.5, "11": 0.5}
+        with pytest.raises(ValueError, match="maximally mixed"):
+            normalized_fidelity(ideal, backend)
+
+    def test_num_states_below_support_raises(self) -> None:
+        """num_states below the ideal's support is rejected, not silently zeroed."""
+        ideal = {"00": 0.5, "11": 0.5}
+        backend = {"00": 0.5, "11": 0.5}
+        with pytest.raises(ValueError, match="smaller than the ideal"):
+            normalized_fidelity(ideal, backend, num_states=1)
+
+    def test_matches_reference_formula(self) -> None:
+        """Result equals the explicit (F_b - F_u)/(1 - F_u) computation."""
+        ideal = {"00": 0.5, "11": 0.5}
+        backend = {"00": 0.45, "11": 0.4, "01": 0.1, "10": 0.05}
+        f_backend = classical_fidelity(ideal, backend)
+        f_uniform = fidelity_with_uniform(ideal)
+        expected = max((f_backend - f_uniform) / (1 - f_uniform), 0.0)
+        assert normalized_fidelity(ideal, backend) == pytest.approx(expected)
+
+
+class TestValidation:
+    """Input validation."""
+
+    def test_empty_distribution_raises(self) -> None:
+        """An empty distribution is rejected."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            classical_fidelity({}, {"0": 1.0})
+
+    def test_zero_mass_raises(self) -> None:
+        """A distribution with no positive mass is rejected."""
+        with pytest.raises(ValueError, match="positive"):
+            fidelity_with_uniform({"0": 0.0, "1": 0.0})
+
+    def test_negative_value_raises(self) -> None:
+        """A negative count/probability is rejected before it reaches sqrt."""
+        with pytest.raises(ValueError, match="negative"):
+            classical_fidelity({"0": 2.0, "1": -1.0}, {"0": 1.0})
+
+    def test_padding_collision_raises(self) -> None:
+        """Keys that collide after zero-padding are a real ambiguity -> error."""
+        with pytest.raises(ValueError, match="collide"):
+            fidelity_with_uniform({"1": 0.5, "01": 0.5})


### PR DESCRIPTION
Environment-hygiene hardening for the `@task` / `@workflow` execution path.

## Changes
- **Isolated task execution.** `@task` bodies (and graph build) run in a per-job subprocess with a minimal, allowlisted environment — the subprocess inherits only an explicit allowlist plus any values a host passes for that job, never the ambient process environment. Defense-in-depth: a task runs with only what it legitimately needs.
- **Defer serialization to dispatch.** `@task` no longer `cloudpickle`-serializes the function at decoration time; it does so lazily (cached) at graph build. This avoids serializing never-dispatched tasks and fixes a `RecursionError` that could occur when decorating local/closure functions under a deep import stack with heavy backends.
- **Opaque result forwarding + size caps.** The parent worker forwards a child's result without deserializing it; failures use a separate error channel so the success path never parses child output; reads are size-capped (aligned with Temporal's payload limit).
- `@workflow` is the supported entry point.

## Behavioral change (for `@task` users)
- **Closure-at-dispatch:** deferring serialization to dispatch means a task's closure captures referenced state as of dispatch, not import/decoration. Identical for deterministic code; a task closing over a value mutated between decoration and dispatch now sees the dispatch-time value. See CHANGELOG.

## New host↔SDK interface
- **`MARQOV_SCRUB_ALLOWLIST`:** a host runner may set this (comma-separated variable names) in the worker process to define the allowlist the SDK uses for a task's subprocess environment. If unset, the SDK falls back to a minimal, secret-free default and logs a warning.

## Tests
Activity/workflow suites green, incl. an e2e `@workflow` run through both subprocess boundaries asserting the parent performs zero in-process `cloudpickle.loads`, plus fail-closed-env and size-cap tests.
