### PR TITLE
release: v0.4.0 — pre-tag hygiene (benchmark tracker refs + guard scope)

### DIFF
--- a/benchmarks/raw_sdk/bell_state_ionq.py
+++ b/benchmarks/raw_sdk/bell_state_ionq.py
@@ -9,8 +9,6 @@ COST WARNING: IonQ Forte is expensive!
 - Per-task: $0.30
 - Per-shot: $0.08
 - 100 shots = $0.30 + $8.00 = $8.30 per circuit
-
-Issue: #173
 """
 
 import os

--- a/benchmarks/raw_sdk/bell_state_ionq_aria.py
+++ b/benchmarks/raw_sdk/bell_state_ionq_aria.py
@@ -9,8 +9,6 @@ COST: IonQ Aria is cheaper than Forte!
 - Per-task: $0.30
 - Per-shot: $0.03 (vs $0.08 for Forte)
 - 100 shots = $0.30 + $3.00 = $3.30 per circuit
-
-Issue: #173
 """
 
 import os

--- a/benchmarks/raw_sdk/bell_state_rigetti.py
+++ b/benchmarks/raw_sdk/bell_state_rigetti.py
@@ -7,8 +7,6 @@ Runs on real Rigetti superconducting quantum hardware.
 
 COST WARNING: ~$1.20 per circuit (1000 shots)
 Total estimated cost for 5 runs: ~$6.00
-
-Issue: #171
 """
 
 import os

--- a/tests/test_no_private_references.py
+++ b/tests/test_no_private_references.py
@@ -29,7 +29,7 @@ import re
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
-_SCAN_DIRS = ("marqov", "docs", "tests")
+_SCAN_DIRS = ("marqov", "docs", "tests", "benchmarks")
 _SCAN_SUFFIXES = {".py", ".md", ".rst", ".txt"}
 # This gate file legitimately contains the banned patterns (as regexes), so it must
 # not scan itself.


### PR DESCRIPTION
Pre-tag hygiene follow-up on the v0.4.0 release branch (on top of the already-merged #71).

- Remove stray bare `Issue: #NNN` docstring lines from three `benchmarks/raw_sdk/*.py` — they pointed at an internal tracker (non-resolving for public readers) and shipped in the sdist. They add nothing for a public user.
- Widen the no-private-references guard's `_SCAN_DIRS` to include `benchmarks/`, which previously went unscanned. Guard passes clean with the wider scope.

Wheel/import surface is unchanged (benchmarks ship only in the sdist), so the TestPyPI `import marqov==0.4.0` validation still holds. Tagging `v0.4.0` follows once this is green on main.