### PR TITLE
docs: credit David Ryan and Anastasia Marchenkova as co-creators

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,11 @@
+# Authors
+
+The Marqov SDK was created by:
+
+- **David Ryan** — [@ddri](https://github.com/ddri)
+- **Anastasia Marchenkova** — [@amarchenkova](https://github.com/amarchenkova)
+
+## Contributors
+
+With thanks to everyone who has contributed to the SDK — see the full list at
+https://github.com/marqov-dev/marqov-sdk/graphs/contributors

--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the executor interface spec, canonica
 
 Bounty issues are open through [unitaryHACK 2026](https://unitaryhack.dev) — see the [issues page](https://github.com/marqov-dev/marqov-sdk/issues) for what's available.
 
+## Authors
+
+This project was created by **David Ryan** ([@ddri](https://github.com/ddri)) and **Anastasia Marchenkova** ([@amarchenkova](https://github.com/amarchenkova)), with contributions from the [community](https://github.com/marqov-dev/marqov-sdk/graphs/contributors).
+
+See [AUTHORS.md](AUTHORS.md) for details.
+
 ## License
 
 [Apache 2.0](LICENSE)


### PR DESCRIPTION
Adds `AUTHORS.md` and a short **Authors** section to the README, crediting the SDK's co-creators — David Ryan ([@ddri](https://github.com/ddri)) and Anastasia Marchenkova ([@amarchenkova](https://github.com/amarchenkova)) — with a pointer to the contributors graph for the community.

Docs-only; no code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no code, configuration, or security impact.
> 
> **Overview**
> Adds project attribution documentation with no runtime or API impact.
> 
> Introduces **`AUTHORS.md`** listing David Ryan and Anastasia Marchenkova as creators and pointing readers to the GitHub contributors graph for community credit.
> 
> Inserts an **Authors** section in **`README.md`** (between Contributing and License) with the same co-creator credit, a link to the contributors page, and a cross-reference to **`AUTHORS.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87826934a18b7cf0221c3ca07301a58fcf154b44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->