### PR TITLE
feat(executors): expose device execution windows on DeviceStatus (Braket serializer)

### DIFF
--- a/marqov/executors/base.py
+++ b/marqov/executors/base.py
@@ -50,6 +50,10 @@ class DeviceStatus:
     status: str  # "online" | "offline" | "maintenance"
     queue_depth: int | None
     queue_time_seconds: int | None
+    # Device execution windows (when the backend reports them), as a portable JSON-friendly shape:
+    # [{"executionDay": <ExecutionDay.value>, "windowStartHour": "HH:MM:SS", "windowEndHour": "HH:MM:SS"}], UTC.
+    # None = unknown / not-applicable / serialize-error; [] = device reported none.
+    execution_windows: list[dict[str, str]] | None = None
 
     @staticmethod
     def always_online() -> "DeviceStatus":

--- a/marqov/executors/braket.py
+++ b/marqov/executors/braket.py
@@ -76,6 +76,30 @@ class BraketExecutorConfig:
     timeout_seconds: float | None = None
 
 
+def _serialize_execution_windows(device: "AwsDevice") -> list[dict[str, str]] | None:
+    """Serialize a Braket device's executionWindows into a portable, JSON-friendly shape.
+
+    Shape: ``[{"executionDay": <ExecutionDay .value, e.g. "Everyday">, "windowStartHour": "HH:MM:SS",
+    "windowEndHour": "HH:MM:SS"}]`` — always ``.value`` (never ``.name``), sub-second truncated via
+    strftime, times UTC. ``[]`` (device reports no windows) is preserved distinct from ``None``.
+
+    Fail-safe: ANY failure (missing property, unexpected shape) returns ``None``, so a malformed payload
+    can never blank a device's availability downstream. Reads the already-fetched ``device`` — no extra
+    GetDevice call. Deliberately does NOT feed ``is_device_available`` (advisory data only).
+    """
+    try:
+        return [
+            {
+                "executionDay": w.executionDay.value,
+                "windowStartHour": w.windowStartHour.strftime("%H:%M:%S"),
+                "windowEndHour": w.windowEndHour.strftime("%H:%M:%S"),
+            }
+            for w in device.properties.service.executionWindows
+        ]
+    except Exception:
+        return None
+
+
 class BraketExecutor(BaseExecutor):
     """Execute circuits on AWS Braket devices.
 
@@ -322,7 +346,12 @@ class BraketExecutor(BaseExecutor):
             except Exception:
                 pass
 
-            return DeviceStatus(status=status, queue_depth=queue_depth, queue_time_seconds=queue_time_seconds)
+            return DeviceStatus(
+                status=status,
+                queue_depth=queue_depth,
+                queue_time_seconds=queue_time_seconds,
+                execution_windows=_serialize_execution_windows(device),
+            )
         except Exception:
             return DeviceStatus(status="maintenance", queue_depth=None, queue_time_seconds=None)
 

--- a/tests/test_braket_execution_windows.py
+++ b/tests/test_braket_execution_windows.py
@@ -1,0 +1,98 @@
+"""Tests for Braket execution-window serialization — the JSON shape consumed by downstream availability tooling.
+
+The serialized shape is a single contract with that consumer; a drift here (wrong token, wrong time
+format, or dropping the []/None distinction) would silently break the advisory downstream.
+"""
+
+from datetime import time
+from types import SimpleNamespace
+
+import pytest
+from braket.device_schema.device_execution_window import DeviceExecutionWindow, ExecutionDay
+
+from marqov.executors.base import DeviceStatus
+from marqov.executors.braket import (
+    BraketExecutor,
+    BraketExecutorConfig,
+    _serialize_execution_windows,
+)
+
+THE_TEN = {
+    "Everyday", "Weekdays", "Weekend",
+    "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
+}
+
+
+def _device(windows: object) -> SimpleNamespace:
+    return SimpleNamespace(properties=SimpleNamespace(service=SimpleNamespace(executionWindows=windows)))
+
+
+def test_serializes_value_and_hhmmss() -> None:
+    # NB: the enum MEMBER is WEEKENDS but its .value is "Weekend" — we must serialize .value, not .name.
+    windows = [
+        DeviceExecutionWindow(executionDay=ExecutionDay.WEEKENDS, windowStartHour=time(0, 0, 0), windowEndHour=time(6, 59, 0)),
+    ]
+    assert _serialize_execution_windows(_device(windows)) == [
+        {"executionDay": "Weekend", "windowStartHour": "00:00:00", "windowEndHour": "06:59:00"},
+    ]
+
+
+def test_truncates_subsecond_to_hhmmss() -> None:
+    windows = [
+        DeviceExecutionWindow(executionDay=ExecutionDay.EVERYDAY, windowStartHour=time(0, 0, 0), windowEndHour=time(23, 59, 59, 999999)),
+    ]
+    out = _serialize_execution_windows(_device(windows))
+    assert out is not None and out[0]["windowEndHour"] == "23:59:59"  # not "23:59:59.999999"
+
+
+def test_empty_windows_preserved_as_empty_list() -> None:
+    # [] (device reports none) must stay distinct from None (unknown) — the platform's state model relies on it.
+    assert _serialize_execution_windows(_device([])) == []
+
+
+def test_missing_property_fails_safe_to_none() -> None:
+    class NoProps:
+        @property
+        def properties(self) -> object:
+            raise RuntimeError("device has no properties")
+
+    assert _serialize_execution_windows(NoProps()) is None
+
+
+def test_non_iterable_windows_fails_safe_to_none() -> None:
+    assert _serialize_execution_windows(_device(object())) is None
+
+
+def test_execution_day_enum_has_exactly_the_ten_values() -> None:
+    # A future braket bump that ADDS a member fails this — forcing a re-look before windows silently drift.
+    assert {e.value for e in ExecutionDay} == THE_TEN
+
+
+def test_device_status_defaults_execution_windows_to_none() -> None:
+    assert DeviceStatus(status="online", queue_depth=0, queue_time_seconds=0).execution_windows is None
+    assert DeviceStatus.always_online().execution_windows is None
+
+
+@pytest.mark.asyncio
+async def test_get_status_includes_serialized_windows() -> None:
+    from unittest.mock import patch
+
+    windows = [
+        DeviceExecutionWindow(executionDay=ExecutionDay.EVERYDAY, windowStartHour=time(9, 0, 0), windowEndHour=time(17, 0, 0)),
+    ]
+    device = SimpleNamespace(
+        status="ONLINE",
+        properties=SimpleNamespace(service=SimpleNamespace(executionWindows=windows)),
+        queue_depth=lambda: SimpleNamespace(quantum_tasks={}),
+    )
+    config = BraketExecutorConfig(
+        device_arn="arn:aws:braket:::device/quantum-simulator/amazon/sv1", s3_bucket="b"
+    )
+    with patch("marqov.executors.braket.AwsDevice", return_value=device), \
+        patch("marqov.executors.braket.boto3.Session"), \
+        patch("marqov.executors.braket.AwsSession"):
+        status = await BraketExecutor(config).get_status()
+
+    assert status.execution_windows == [
+        {"executionDay": "Everyday", "windowStartHour": "09:00:00", "windowEndHour": "17:00:00"},
+    ]


### PR DESCRIPTION
Adds `execution_windows` to `DeviceStatus` and a Braket serializer, so downstream tooling can read a device's advertised execution windows in a portable, JSON-friendly shape.

## What
- **`DeviceStatus.execution_windows: list[dict[str, str]] | None`** — additive, defaulted (backward-compatible; existing constructors and `always_online()` get `None`).
- **`_serialize_execution_windows(device)`** in the Braket executor: reads `device.properties.service.executionWindows` on the already-fetched device (no extra `GetDevice`), emitting `[{"executionDay": <ExecutionDay .value, e.g. "Everyday">, "windowStartHour": "HH:MM:SS", "windowEndHour": "HH:MM:SS"}]` — UTC, `.value` (never `.name`), sub-second truncated.
- Wired into `BraketExecutor.get_status()`.

## Safety
- **Fail-safe:** any failure (missing property, unexpected shape) returns `None`, so a malformed payload can never blank a device's availability downstream.
- `[]` (device reports no windows) is preserved **distinct from** `None` (unknown / not applicable).
- **`is_device_available()` is untouched** — this is advisory data only, never an availability gate.

## Tests
`tests/test_braket_execution_windows.py`: `.value`-not-`.name`, sub-second truncation, `[]`≠`None`, the fail-safe path, a `get_status` integration test, and an **enum-drift guard** (`{e.value for e in ExecutionDay}` equals the ten known values, so a future `braket` release that adds a member is a red build rather than a silent coverage gap). Full executor suite stays green.
