### PR TITLE
feat(qutip): marqov.qutip.record — open-system-dynamics result helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the `marqov` SDK are documented here. This project follow
 still change between minor versions; `1.0.0` is reserved for the first API-stable
 release.
 
+## [Unreleased]
+
+### Added
+
+- **`marqov.qutip.record` — open-system-dynamics result capture.** New optional
+  helper that serialises a QuTiP solver `Result` (`mesolve`/`sesolve`/`mcsolve`)
+  into the platform's `open-system-dynamics` v1 stdout-JSON contract with a
+  single call: `record(result, ["sigma_z", "sigma_x"])`. Test-only qutip
+  dependency — `record.py` duck-types the `Result` and never imports qutip at
+  runtime. Enforces the contract's guardrails so a hand-built dict can't get
+  them wrong: density-matrix `.states` are refused on stdout (offload by
+  reference), unseeded `mcsolve` runs are rejected as non-reproducible (seeds
+  emitted as strings to survive JSON float precision), and non-finite / genuinely
+  complex expectation values are rejected rather than silently coerced.
+
 ## [0.3.1] — 2026-07-25
 
 ### Fixed

--- a/marqov/qutip/__init__.py
+++ b/marqov/qutip/__init__.py
@@ -1,0 +1,2 @@
+from marqov.qutip.record import record
+__all__ = ["record"]

--- a/marqov/qutip/record.py
+++ b/marqov/qutip/record.py
@@ -115,6 +115,11 @@ def record(result: Any, observable_names: list[str] | None = None, *,
         "observables": observables,
     }
     if seeds:
+        # REPRODUCIBILITY CAVEAT (verified qutip 5.3): these seeds reproduce mcsolve
+        # bit-identically ONLY under options={"map": "serial"}. The parallel map does
+        # not preserve seed->trajectory assignment, so a re-run with the same seeds
+        # produces a DIFFERENT trajectory set (max|Δ| up to 2.0). A Capsule re-run of a
+        # stochastic open-system result must force serial to actually reproduce.
         payload["seeds"] = [_seed_to_str(s) for s in seeds]
     if states_artifact_path is not None:
         payload["states_artifact"] = states_artifact_path

--- a/marqov/qutip/record.py
+++ b/marqov/qutip/record.py
@@ -110,6 +110,7 @@ def record(result: Any, observable_names: list[str] | None = None, *,
 
     payload: dict[str, Any] = {
         "result_type": "open-system-dynamics",
+        "schema_version": 1,
         "times": times,
         "observables": observables,
     }

--- a/marqov/qutip/record.py
+++ b/marqov/qutip/record.py
@@ -31,16 +31,32 @@ def _seed_to_str(s: Any) -> str:
 def _coerce_series(arr: Any, name: str) -> list[float]:
     a = np.asarray(arr)
     if np.iscomplexobj(a):
+        # Tolerance is RELATIVE to the max |real| with an absolute floor of 1e-6
+        # (scale >= 1.0). Note: for an observable decaying toward zero the floor
+        # dominates, so this is effectively an absolute 1e-6 there — acceptable
+        # because a true residual imaginary part at that scale is numerical noise.
         scale = max(1.0, float(np.abs(a.real).max())) if a.size else 1.0
         imag_max = float(np.abs(a.imag).max()) if a.size else 0.0
-        if imag_max <= 1e-6 * scale:  # max(relative 1e-6, absolute 1e-6 via scale>=1 floor)
-            return [float(x.real) for x in a]
+        if imag_max > 1e-6 * scale:
+            raise ValueError(
+                f"observable '{name}' has genuinely complex expectation values "
+                "(non-Hermitian operator). The MVP records real observables only; "
+                "use a Hermitian operator, or await the {re, im} schema decision (OD-2)."
+            )
+        real = a.real
+    else:
+        real = a
+    # NaN/Inf are not valid JSON — json.dumps emits bare NaN/Infinity tokens that
+    # no browser JSON parser accepts. Fail at emit, naming the offending index,
+    # rather than shipping an unparseable artifact (a decay curve with holes reads
+    # as data). Never silently substitute null.
+    nonfinite = np.where(~np.isfinite(real))[0] if real.size else np.empty(0, dtype=int)
+    if nonfinite.size:
         raise ValueError(
-            f"observable '{name}' has genuinely complex expectation values "
-            "(non-Hermitian operator). The MVP records real observables only; "
-            "use a Hermitian operator, or await the {re, im} schema decision (OD-2)."
+            f"observable '{name}' has a non-finite value (NaN/Inf) at index "
+            f"{int(nonfinite[0])}; recorded observables must be finite."
         )
-    return [float(x) for x in a]
+    return [float(x) for x in real]
 
 
 def record(result: Any, observable_names: list[str] | None = None, *,
@@ -94,4 +110,6 @@ def record(result: Any, observable_names: list[str] | None = None, *,
     if states_artifact_path is not None:
         payload["states_artifact"] = states_artifact_path
 
-    print(json.dumps(payload))
+    # allow_nan=False: any non-finite that slipped through (e.g. in `times`)
+    # raises here rather than emitting invalid JSON.
+    print(json.dumps(payload, allow_nan=False))

--- a/marqov/qutip/record.py
+++ b/marqov/qutip/record.py
@@ -1,0 +1,97 @@
+"""Capture a qutip.solver.Result into the script-executor stdout-JSON contract.
+
+Invariants (spec §7): .states NEVER go through stdout (offload or hard-fail);
+stochastic (mcsolve) runs MUST carry seeds or they are not Capsule-reproducible.
+Verified on qutip 5.3.0 — see plan header for the API facts this relies on.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import numpy as np
+
+
+def _is_stochastic(result: Any) -> bool:
+    # mcsolve carries .num_trajectories; mesolve/sesolve do not. stats["solver"]
+    # is "Master Equation Evolution" for BOTH, so it cannot discriminate.
+    return hasattr(result, "num_trajectories")
+
+
+def _seed_to_str(s: Any) -> str:
+    # result.seeds are numpy SeedSequence; int(s) raises. The reusable value is
+    # s.entropy (128-bit int) — emit as a STRING to survive JS/jsonb float64.
+    # Verified 5.3.0: seeds=[int(entropy)] reproduces mcsolve exactly.
+    entropy = getattr(s, "entropy", None)
+    if entropy is None:  # not a SeedSequence -> fail clearly, don't int() it
+        raise ValueError(f"cannot serialise seed of type {type(s).__name__}")
+    return str(entropy)
+
+
+def _coerce_series(arr: Any, name: str) -> list[float]:
+    a = np.asarray(arr)
+    if np.iscomplexobj(a):
+        scale = max(1.0, float(np.abs(a.real).max())) if a.size else 1.0
+        imag_max = float(np.abs(a.imag).max()) if a.size else 0.0
+        if imag_max <= 1e-6 * scale:  # max(relative 1e-6, absolute 1e-6 via scale>=1 floor)
+            return [float(x.real) for x in a]
+        raise ValueError(
+            f"observable '{name}' has genuinely complex expectation values "
+            "(non-Hermitian operator). The MVP records real observables only; "
+            "use a Hermitian operator, or await the {re, im} schema decision (OD-2)."
+        )
+    return [float(x) for x in a]
+
+
+def record(result: Any, observable_names: list[str] | None = None, *,
+           states_artifact_path: str | None = None) -> None:
+    """Serialise `result` and print one JSON object to stdout.
+
+    Observable names: explicit `observable_names` wins; otherwise the keys of a
+    dict `e_ops` (via result.e_data) are used; otherwise obs_0, obs_1, ....
+    """
+    states = getattr(result, "states", None)
+    if states is not None and len(states) > 0 and states_artifact_path is None:
+        raise ValueError(
+            "result.states are present but no states_artifact_path was given. "
+            "Density matrices must be offloaded by reference, never serialised "
+            "to stdout. Pass states_artifact_path=... or drop states."
+        )
+
+    seeds = getattr(result, "seeds", None)
+    if _is_stochastic(result) and not seeds:
+        raise ValueError(
+            "stochastic solver (mcsolve) result has no seeds; an unseeded run is "
+            "not Capsule-reproducible. Reuse a prior result's .seeds."
+        )
+
+    times = [float(t) for t in result.times]
+    expect = result.expect if result.expect is not None else []
+
+    if observable_names is not None:
+        names = observable_names
+    else:
+        edata = getattr(result, "e_data", None)
+        if isinstance(edata, dict) and len(edata) == len(expect) \
+                and all(isinstance(k, str) for k in edata):
+            names = list(edata.keys())          # user passed e_ops as a dict
+        else:
+            names = [f"obs_{i}" for i in range(len(expect))]
+    if len(names) != len(expect):
+        raise ValueError(
+            f"observable_names has {len(names)} entries but result has "
+            f"{len(expect)} observables."
+        )
+    observables = {n: _coerce_series(a, n) for n, a in zip(names, expect)}
+
+    payload: dict[str, Any] = {
+        "result_type": "open-system-dynamics",
+        "times": times,
+        "observables": observables,
+    }
+    if seeds:
+        payload["seeds"] = [_seed_to_str(s) for s in seeds]
+    if states_artifact_path is not None:
+        payload["states_artifact"] = states_artifact_path
+
+    print(json.dumps(payload))

--- a/marqov/qutip/record.py
+++ b/marqov/qutip/record.py
@@ -30,11 +30,24 @@ def _seed_to_str(s: Any) -> str:
 
 def _coerce_series(arr: Any, name: str) -> list[float]:
     a = np.asarray(arr)
+    # Reject non-finite FIRST, on the raw array — before the complex gate below.
+    # np.isfinite on a complex array is False when EITHER component is non-finite,
+    # so this catches a NaN/Inf hiding in the imaginary part, which would otherwise
+    # slip through the gate (NaN > tol is False) and be silently dropped by taking
+    # a.real. NaN/Inf are also invalid JSON. Fail here, naming the index; never
+    # null-substitute — a decay curve with holes reads as data.
+    nonfinite = np.where(~np.isfinite(a))[0] if a.size else np.empty(0, dtype=int)
+    if nonfinite.size:
+        raise ValueError(
+            f"observable '{name}' has a non-finite value (NaN/Inf) at index "
+            f"{int(nonfinite[0])}; recorded observables must be finite."
+        )
     if np.iscomplexobj(a):
-        # Tolerance is RELATIVE to the max |real| with an absolute floor of 1e-6
-        # (scale >= 1.0). Note: for an observable decaying toward zero the floor
-        # dominates, so this is effectively an absolute 1e-6 there — acceptable
-        # because a true residual imaginary part at that scale is numerical noise.
+        # Tolerance anchor is the SERIES MAXIMUM |real| (global over the series,
+        # not per-point), with an absolute 1e-6 floor. For a curve decaying to
+        # zero the floor holds the tolerance at 1e-6 across all samples rather
+        # than tightening toward the tail and rejecting numerical noise there —
+        # a deliberate choice. Hard-fail on a genuinely complex observable.
         scale = max(1.0, float(np.abs(a.real).max())) if a.size else 1.0
         imag_max = float(np.abs(a.imag).max()) if a.size else 0.0
         if imag_max > 1e-6 * scale:
@@ -43,20 +56,8 @@ def _coerce_series(arr: Any, name: str) -> list[float]:
                 "(non-Hermitian operator). The MVP records real observables only; "
                 "use a Hermitian operator, or await the {re, im} schema decision (OD-2)."
             )
-        real = a.real
-    else:
-        real = a
-    # NaN/Inf are not valid JSON — json.dumps emits bare NaN/Infinity tokens that
-    # no browser JSON parser accepts. Fail at emit, naming the offending index,
-    # rather than shipping an unparseable artifact (a decay curve with holes reads
-    # as data). Never silently substitute null.
-    nonfinite = np.where(~np.isfinite(real))[0] if real.size else np.empty(0, dtype=int)
-    if nonfinite.size:
-        raise ValueError(
-            f"observable '{name}' has a non-finite value (NaN/Inf) at index "
-            f"{int(nonfinite[0])}; recorded observables must be finite."
-        )
-    return [float(x) for x in real]
+        return [float(x.real) for x in a]
+    return [float(x) for x in a]
 
 
 def record(result: Any, observable_names: list[str] | None = None, *,
@@ -81,7 +82,14 @@ def record(result: Any, observable_names: list[str] | None = None, *,
             "not Capsule-reproducible. Reuse a prior result's .seeds."
         )
 
-    times = [float(t) for t in result.times]
+    times_arr = np.asarray(result.times)
+    bad_t = np.where(~np.isfinite(times_arr))[0] if times_arr.size else np.empty(0, dtype=int)
+    if bad_t.size:
+        raise ValueError(
+            f"times has a non-finite value (NaN/Inf) at index {int(bad_t[0])}; "
+            "check the tlist passed to the solver."
+        )
+    times = [float(t) for t in times_arr]
     expect = result.expect if result.expect is not None else []
 
     if observable_names is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "ruff>=0.1.0",
     "mypy>=1.8.0",
+    # Test-only: exercises marqov.qutip.record's mesolve/mcsolve integration
+    # tests (tests/qutip/test_record.py). Not a runtime dependency — record.py
+    # duck-types the qutip Result and never imports qutip itself.
+    "qutip>=5.3.0,<6.0.0",
 ]
 qiskit = [
     "qiskit>=1.0.0",

--- a/tests/qutip/test_record.py
+++ b/tests/qutip/test_record.py
@@ -16,6 +16,7 @@ def test_record_emits_times_and_observables():
         record(_fake([0.0, 1.0], [np.array([1.0, 0.5])]), observable_names=["sz"])
     out = json.loads(buf.getvalue())
     assert out["result_type"] == "open-system-dynamics"
+    assert out["schema_version"] == 1  # required for the platform chart renderer
     assert out["observables"]["sz"] == [1.0, 0.5]
 
 def test_record_rejects_states_without_offload():

--- a/tests/qutip/test_record.py
+++ b/tests/qutip/test_record.py
@@ -36,6 +36,25 @@ def test_record_coerces_near_real_complex():
         record(_fake([0.0], [np.array([1.0 + 1e-9j])]), observable_names=["sz"])
     assert json.loads(buf.getvalue())["observables"]["sz"] == [1.0]
 
+def test_record_rejects_nonfinite_observable():
+    # NaN/Inf are invalid JSON; must fail at emit, naming the offending index,
+    # never silently substitute null.
+    with pytest.raises(ValueError, match="non-finite.*index 1"):
+        record(_fake([0.0, 1.0], [np.array([1.0, np.nan])]), observable_names=["sz"])
+
+def test_record_rejects_inf_observable():
+    with pytest.raises(ValueError, match="non-finite"):
+        record(_fake([0.0], [np.array([np.inf])]), observable_names=["sz"])
+
+def test_record_output_is_strict_json_no_nan_tokens():
+    # allow_nan=False guarantees the emitted text is standards-compliant JSON
+    # (json.loads with parse_constant that rejects would also pass).
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        record(_fake([0.0, 1.0], [np.array([1.0, 0.5])]), observable_names=["sz"])
+    text = buf.getvalue()
+    assert "NaN" not in text and "Infinity" not in text
+
 def test_record_real_mesolve_integration():
     pytest.importorskip("qutip")
     from qutip import basis, sigmaz, sigmam, mesolve

--- a/tests/qutip/test_record.py
+++ b/tests/qutip/test_record.py
@@ -78,7 +78,11 @@ def test_record_mcsolve_seeds_round_trip_reproduces():
     from qutip import basis, sigmaz, sigmam, mcsolve
     from numpy.random import SeedSequence
     args = (sigmaz(), basis(2, 0), np.linspace(0, 1, 3))
-    kw = dict(c_ops=[0.1 * sigmam()], e_ops=[sigmaz()], ntraj=4)
+    # map=serial is REQUIRED here, not test hygiene: seed->trajectory assignment is
+    # NOT stable under the parallel map, so seeded mcsolve reproduces bit-identically
+    # ONLY serially. Measured on qutip 5.3: serial max|Δ|=0 every run; parallel max|Δ|
+    # up to 2.0 (a different trajectory set). See the caveat in record.py.
+    kw = dict(c_ops=[0.1 * sigmam()], e_ops=[sigmaz()], ntraj=4, options={"map": "serial"})
     res = mcsolve(*args, **kw)
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):

--- a/tests/qutip/test_record.py
+++ b/tests/qutip/test_record.py
@@ -1,0 +1,67 @@
+import io, json, contextlib
+import numpy as np
+import pytest
+from types import SimpleNamespace
+from marqov.qutip.record import record
+
+def _fake(times, expect, states=None, seeds=None, stochastic=False):
+    ns = SimpleNamespace(times=np.asarray(times), expect=expect, states=states, seeds=seeds)
+    if stochastic:
+        ns.num_trajectories = 4
+    return ns
+
+def test_record_emits_times_and_observables():
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        record(_fake([0.0, 1.0], [np.array([1.0, 0.5])]), observable_names=["sz"])
+    out = json.loads(buf.getvalue())
+    assert out["result_type"] == "open-system-dynamics"
+    assert out["observables"]["sz"] == [1.0, 0.5]
+
+def test_record_rejects_states_without_offload():
+    with pytest.raises(ValueError, match="states"):
+        record(_fake([0.0], [np.array([1.0])], states=[object()]))
+
+def test_record_rejects_unseeded_stochastic():
+    with pytest.raises(ValueError, match="seed"):
+        record(_fake([0.0], [np.array([1.0])], seeds=None, stochastic=True))
+
+def test_record_rejects_genuinely_complex_observable():
+    with pytest.raises(ValueError, match="complex"):
+        record(_fake([0.0], [np.array([0.0 + 1.0j])]), observable_names=["sm"])
+
+def test_record_coerces_near_real_complex():
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        record(_fake([0.0], [np.array([1.0 + 1e-9j])]), observable_names=["sz"])
+    assert json.loads(buf.getvalue())["observables"]["sz"] == [1.0]
+
+def test_record_real_mesolve_integration():
+    pytest.importorskip("qutip")
+    from qutip import basis, sigmaz, sigmam, mesolve
+    res = mesolve(sigmaz(), basis(2, 0), np.linspace(0, 1, 5),
+                  c_ops=[0.1 * sigmam()], e_ops=[sigmaz()])
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        record(res, observable_names=["sz"])
+    out = json.loads(buf.getvalue())
+    assert len(out["times"]) == 5 and len(out["observables"]["sz"]) == 5
+    assert "seeds" not in out
+
+def test_record_mcsolve_seeds_round_trip_reproduces():
+    pytest.importorskip("qutip")
+    from qutip import basis, sigmaz, sigmam, mcsolve
+    from numpy.random import SeedSequence
+    args = (sigmaz(), basis(2, 0), np.linspace(0, 1, 3))
+    kw = dict(c_ops=[0.1 * sigmam()], e_ops=[sigmaz()], ntraj=4)
+    res = mcsolve(*args, **kw)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        record(res, observable_names=["sz"])
+    seeds_json = json.loads(buf.getvalue())["seeds"]
+    assert all(isinstance(s, str) for s in seeds_json)  # 128-bit-safe as strings
+    # Re-run from the captured seeds. Verified 5.3.0: reproduction is EXACT
+    # (max|Δ|=0.0); seeds= accepts SeedSequence or int. Do NOT loosen this.
+    reused = [SeedSequence(int(s)) for s in seeds_json]
+    res2 = mcsolve(*args, seeds=reused, **kw)
+    np.testing.assert_allclose(res.expect[0], res2.expect[0])

--- a/tests/qutip/test_record.py
+++ b/tests/qutip/test_record.py
@@ -46,14 +46,19 @@ def test_record_rejects_inf_observable():
     with pytest.raises(ValueError, match="non-finite"):
         record(_fake([0.0], [np.array([np.inf])]), observable_names=["sz"])
 
-def test_record_output_is_strict_json_no_nan_tokens():
-    # allow_nan=False guarantees the emitted text is standards-compliant JSON
-    # (json.loads with parse_constant that rejects would also pass).
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        record(_fake([0.0, 1.0], [np.array([1.0, 0.5])]), observable_names=["sz"])
-    text = buf.getvalue()
-    assert "NaN" not in text and "Infinity" not in text
+def test_record_rejects_nonfinite_times():
+    # times gets the same named + indexed validation (a bad tlist/linspace is the
+    # likely source, and it isn't covered by the observable coercion path).
+    with pytest.raises(ValueError, match="times.*index 1"):
+        record(_fake([0.0, np.inf], [np.array([1.0, 0.5])]), observable_names=["sz"])
+
+def test_record_rejects_nonfinite_in_imaginary_part():
+    # Regression: a NaN in the IMAGINARY part must be rejected, not slipped
+    # through the complex gate (NaN > tol is False) and then silently dropped by
+    # taking .real. The finite check runs on the raw complex array first.
+    with pytest.raises(ValueError, match="non-finite"):
+        record(_fake([0.0, 1.0], [np.array([1.0 + 0j, complex(0.5, float("nan"))])]),
+               observable_names=["sz"])
 
 def test_record_real_mesolve_integration():
     pytest.importorskip("qutip")


### PR DESCRIPTION
## `marqov.qutip.record` — open-system-dynamics result helper

Ships the SDK counterpart to the QuTiP open-systems integration that's already live on the platform (routing `marqov-platform#1375`, chart renderer `#1390`). The shipped example `examples/qutip_open_system.py` names `marqov.qutip.record(...)` as the ergonomic way to emit the result contract *"once the SDK ships it"* — this ships it.

### What it does

One call turns a QuTiP solver `Result` (`mesolve` / `sesolve` / `mcsolve`) into the platform's `open-system-dynamics` **v1** stdout-JSON contract:

```python
from marqov.qutip.record import record
res = mesolve(H, psi0, tlist, c_ops=[...], e_ops=[sigmaz(), sigmax()])
record(res, ["sigma_z", "sigma_x"])   # prints {result_type, schema_version, times, observables, seeds?}
```

### Why it's more than sugar (guardrails a hand-built dict gets wrong)

- **No density matrices on stdout** — `.states` present without an offload path is refused, not serialised.
- **Reproducibility** — unseeded `mcsolve` is rejected (not Capsule-reproducible); seeds are emitted as **strings** to survive JSON float precision. (Bit-exact reproduction requires `options={"map": "serial"}` — pinned by a test.)
- **Validity** — non-finite (NaN/Inf) and genuinely-complex expectation values are rejected with a clear, indexed error rather than silently coerced or null-filled.

### Contract conformance

Emits exactly the fields the platform's `2026-07-25` open-system-dynamics display-contract spec requires (`result_type`, `schema_version: 1`, `times`, `observables`, optional `seeds`). The spec was written around this emitter — invariant **I4** cites `record()`'s `rel-1e-6 / abs-1e-6-floor` tolerance and the contract's `seeds: array[string]` matches its serialization. Also supports contract invariant **I2** (producer declares `result_type`+`schema_version`; the worker should stop inferring).

### Dependency / risk

- **Test-only dep.** `qutip>=5.3.0,<6.0.0` added to the `dev` extra. `record.py` **duck-types** the `Result` and never imports qutip at runtime — the SDK's runtime footprint is unchanged.
- **11 tests pass** (`tests/qutip/`), incl. real `mesolve`/`mcsolve` integration.

### Scope notes

- **Lockfile intentionally not regenerated.** CI installs from extras (`uv pip install -e ".[all,dev]"`), not from `uv.lock`, and a full `uv lock` also pulls in the currently-unlocked `cudaq` extra tree — best handled as separate lockfile housekeeping.
- Reconstructed as a clean branch off current `main` (the original `feat/qutip-lindblad-phase-a` predates the `marqov.platform` client / CUDA-Q / workflow-isolation work); the original spike scripts are omitted.

### Follow-up (not in this PR)

After merge: cut an SDK release (e.g. `0.3.2`) and bump the platform `marqov` pin so `marqov.qutip.record` is importable in the worker venv. Until then the example's raw-`json.dumps` path remains the working default — nothing is broken, this just makes the ergonomic path real.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional subpackage with no runtime QuTiP dependency; behavior is additive stdout JSON for script executors, with strict validation that fails fast rather than mutating platform data.
> 
> **Overview**
> Adds **`marqov.qutip.record`**, a helper that prints one **`open-system-dynamics` v1** JSON object to stdout from a duck-typed QuTiP solver `Result` (`mesolve`/`sesolve`/`mcsolve`). Callers use `record(result, observable_names)` (or inferred names from `e_data` / `obs_*`) instead of hand-building the platform contract.
> 
> **Guardrails** are enforced at emit time: non-empty `.states` without `states_artifact_path` is rejected; unseeded stochastic (`mcsolve`) results are rejected; `times` and observables must be finite; genuinely complex expectations fail (near-real imaginary parts are coerced); `mcsolve` seeds are serialized as strings from `SeedSequence.entropy`. Optional `states_artifact` and `seeds` are included when applicable.
> 
> **`qutip>=5.3.0`** is added only to the **`dev`** extra for integration tests; runtime does not import QuTiP. **CHANGELOG** documents the feature under `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5682254986c3ceba15549c5d052f8b92632df41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->