### PR TITLE
fix(device): make MarqovDevice.run event-loop-safe on real QPUs (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ release.
   CZ/XY) and raises `ValueError` otherwise. Addresses the verbatim gap
   identified in the device/executor parity audit (marqov-sdk#66).
 
+### Fixed
+
+- **`MarqovDevice.run` is now event-loop-safe on real QPUs.** Braket's
+  `AwsQuantumTask.result()` polls via `run_until_complete()`, which raised
+  *"This event loop is already running"* when `run()` was called from within a
+  running event loop (e.g. an async experiment runner driving a real QPU). The
+  blocking Braket call is now offloaded to a worker thread that has its own
+  event loop when a running loop is detected. Simulators were unaffected.
+  (marqov-sdk#67)
+
 ## [0.3.1] — 2026-07-25
 
 ### Fixed

--- a/marqov/device.py
+++ b/marqov/device.py
@@ -2,8 +2,40 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from marqov.backends import is_azure, is_braket, is_ibm, is_simulator
 from marqov.circuits import Circuit
+
+
+def _run_loop_safe(fn):
+    """Run a blocking callable safely regardless of the caller's async context.
+
+    Braket's ``AwsQuantumTask.result()`` drives its polling via
+    ``asyncio.get_event_loop().run_until_complete(...)``, which raises
+    "This event loop is already running" when called from within a running loop
+    (e.g. an async experiment runner). If a loop is running in this thread, run
+    ``fn`` in a worker thread that has its own event loop; otherwise call it
+    directly. See marqov-sdk#67.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return fn()  # no running loop — safe to call directly
+
+    import concurrent.futures
+
+    def _worker():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            return fn()
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        return ex.submit(_worker).result()
 
 
 class MarqovDevice:
@@ -281,11 +313,17 @@ class MarqovDevice:
 
             try:
                 disable_rewiring = kwargs.get("disable_qubit_rewiring", False)
-                task = device.run(
-                    native_circuit, s3_folder, shots=shots,
-                    disable_qubit_rewiring=disable_rewiring,
-                )
-                result = task.result()
+
+                def _submit_and_wait():
+                    task = device.run(
+                        native_circuit, s3_folder, shots=shots,
+                        disable_qubit_rewiring=disable_rewiring,
+                    )
+                    return task.result()
+
+                # Braket's result() polls via run_until_complete; run it
+                # loop-safe so this works from an async runner too (marqov-sdk#67).
+                result = _run_loop_safe(_submit_and_wait)
                 counts = dict(result.measurement_counts)
                 if not counts:
                     # Some QPU backends (e.g. IonQ Forte-1) return measurement_probabilities

--- a/tests/test_device_integration.py
+++ b/tests/test_device_integration.py
@@ -1,5 +1,7 @@
 """Integration tests for MarqovDevice type conversion and execution."""
 
+import asyncio
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -222,3 +224,46 @@ class TestBraketVerbatim:
         with patch.object(MarqovDevice, "_get_provider_device", return_value=mock_aws):
             device.run(circuit, shots=100)
         assert "StartVerbatimBox" not in self._submitted_op_types(mock_aws)
+
+
+class _LoopBoundTask:
+    """Mimics Braket's AwsQuantumTask.result(): drives a coroutine via
+    asyncio.get_event_loop().run_until_complete — which raises inside a running
+    loop unless the caller offloads to a worker thread with its own loop.
+    """
+
+    def result(self):
+        async def _poll():
+            return SimpleNamespace(measurement_counts={"0": 100})
+
+        return asyncio.get_event_loop().run_until_complete(_poll())
+
+
+class TestBraketEventLoopSafety:
+    """MarqovDevice.run must be callable from within a running event loop on a
+    real-QPU backend, where Braket's result() uses run_until_complete internally
+    (marqov-sdk#67). Simulators don't hit this — only real Braket QPU tasks.
+    """
+
+    def _rigetti_device(self) -> MarqovDevice:
+        return MarqovDevice(
+            "rigetti-cepheus-1",
+            {
+                "backend": "rigetti-cepheus-1",
+                "device_arn": (
+                    "arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q"
+                ),
+                "s3_bucket": "my-bucket",
+                "s3_prefix": "my-prefix",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_is_safe_from_within_running_loop(self) -> None:
+        device = self._rigetti_device()
+        mock_aws = MagicMock()
+        mock_aws.run.return_value = _LoopBoundTask()
+        # Called synchronously from inside this async test — i.e. a running loop.
+        with patch.object(MarqovDevice, "_get_provider_device", return_value=mock_aws):
+            counts = device.run(Circuit().rx(0.5, 0), shots=100)
+        assert counts == {"0": 100}


### PR DESCRIPTION
## Summary

Makes `MarqovDevice.run` **event-loop-safe** on real Braket QPU backends. Braket's `AwsQuantumTask.result()` polls via `run_until_complete()`, which raises *"This event loop is already running"* when `run()` is called from within a running event loop — e.g. an async experiment runner (`run_srb`) driving a real QPU. The blocking Braket call is now offloaded to a worker thread (with its own event loop) when a running loop is detected; the direct path is unchanged when no loop is running.

Fixes #67. For the **0.4.0** milestone (companion to the verbatim change, #68).

## Why it matters

This is the second half of "make `MarqovDevice` actually drivable for real QMT runs." Verbatim (#68) makes Rigetti produce a real decay; this makes the async SRB path able to *retrieve* the results without crashing. Surfaced while running the verbatim SRB validation on Cepheus — the circuits submitted fine, but every result-fetch threw the loop error.

## Changes

- `device.py` — `_run_loop_safe()` helper + wired into the Braket branch
- `tests/test_device_integration.py` — a test that reproduces the collision (a fake task whose `result()` uses `run_until_complete`, like Braket's) and asserts `run()` works from within a running loop
- `CHANGELOG.md` — 0.4.0 Fixed entry

## Note

Merging does not release anything — the PyPI publish is tag-gated (`v*`).
