### PR TITLE
ci(security): SHA-pin gh-action-pypi-publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with: { name: dist, path: dist/ }
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -43,4 +43,4 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with: { name: dist, path: dist/ }
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2


### PR DESCRIPTION
## What
Both `pypa/gh-action-pypi-publish@release/v1` → `@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2` (commit SHA of the latest release).

## Why (live risk, not a public-flip item)
Those steps run with `id-token: write` for PyPI trusted publishing. `@release/v1` is a **moving ref** — if that action's tag is repointed to malicious code (cf. the March 2025 `tj-actions/changed-files` compromise), it runs inside a job that can mint a PyPI OIDC token. Pinning to an immutable SHA closes that. This is exposure at *current* visibility.

## Note
`# v1.14.2` comment keeps it human-readable; a Dependabot/Renovate `github-actions` updater will bump the SHA + comment together. Pinning without an updater rots — worth enabling one (separate).

## Failure mode
None functional — same action, immutable ref. **Rollback:** restore `@release/v1`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no app logic impact; same action version, fixed ref reduces supply-chain risk in OIDC-enabled publish jobs.
> 
> **Overview**
> **Pins** `pypa/gh-action-pypi-publish` in the release workflow from the moving `@release/v1` ref to commit `dc37677…` (**v1.14.2**), in both **TestPyPI** (`workflow_dispatch`) and **production PyPI** (tag) publish jobs.
> 
> This is a supply-chain hardening change: those jobs run with **`id-token: write`** for trusted publishing, so an immutable SHA avoids running unexpected code if the action’s release tag were ever repointed. Behavior should stay the same; the `# v1.14.2` comment keeps the pin readable for future bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd7a296b76ed7751253c8fb87a666569ad5bfe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->