### PR TITLE
ci: stop running CI twice per PR (push wildcard → main only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: CI
 on:
-  push:
-    branches: ["**"]
+  # PRs run via pull_request; direct pushes run only on main (post-merge).
+  # Previously `push: branches: ["**"]` + `pull_request:` ran CI TWICE on every
+  # PR commit (once per event) and also ran on every throwaway branch push.
   pull_request:
+    branches: [main]
+  push:
+    branches: [main]
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
`on: push: branches: ["**"]` + `pull_request:` → `pull_request: [main]` + `push: [main]`.

## Why
Every commit on a PR branch fired **both** the `push` and `pull_request` events, running the full suite twice; `["**"]` also ran CI on every throwaway branch with no PR. Confirmed in the run log (same commits showing `pull_request + push`).

## Effect
One run per PR commit instead of two. Post-merge CI still runs (`push: [main]`). No `concurrency` group here yet — that's a separate follow-up if you want it (this repo would benefit).

## Failure mode
A PR targeting a non-`main` base would no longer trigger CI (pull_request now scoped to `[main]`). sdk targets main, so this is intended. **Rollback:** restore the previous trigger block.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only trigger change; no application code or test logic changes, with the intended tradeoff that PRs against non-`main` bases no longer run this workflow.
> 
> **Overview**
> **CI trigger policy** in `.github/workflows/ci.yml` is narrowed so the full suite no longer runs twice for the same PR commit and no longer runs on every branch push.
> 
> `push` is limited to **`main`** instead of **`["**"]`**, and **`pull_request`** is scoped to PRs targeting **`main`**. PR updates still run via `pull_request`; merges to `main` still run via `push`. Throwaway branch pushes without a PR to `main` no longer start CI.
> 
> Comments in the workflow document the old double-fire behavior. **Test jobs and steps are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a436d36a92fcc52073ed6c493395df98c04690d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->