### PR TITLE
fix(0.4.1): replayable mcsolve seeds + drop Measure from the verbatim allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to the `marqov` SDK are documented here. This project follow
 still change between minor versions; `1.0.0` is reserved for the first API-stable
 release.
 
+## [Unreleased] — 0.4.1
+
+### Fixed
+
+- **Verbatim compilation no longer allow-lists an explicit `Measure`.** 0.4.0's
+  allowed native set was `{Rx, Rz, CZ, XY, Measure}` and both the error message and
+  the changelog advertised "plus Measure". Braket rejects it: `add_verbatim_box`
+  raises *"cannot measure a subcircuit inside a verbatim box"*. So a caller passing an
+  explicit measurement with `verbatim=True` cleared our validator and then hit an
+  opaque Braket error instead of our actionable one. `Measure` is now excluded in both
+  paths (`MarqovDevice.run` and `BraketExecutor.execute`), and the error names the
+  offending instruction. Braket applies measurement implicitly via `shots`, so an
+  explicit `Measure` was never needed — for randomized benchmarking in particular.
+  (marqov-sdk#66)
+
+- **`marqov.qutip.record` emitted `mcsolve` seeds that did not reproduce the run.**
+  Seeds were serialised as `SeedSequence.entropy` alone. Every trajectory of a
+  single `mcsolve` call is a *spawned child* of one root `SeedSequence`: they all
+  share `entropy` and differ only by `spawn_key`. So the recorded seeds were
+  identical to one another, and a replay collapsed the Monte Carlo ensemble to a
+  single trajectory repeated `ntraj` times — measured **0/20** reproduction on runs
+  containing a collapse.
+
+  Seeds are now serialised as the full `SeedSequence.state` (numpy's own round-trip
+  contract), one JSON object per trajectory:
+
+  ```json
+  {"entropy": "179663937626102255308327548008974693620",
+   "spawn_key": [3], "pool_size": 4, "n_children_spawned": 0}
+  ```
+
+  `entropy` stays a string (128-bit; would lose precision in JS/`jsonb` float64) and
+  `spawn_key` is a list (JSON has no tuple). New public helper
+  **`marqov.qutip.record.seed_from_json`** rebuilds a `SeedSequence` for replay, so
+  callers do not reimplement those conversions. Reproduction is now **20/20** on runs
+  with collapses.
+
+  **Breaking, deliberately:** the `seeds` field changes from `list[str]` to
+  `list[object]`. Records written by **0.4.0 cannot be replayed** — their seeds were
+  never sufficient to reproduce the run, so nothing correct is lost. Re-record any
+  affected `mcsolve` runs. The platform stores this field in flexible `jsonb` and does
+  not destructure it.
+
+  This was masked by a test whose collapse rate was so low that most runs had no
+  quantum jumps at all — a degenerate seed set reproduces a jump-free run trivially.
+  With the old fixture (`0.1 * sigmam()`, `ntraj=4`), 57/60 runs were jump-free and
+  passed vacuously; the 3 that jumped failed 3/3, which read as CI flake. The test now
+  uses `0.4 * sigmam()`/`ntraj=8`, loops until a trajectory actually collapses, and
+  asserts exact reproduction — plus a one-line guard that the seeds are distinct from
+  each other, which is what would have caught this immediately.
+
 ## [0.4.0] — 2026-08-11
 
 ### Added

--- a/marqov/device.py
+++ b/marqov/device.py
@@ -295,7 +295,10 @@ class MarqovDevice:
             if kwargs.get("verbatim"):
                 from braket.circuits import Circuit as BraketCircuit
 
-                _RIGETTI_VERBATIM_ALLOWED = {"rx", "rz", "cz", "xy", "measure"}
+                # Measure is deliberately NOT allowed — see BraketExecutor.execute:
+                # Braket refuses to box a measured subcircuit and adds measurement
+                # implicitly via `shots`.
+                _RIGETTI_VERBATIM_ALLOWED = {"rx", "rz", "cz", "xy"}
                 non_native = [
                     instr.operator.name
                     for instr in native_circuit.instructions
@@ -304,7 +307,8 @@ class MarqovDevice:
                 if non_native:
                     raise ValueError(
                         f"verbatim=True requires Rigetti native gates only "
-                        f"(1Q: Rx/Rz, 2Q: CZ/XY, plus Measure). "
+                        f"(1Q: Rx/Rz, 2Q: CZ/XY; no explicit Measure — Braket cannot box a "
+                        f"measured subcircuit and adds measurement implicitly via shots). "
                         f"Found non-native gates: {sorted(set(non_native))}. "
                         f"Use clifford_to_circuit_native() or set "
                         f"SRBConfig.use_native_gates=True."

--- a/marqov/executors/braket.py
+++ b/marqov/executors/braket.py
@@ -207,7 +207,12 @@ class BraketExecutor(BaseExecutor):
         # device-aware lookup when IQM or other verbatim providers are added.
         # IQM native set is {Rz, SX, CZ} — different from Rigetti.
         if kwargs.get("verbatim"):
-            _RIGETTI_VERBATIM_ALLOWED = {"rx", "rz", "cz", "xy", "measure"}
+            # Measure is deliberately NOT allowed: Braket refuses to box a subcircuit
+            # containing a measurement (`add_verbatim_box` -> "cannot measure a
+            # subcircuit inside a verbatim box"). Allow-listing it would let the caller
+            # clear this check and then hit Braket's opaque error instead of ours.
+            # Braket applies measurement implicitly via `shots`.
+            _RIGETTI_VERBATIM_ALLOWED = {"rx", "rz", "cz", "xy"}
             non_native = [
                 instr.operator.name
                 for instr in braket_circuit.instructions
@@ -216,7 +221,8 @@ class BraketExecutor(BaseExecutor):
             if non_native:
                 raise ValueError(
                     f"verbatim=True requires Rigetti native gates only "
-                    f"(1Q: Rx/Rz, 2Q: CZ/XY, plus Measure). "
+                    f"(1Q: Rx/Rz, 2Q: CZ/XY; no explicit Measure — Braket cannot box a "
+                    f"measured subcircuit and adds measurement implicitly via shots). "
                     f"Found non-native gates: {sorted(set(non_native))}. "
                     f"Use clifford_to_circuit_native() or set SRBConfig.use_native_gates=True."
                 )

--- a/marqov/qutip/record.py
+++ b/marqov/qutip/record.py
@@ -2,7 +2,7 @@
 
 Invariants (spec §7): .states NEVER go through stdout (offload or hard-fail);
 stochastic (mcsolve) runs MUST carry seeds or they are not Capsule-reproducible.
-Verified on qutip 5.3.0 — see plan header for the API facts this relies on.
+Verified on qutip 5.3.0 and 5.3.1 — see plan header for the API facts this relies on.
 """
 from __future__ import annotations
 
@@ -18,14 +18,45 @@ def _is_stochastic(result: Any) -> bool:
     return hasattr(result, "num_trajectories")
 
 
-def _seed_to_str(s: Any) -> str:
-    # result.seeds are numpy SeedSequence; int(s) raises. The reusable value is
-    # s.entropy (128-bit int) — emit as a STRING to survive JS/jsonb float64.
-    # Verified 5.3.0: seeds=[int(entropy)] reproduces mcsolve exactly.
-    entropy = getattr(s, "entropy", None)
-    if entropy is None:  # not a SeedSequence -> fail clearly, don't int() it
+def _seed_to_json(s: Any) -> dict[str, Any]:
+    """Serialise one numpy SeedSequence to a JSON-safe dict, losslessly.
+
+    The whole state is required, NOT just `entropy`. The trajectories of a single
+    mcsolve call are spawned children of one root SeedSequence: they all share the
+    same `entropy` and differ ONLY by `spawn_key`. Emitting `entropy` alone writes
+    the same value ntraj times, and a replay then collapses the ensemble to one
+    trajectory repeated — measured 0/20 reproduction on runs containing a collapse.
+
+    `SeedSequence.state` is exactly the reconstruction kwargs (numpy's own
+    round-trip contract: `SeedSequence(**s.state)` regenerates an identical
+    stream), so we round-trip it whole rather than cherry-picking fields.
+    `entropy` becomes a STRING because it is a 128-bit int and would lose
+    precision in JS/jsonb float64; `spawn_key` becomes a list because JSON has
+    no tuple. Inverse: `seed_from_json`.
+    """
+    state = getattr(s, "state", None)
+    if state is None:  # not a SeedSequence -> fail clearly, don't int() it
         raise ValueError(f"cannot serialise seed of type {type(s).__name__}")
-    return str(entropy)
+    out = dict(state)
+    out["entropy"] = str(out["entropy"])
+    out["spawn_key"] = list(out.get("spawn_key", ()))
+    return out
+
+
+def seed_from_json(d: dict[str, Any]) -> Any:
+    """Rebuild a numpy SeedSequence from `_seed_to_json` output.
+
+    Inverse of the serialiser, exposed publicly so replay callers do not have to
+    reimplement the entropy-string / spawn_key-tuple conversions themselves.
+    """
+    from numpy.random import SeedSequence
+
+    return SeedSequence(
+        entropy=int(d["entropy"]),
+        spawn_key=tuple(d.get("spawn_key", ())),
+        pool_size=d.get("pool_size", 4),
+        n_children_spawned=d.get("n_children_spawned", 0),
+    )
 
 
 def _coerce_series(arr: Any, name: str) -> list[float]:
@@ -115,12 +146,16 @@ def record(result: Any, observable_names: list[str] | None = None, *,
         "observables": observables,
     }
     if seeds:
+        # One object per trajectory, each the full SeedSequence state — see
+        # _seed_to_json for why `entropy` alone is NOT sufficient. Rebuild with
+        # seed_from_json() and pass the list to mcsolve(seeds=...) to replay.
+        #
         # REPRODUCIBILITY CAVEAT (verified qutip 5.3): these seeds reproduce mcsolve
         # bit-identically ONLY under options={"map": "serial"}. The parallel map does
         # not preserve seed->trajectory assignment, so a re-run with the same seeds
         # produces a DIFFERENT trajectory set (max|Δ| up to 2.0). A Capsule re-run of a
         # stochastic open-system result must force serial to actually reproduce.
-        payload["seeds"] = [_seed_to_str(s) for s in seeds]
+        payload["seeds"] = [_seed_to_json(s) for s in seeds]
     if states_artifact_path is not None:
         payload["states_artifact"] = states_artifact_path
 

--- a/tests/qutip/test_record.py
+++ b/tests/qutip/test_record.py
@@ -73,28 +73,56 @@ def test_record_real_mesolve_integration():
     assert len(out["times"]) == 5 and len(out["observables"]["sz"]) == 5
     assert "seeds" not in out
 
-def test_record_mcsolve_seeds_round_trip_reproduces():
+def test_record_mcsolve_seeds_are_distinct_per_trajectory():
+    """Each trajectory needs its OWN seed. The trajectories of one mcsolve call are
+    spawned children of one root SeedSequence: they share `entropy` and differ ONLY
+    by `spawn_key`. Serialising `entropy` alone emits the same value ntraj times, so
+    a replay collapses the ensemble to one trajectory repeated. This one-line
+    distinctness check is the cheapest possible guard against that."""
     pytest.importorskip("qutip")
     from qutip import basis, sigmaz, sigmam, mcsolve
-    from numpy.random import SeedSequence
     args = (sigmaz(), basis(2, 0), np.linspace(0, 1, 3))
-    # map=serial: seed->trajectory assignment is not stable under the parallel map.
-    kw = dict(c_ops=[0.1 * sigmam()], e_ops=[sigmaz()], ntraj=4, options={"map": "serial"})
+    kw = dict(c_ops=[0.4 * sigmam()], e_ops=[sigmaz()], ntraj=8, options={"map": "serial"})
     res = mcsolve(*args, **kw)
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         record(res, observable_names=["sz"])
     seeds_json = json.loads(buf.getvalue())["seeds"]
-    # record()'s contract: emit one 128-bit seed per trajectory as a JSON string
-    # (survives JS/jsonb float64), each round-tripping to a valid SeedSequence that
-    # drives a re-run. Bit-exact reproduction is qutip's property, NOT record()'s,
-    # and is not guaranteed run-to-run on qutip 5.3.1 (measured: ~29/30 exact, the
-    # remainder a single-trajectory divergence up to max|Δ|≈0.5 — a different
-    # collapse, not numerical drift, so tolerance-loosening would be wrong). Assert
-    # what record() actually owns: faithful seed capture + a finite, same-shape re-run.
     assert len(seeds_json) == len(res.seeds)
-    assert all(isinstance(s, str) for s in seeds_json)  # 128-bit-safe as strings
-    reused = [SeedSequence(int(s)) for s in seeds_json]
-    res2 = mcsolve(*args, seeds=reused, **kw)
-    assert np.asarray(res2.expect[0]).shape == np.asarray(res.expect[0]).shape
-    assert np.all(np.isfinite(res2.expect[0]))
+    canonical = [json.dumps(s, sort_keys=True) for s in seeds_json]
+    assert len(set(canonical)) == len(canonical), (
+        f"seeds must be distinct per trajectory; got {len(set(canonical))} "
+        f"distinct of {len(canonical)}"
+    )
+
+
+def test_record_mcsolve_seeds_round_trip_reproduces():
+    """Replaying from recorded seeds must reproduce `expect` exactly.
+
+    The collapse rate and ntraj are chosen so that trajectories actually JUMP: with
+    a weak c_op nearly every trajectory is jump-free, in which case a degenerate
+    (all-identical) seed set coincidentally reproduces and the test proves nothing.
+    Measured with 0.1*sigmam/ntraj=4: 57/60 runs jump-free -> passed trivially;
+    the 3 that jumped failed 3/3. With 0.4*sigmam/ntraj=8 roughly 80% of runs jump.
+
+    map=serial: seed->trajectory assignment is not stable under the parallel map.
+    """
+    pytest.importorskip("qutip")
+    from qutip import basis, sigmaz, sigmam, mcsolve
+    from marqov.qutip.record import seed_from_json
+    args = (sigmaz(), basis(2, 0), np.linspace(0, 1, 3))
+    kw = dict(c_ops=[0.4 * sigmam()], e_ops=[sigmaz()], ntraj=8, options={"map": "serial"})
+    # Loop until we get a run with at least one collapse — a jump-free run does not
+    # exercise the seed round-trip at all. Bounded so a pathological RNG can't hang.
+    for _ in range(25):
+        res = mcsolve(*args, **kw)
+        if not np.allclose(res.expect[0], 1.0):
+            break
+    else:
+        pytest.skip("no trajectory collapsed in 25 attempts; nothing to reproduce")
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        record(res, observable_names=["sz"])
+    seeds_json = json.loads(buf.getvalue())["seeds"]
+    res2 = mcsolve(*args, seeds=[seed_from_json(s) for s in seeds_json], **kw)
+    np.testing.assert_allclose(res.expect[0], res2.expect[0])

--- a/tests/test_device_integration.py
+++ b/tests/test_device_integration.py
@@ -217,6 +217,28 @@ class TestBraketVerbatim:
             with pytest.raises(ValueError, match="native"):
                 device.run(circuit, shots=100, verbatim=True)
 
+    def test_verbatim_rejects_explicit_measure(self) -> None:
+        """Parity with BraketExecutor: an explicit Measure must raise OUR error.
+
+        Braket refuses to box a measured subcircuit, so allow-listing Measure would
+        let the caller past this check and into Braket's opaque error. Measurement is
+        applied implicitly via `shots`.
+        """
+        device = self._rigetti_device()
+        mock_aws = self._mock_aws_device()
+        # marqov.Circuit has no measure(); inject at the Braket-conversion boundary,
+        # which is where an explicit Measure could realistically arrive.
+        instr = MagicMock()
+        instr.operator.name = "Measure"
+        braket_circuit = MagicMock()
+        braket_circuit.instructions = [instr]
+        circuit = Circuit().rx(0.5, 0)
+        with patch.object(MarqovDevice, "_get_provider_device", return_value=mock_aws):
+            with patch.object(MarqovDevice, "_to_backend_format", return_value=braket_circuit):
+                with pytest.raises(ValueError, match="native") as exc:
+                    device.run(circuit, shots=100, verbatim=True)
+        assert "Measure" in str(exc.value)
+
     def test_no_verbatim_box_by_default(self) -> None:
         device = self._rigetti_device()
         mock_aws = self._mock_aws_device()

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -362,6 +362,45 @@ class TestBraketExecutor:
                         with pytest.raises(ValueError, match="non-native gates"):
                             await executor.execute(circuit, shots=100, verbatim=True)
 
+    @pytest.mark.asyncio
+    async def test_verbatim_mode_rejects_explicit_measure(self, mock_braket: dict) -> None:
+        """verbatim=True raises OUR ValueError for an explicit Measure instruction.
+
+        Braket refuses to box a subcircuit containing a measurement — `add_verbatim_box`
+        raises `ValueError: cannot measure a subcircuit inside a verbatim box.`
+        (braket/circuits/circuit.py). So Measure must NOT be in our allowed set: if it
+        is, the caller clears our validator and then hits Braket's opaque error instead
+        of our actionable one. Braket applies measurement implicitly via `shots`, so an
+        explicit Measure is never needed for SRB anyway.
+        """
+        config = BraketExecutorConfig(
+            device_arn="arn:aws:braket:us-west-1::device/qpu/rigetti/Cepheus-1-108Q",
+            s3_bucket="my-bucket",
+        )
+
+        # Native 1Q/2Q gates plus an explicit Measure — previously allow-listed.
+        names = ["Rx", "Rz", "CZ", "Measure"]
+        mock_instrs = []
+        for name in names:
+            instr = MagicMock()
+            instr.operator.name = name
+            mock_instrs.append(instr)
+        mock_braket_circuit = MagicMock()
+        mock_braket_circuit.instructions = mock_instrs
+
+        with patch("marqov.executors.braket.AwsDevice", return_value=mock_braket["device"]):
+            with patch("marqov.executors.braket.boto3.Session"):
+                with patch("marqov.executors.braket.AwsSession"):
+                    executor = BraketExecutor(config)
+                    circuit = Circuit().rx(0.5, 0)
+                    with patch.object(circuit, "to_braket", return_value=mock_braket_circuit):
+                        with pytest.raises(ValueError, match="non-native gates") as exc:
+                            await executor.execute(circuit, shots=100, verbatim=True)
+        assert "Measure" in str(exc.value), (
+            "the error should name Measure as the offending instruction"
+        )
+
+
 class TestQuantinuumExecutor:
     """Tests for QuantinuumExecutor."""
 


### PR DESCRIPTION
Two independent correctness fixes for **0.4.1**. Both are shipped-in-0.4.0 defects.

Closes #73. Addresses the two findings recorded on #66.

---

## 1. `record()` emitted mcsolve seeds that cannot reproduce the run (#73)

Seeds were serialised as `SeedSequence.entropy` alone. Every trajectory of a single `mcsolve` call is a *spawned child* of one root `SeedSequence`: they share `entropy` and differ **only** by `spawn_key`. So the record held N copies of one seed, and a replay collapsed the Monte Carlo ensemble to a single trajectory repeated `ntraj` times.

```
emitted seeds : 1 distinct value of 8
original      : [1.  0.75 0.5 ]
replayed      : [1. -1.  -1. ]
```

Seeds now round-trip the full `SeedSequence.state` — numpy's own reconstruction contract — as one JSON object per trajectory:

```json
{"entropy": "179663937626102255308327548008974693620",
 "spawn_key": [3], "pool_size": 4, "n_children_spawned": 0}
```

`entropy` stays a string (128-bit, lossy in JS/`jsonb` float64), `spawn_key` becomes a list (JSON has no tuple). New public helper `marqov.qutip.record.seed_from_json` is the inverse, so replay callers don't reimplement those conversions.

Holding qutip fixed and varying only what we serialise, over runs where at least one trajectory actually collapsed:

| Serialised | Reproduced |
|---|---|
| `entropy` only (0.4.0) | **0 / 20** |
| full `.state` (this PR) | **20 / 20** |

**Breaking, deliberately:** `seeds` moves from `list[str]` to `list[object]`. Records written by 0.4.0 **cannot be replayed** — their seeds were never sufficient, so nothing correct is lost. The platform stores this field in flexible `jsonb` and no platform code destructures it; the QuTiP design spec leaves `seeds?` deliberately untyped.

### Why this got through

The test asserted **proxies** — seed count, array shape, finiteness — rather than the **property** (replay reproduces). Combined with a fixture so low-variance that **57/60 runs had no quantum jump at all**, a degenerate seed set reproduced jump-free runs trivially. It passed ~95% of the time; the 3/60 that jumped failed 3/3, which read as CI flake and was cleared by a re-run.

The test now uses `0.4*sigmam()`/`ntraj=8`, loops until a trajectory actually collapses, asserts exact reproduction, and adds a one-line distinctness guard that would have caught this immediately.

## 2. Verbatim compilation allow-listed a `Measure` that Braket rejects (#66)

The allowed native set was `{Rx, Rz, CZ, XY, Measure}`, and both the error message and the 0.4.0 changelog advertised "plus Measure". Braket disagrees — `add_verbatim_box` raises *"cannot measure a subcircuit inside a verbatim box"* (`braket/circuits/circuit.py:871`). So a caller passing an explicit measurement with `verbatim=True` cleared our validator and then hit an opaque Braket error instead of our actionable one.

`Measure` is now excluded in **both** paths — `MarqovDevice.run` and `BraketExecutor.execute` — with the offending instruction named in the error. Braket applies measurement implicitly via `shots`, so an explicit `Measure` was never needed, least of all for randomized benchmarking.

Chose to reject rather than silently strip: discarding instructions a caller wrote is worse than telling them.

---

## Verification

- Full suite **674 passed**
- QuTiP suite **40/40 consecutive runs** — the number that matters, given the old test passed ~95% of the time by luck
- Each new test **watched fail first**; the distinctness test failed with `got 1 distinct of 8`, i.e. the real defect
- `ruff` clean on all changed files; `mypy` error count **unchanged at 25** (pre-existing `braket.aws`/`braket.circuits` stub warnings — stashed and compared rather than assumed)
- CI URL-deps guard passes

`tests/test_version.py::test_version_is_single_sourced` fails identically on `origin/main` with these changes stashed — stale installed dist metadata in the local venv, not a regression.

## Tests added

| Test | Guards |
|---|---|
| `test_record_mcsolve_seeds_are_distinct_per_trajectory` | the degenerate-seed defect, in one line |
| `test_record_mcsolve_seeds_round_trip_reproduces` | exact replay, gated on a run that actually collapses |
| `test_verbatim_mode_rejects_explicit_measure` (executor) | our error fires, not Braket's |
| `test_verbatim_rejects_explicit_measure` (device) | device↔executor parity, per #66 |

## Not in this PR

- **Version bump to 0.4.1** — 0.4.0 did that as its own `chore(release)` commit; following that pattern.
- **Recording the seed in executor metadata.** `LocalExecutor`, `CudaQExecutor` and `simulation/executor.py` each accept a seed, use it, and never write it to the result. Deliberately held: `ExecutionResult.metadata` additions are a compatibility surface, and the ExperimentRecord schema has no slot for RNG state (marqov-dev/marqov-platform#876). Adding three ad-hoc conventions now guarantees a reconciliation later. Tracked in #74.
- **`Circuit.from_*` silently dropping mid-circuit `measure`/`reset`/`delay`** — third instance of the same pattern, filed as #76.