### PR TITLE
ci: add "CI Success" aggregation job (future required check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,26 @@ jobs:
         run: uv pip install --system -e ".[cudaq,dev]"
       - name: CUDA-Q executor tests (incl. real qpp-cpu run)
         run: pytest tests/test_cudaq_executor.py -q
+
+  # Single required status check — the ruleset requires only "CI Success", so the
+  # required context stays stable if the job set ever changes.
+  #
+  # INVARIANT: every job above must be listed in `needs:` here. A job missing here
+  # can fail while CI Success stays green and the ruleset stays satisfied — its
+  # failures become invisible. Add new jobs to `needs:` in the same PR.
+  #
+  # `if: always()` runs this even when an upstream job fails; the step then fails
+  # unless EVERY needed result is 'success'. A naive `success()` gate would go
+  # GREEN when an upstream job was skipped.
+  ci-success:
+    name: CI Success
+    if: always()
+    needs: [test, test-cudaq]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail unless every required job succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo "::error::A required job did not succeed — results: ${{ join(needs.*.result, ', ') }}"
+          exit 1


### PR DESCRIPTION
Step 1 of aligning sdk's merge gate with platform & capsule.

## What
Adds a `CI Success` job that `needs: [test, test-cudaq]` and fails unless both succeed — using `if: always()` + an explicit `contains(needs.*.result, ...)` guard (not `success()`, which goes green on a skipped upstream).

## Why
sdk's `main` is on *classic* branch protection with **1 review required but no required status check** — a reviewed-but-red PR can merge to the published SDK. This job gives a single stable required context.

## Two-step
This PR only **adds the job**. After it merges and `CI Success` reports green on a merged commit, I'll swap classic protection for a ruleset (**PR required · CI Success required · 0 approvals · non-strict**) — then all three repos share one shape, and the human gate lives where it's irreversible (the `pypi` publish reviewer, already enabled here).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change with no application or runtime impact; the main risk is operational if new jobs are added without updating `needs:` on `ci-success`.
> 
> **Overview**
> Adds a **`CI Success`** workflow job that depends on **`test`** and **`test-cudaq`** and exposes one GitHub status context for future branch rulesets, so merge protection does not have to list every job by name.
> 
> The job uses **`if: always()`** and fails when any needed job is **failure**, **cancelled**, or **skipped**—avoiding a **`success()`**-only gate that could stay green if an upstream job was skipped. Inline comments document the invariant that every CI job must stay in **`needs:`** so failures cannot be hidden behind a green aggregator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604502ea9dc128cb73b0f640635ce0071aecbb33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->