### PR TITLE
test(boundary): AST-parse the core→platform guard instead of grepping lines

### DIFF
--- a/docs/design/platform-client-boundary.md
+++ b/docs/design/platform-client-boundary.md
@@ -98,12 +98,24 @@ rule:
 inspection, not a test — there's no mechanical way to check "does this
 feature only make sense with a `MARQOV_PLATFORM_KEY`."
 
-**Direction 2** (platform doesn't leak into core) is only half machine-checked
-today: `tests/test_platform_package.py::TestLaziness` confirms `import marqov`
-never pulls in `marqov.platform`, but nothing currently asserts the reverse —
-that core files never contain `from marqov.platform import ...` — as a lint
-rule or CI guard. Until that guard exists, treat this rule as enforced by code
-review, not by the test suite.
+**Direction 2** (platform doesn't leak into core) is machine-checked in both
+halves. `tests/test_platform_package.py::TestLaziness` confirms `import marqov`
+never pulls in `marqov.platform` at runtime;
+`tests/test_platform_package.py::TestCoreDoesNotImportPlatform` asserts the
+reverse statically — it parses the AST of **every module under `marqov/` except
+`marqov/platform/` itself** and fails on any reference to the platform package.
+The enumerated file lists elsewhere in this document are illustrative; that
+exclusion rule is the enforced scope, so a new core module is covered the moment
+it lands.
+
+The guard catches plain, aliased, submodule, and relative imports
+(`from ..platform import ...`), `from marqov import platform`, imports nested
+inside a function body, and string literals passed to `importlib.import_module`.
+Type-only imports under `if TYPE_CHECKING:` are **not** exempt — the boundary is
+absolute; if a core module ever genuinely needs a platform type, use a string
+annotation or a platform-free protocol. Only a module name assembled
+dynamically at runtime escapes the check, which is a deliberate best-effort
+limit rather than a supported way through the boundary.
 
 ---
 

--- a/tests/test_platform_package.py
+++ b/tests/test_platform_package.py
@@ -6,11 +6,14 @@ Verifies that:
 3. Importing ``marqov`` (the core SDK) does NOT trigger a side-import of
    ``marqov.platform`` (laziness guarantee — tested via a subprocess so that
    prior imports in this test process cannot pollute the check).
+4. No core SDK file imports ``marqov.platform`` (the reverse direction of the
+   same boundary — an AST scan over everything under ``marqov/`` except the
+   platform subpackage itself).
 """
 
 from __future__ import annotations
 
-import re
+import ast
 import subprocess
 import sys
 from collections.abc import Iterator
@@ -181,43 +184,128 @@ class TestLaziness:
 # ---------------------------------------------------------------------------
 # 4. Boundary: core SDK files never import marqov.platform (the other
 #    direction of the laziness guarantee — see docs/design/platform-client-
-#    boundary.md's "two-direction rule"). Mirrors the grep-gate pattern in
-#    tests/test_no_private_references.py.
+#    boundary.md's "two-direction rule").
+#
+#    This parses the AST rather than grepping raw lines (the grep-gate pattern
+#    of tests/test_no_private_references.py). Two reasons: text in docstrings
+#    and comments cannot trip it, and every real import form is covered —
+#    submodule from-imports, relative imports, `from marqov import platform`,
+#    and aliased plain imports, at module level or inside a function body.
+#
+#    ``if TYPE_CHECKING:`` blocks are deliberately NOT exempt: the boundary is
+#    absolute, so a type-only import is a violation too. Use a string
+#    annotation or a platform-free protocol instead.
 # ---------------------------------------------------------------------------
 
-_CORE_PATHS = (
-    "marqov/circuits.py",
-    "marqov/device.py",
-    "marqov/backends.py",
-    "marqov/executors",
-    "marqov/workflows",
-)
-_PLATFORM_IMPORT = re.compile(r"^\s*(from\s+marqov\.platform\s+import|import\s+marqov\.platform)")
+_ROOT = Path(__file__).resolve().parent.parent
+_CORE_ROOT = _ROOT / "marqov"
+# Denylist, not an allowlist: everything under marqov/ is core except the
+# platform subpackage itself, so a newly added core module is covered the
+# moment it lands and there is no path list to drift out of sync.
+_EXCLUDED_DIRS = frozenset({"platform"})
+_BANNED_MODULE = "marqov.platform"
+# Dynamic-import helpers whose first string-literal argument is inspected.
+# Best-effort by design: a module name assembled at runtime is out of scope.
+_DYNAMIC_IMPORT_FUNCS = frozenset({"import_module", "__import__"})
+# Floor on the scan size, so a moved/renamed tree fails loudly instead of
+# passing vacuously on zero files (the core tree is ~36 files today).
+_MIN_SCANNED_FILES = 30
 
 
 def _iter_core_files() -> Iterator[Path]:
-    root = Path(__file__).resolve().parent.parent
-    for rel in _CORE_PATHS:
-        base = root / rel
-        if base.is_file():
-            yield base
-        elif base.is_dir():
-            yield from base.rglob("*.py")
+    """Every ``.py`` file under ``marqov/`` except the platform subpackage."""
+    for path in sorted(_CORE_ROOT.rglob("*.py")):
+        # Directory components only — a core module that merely happens to be
+        # named platform.py is still core, and still scanned.
+        if _EXCLUDED_DIRS.isdisjoint(path.relative_to(_CORE_ROOT).parts[:-1]):
+            yield path
+
+
+def _package_parts(path: Path) -> list[str]:
+    """Dotted parts of the package that ``path`` lives in.
+
+    This is the base a relative import resolves against: ``marqov/device.py``
+    and ``marqov/__init__.py`` both resolve against ``marqov``, while
+    ``marqov/executors/factory.py`` resolves against ``marqov.executors``.
+    """
+    return list(path.relative_to(_ROOT).with_suffix("").parts)[:-1]
+
+
+def _resolve_from(node: ast.ImportFrom, package: list[str]) -> str | None:
+    """Absolute module name a ``from ... import`` targets, or None if unresolvable."""
+    if not node.level:
+        return node.module
+    base = package[: len(package) - node.level + 1]
+    if not base:  # more dots than the package has levels
+        return None
+    return ".".join([*base, node.module] if node.module else base)
+
+
+def _is_banned(module: str) -> bool:
+    return module == _BANNED_MODULE or module.startswith(f"{_BANNED_MODULE}.")
+
+
+def _platform_references(tree: ast.Module, package: list[str]) -> Iterator[tuple[int, str]]:
+    """Yield ``(lineno, source-ish description)`` for each marqov.platform reference."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_banned(alias.name):
+                    yield node.lineno, f"import {alias.name}"
+        elif isinstance(node, ast.ImportFrom):
+            module = _resolve_from(node, package)
+            if module is None:
+                continue
+            prefix = f"from {'.' * node.level}{node.module or ''} import"
+            if _is_banned(module):
+                yield node.lineno, f"{prefix} {', '.join(a.name for a in node.names)}"
+                continue
+            # `from marqov import platform` / `from . import platform`.
+            for alias in node.names:
+                if _is_banned(f"{module}.{alias.name}"):
+                    yield node.lineno, f"{prefix} {alias.name}"
+        elif isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name not in _DYNAMIC_IMPORT_FUNCS or not node.args:
+                continue
+            arg = node.args[0]
+            # Prefix match: best-effort cover for the dynamic-import escape hatch.
+            if (
+                isinstance(arg, ast.Constant)
+                and isinstance(arg.value, str)
+                and arg.value.startswith(_BANNED_MODULE)
+            ):
+                yield node.lineno, f"{name}({arg.value!r})"
 
 
 class TestCoreDoesNotImportPlatform:
     """Confirm marqov.platform never leaks into the core SDK (the reverse
     direction of TestLaziness above)."""
 
+    def test_scan_is_not_vacuous(self) -> None:
+        """A moved or renamed core tree must fail here, not silently scan nothing."""
+        scanned = list(_iter_core_files())
+        assert len(scanned) > _MIN_SCANNED_FILES, (
+            f"Only {len(scanned)} core file(s) found under {_CORE_ROOT} — the boundary "
+            "scan below would pass vacuously. Did the package move or get renamed?"
+        )
+
     def test_core_files_never_import_platform(self) -> None:
         offenders: list[str] = []
         for path in _iter_core_files():
-            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-                if _PLATFORM_IMPORT.match(line):
-                    offenders.append(f"{path}:{lineno}: {line.strip()}")
+            rel = path.relative_to(_ROOT)
+            source = path.read_text(encoding="utf-8", errors="replace")
+            try:
+                tree = ast.parse(source, filename=str(path))
+            except SyntaxError as exc:
+                offenders.append(f"{rel}:{exc.lineno}: unparseable ({exc.msg})")
+                continue
+            for lineno, what in _platform_references(tree, _package_parts(path)):
+                offenders.append(f"{rel}:{lineno}: {what}")
         assert not offenders, (
-            f"{len(offenders)} core-SDK import(s) of marqov.platform found — this "
+            f"{len(offenders)} core-SDK reference(s) to marqov.platform found — this "
             "breaks the boundary documented in docs/design/platform-client-boundary.md "
-            "(platform is a consumer of the core, never a dependency of it):\n  "
-            + "\n  ".join(offenders)
+            "(platform is a consumer of the core, never a dependency of it). Type-only "
+            "imports under `if TYPE_CHECKING:` count too:\n  " + "\n  ".join(offenders)
         )


### PR DESCRIPTION
Closes #82.

Rewrites `TestCoreDoesNotImportPlatform` as an `ast.walk` over Import/ImportFrom/Call nodes with relative-import levels resolved against each file's own package, and inverts the hand-synced `_CORE_PATHS` allowlist to a denylist (everything under `marqov/` except `marqov/platform/`), so there is no path list to drift. Adds `test_scan_is_not_vacuous` (floor of 30 files; 36 today) so a moved tree fails loudly. `errors="replace"` + SyntaxError-as-offender remove the crash modes; AST parsing removes the docstring/comment false positives.

Policy, documented in the module: `if TYPE_CHECKING:` imports count as violations (the boundary is absolute), and `import_module()`/`__import__` detection is a best-effort string-literal prefix match.

Verification: nine violation forms planted in real core modules, each individually confirmed to fail the guard (submodule from-import, private submodule, `..platform`, `.platform` module-level and function-local, `from marqov import platform`, `import_module("marqov.platform")`, TYPE_CHECKING-guarded, aliased plain import); vacuous-pass and non-UTF8 resilience demonstrated. Clean tree: 677 passed, 17 skipped, 13 xpassed.

Also fixes the Direction-2 paragraph in `docs/design/platform-client-boundary.md` (born stale in #81 — it denied the existence of the guard that same commit added) and adds item 4 to the test module docstring.