### PR TITLE
fix(qutip): scope bit-exact replay claim to map=serial, add tolerance-based parallel test

### DIFF
--- a/marqov/qutip/record.py
+++ b/marqov/qutip/record.py
@@ -151,11 +151,16 @@ def record(result: Any, observable_names: list[str] | None = None, *,
         # seed_from_json() and pass the list to mcsolve(seeds=...) to replay.
         #
         # Reproducibility: verified on qutip 5.3.1 that a replay reproduces the
-        # original run's expect values bit-identically (max|Δ| == 0.0) under both
-        # options={"map": "serial"} and the default "parallel" map, now that seeds
-        # round-trip the full SeedSequence.state (see _seed_to_json above — the
-        # earlier entropy-only serialisation was what made parallel replay
-        # diverge). No need to force serial to reproduce.
+        # original run's expect values bit-identically (max|Δ| == 0.0) under
+        # options={"map": "serial"}, now that seeds round-trip the full
+        # SeedSequence.state (see _seed_to_json above — the earlier entropy-only
+        # serialisation was what made parallel replay diverge). Under
+        # options={"map": "parallel"} (qutip's own default is "serial"),
+        # seed->trajectory assignment is stable too, but summation
+        # order is not: measured 24/27 collapsing runs bit-exact, the other 3
+        # deviating by 1 ULP (~1.11e-16) — replay reproduces to floating-point
+        # tolerance, not bit-identically. Force map="serial" if a consumer needs
+        # bit-exact equality.
         payload["seeds"] = [_seed_to_json(s) for s in seeds]
     if states_artifact_path is not None:
         payload["states_artifact"] = states_artifact_path

--- a/tests/qutip/test_record.py
+++ b/tests/qutip/test_record.py
@@ -105,7 +105,12 @@ def test_record_mcsolve_seeds_round_trip_reproduces():
     Measured with 0.1*sigmam/ntraj=4: 57/60 runs jump-free -> passed trivially;
     the 3 that jumped failed 3/3. With 0.4*sigmam/ntraj=8 roughly 80% of runs jump.
 
-    map=serial: seed->trajectory assignment is not stable under the parallel map.
+    map=serial: forces bit-exact reproduction (and is qutip's own default).
+    Seed->trajectory assignment is stable under map=parallel too, but summation
+    order is not, so
+    parallel replay reproduces only to floating-point tolerance (~1 ULP on a
+    minority of collapsing runs) rather than bit-identically — see the caveat
+    in record.py.
     """
     pytest.importorskip("qutip")
     from qutip import basis, sigmaz, sigmam, mcsolve
@@ -126,3 +131,36 @@ def test_record_mcsolve_seeds_round_trip_reproduces():
     seeds_json = json.loads(buf.getvalue())["seeds"]
     res2 = mcsolve(*args, seeds=[seed_from_json(s) for s in seeds_json], **kw)
     np.testing.assert_allclose(res.expect[0], res2.expect[0])
+
+
+def test_record_mcsolve_seeds_round_trip_reproduces_parallel_to_tolerance():
+    """Companion to test_record_mcsolve_seeds_round_trip_reproduces: same setup,
+    but under the parallel map, replay reproduces `expect` only to
+    floating-point tolerance, not bit-identically.
+
+    Seed->trajectory assignment is stable under the parallel map too (that's
+    what the seed round-trip owns), but summation order is not: measured
+    max|Δ| ~1e-16 (1 ULP) from nondeterministic parallel reduction, on a
+    minority of collapsing runs. atol=1e-12 leaves ~4 orders of magnitude of
+    margin over that measured noise while still catching a real seed-replay
+    regression, which collapses to a genuinely DIFFERENT trajectory (max|Δ| up
+    to 2.0 — see the entropy-only-serialisation bug this seed round-trip
+    guards against, and the caveat in record.py).
+    """
+    pytest.importorskip("qutip")
+    from qutip import basis, sigmaz, sigmam, mcsolve
+    from marqov.qutip.record import seed_from_json
+    args = (sigmaz(), basis(2, 0), np.linspace(0, 1, 3))
+    kw = dict(c_ops=[0.4 * sigmam()], e_ops=[sigmaz()], ntraj=8, options={"map": "parallel"})
+    for _ in range(25):
+        res = mcsolve(*args, **kw)
+        if not np.allclose(res.expect[0], 1.0):
+            break
+    else:
+        pytest.skip("no trajectory collapsed in 25 attempts; nothing to reproduce")
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        record(res, observable_names=["sz"])
+    seeds_json = json.loads(buf.getvalue())["seeds"]
+    res2 = mcsolve(*args, seeds=[seed_from_json(s) for s in seeds_json], **kw)
+    np.testing.assert_allclose(res.expect[0], res2.expect[0], atol=1e-12, rtol=0)


### PR DESCRIPTION
Closes #83.

`record.py`'s reproducibility comment claimed parallel-map replay reproduces expect values bit-identically; measured on qutip 5.3.1 that's only true 24/27 collapsing runs (3 deviate by 1 ULP from nondeterministic parallel summation order). The comment now scopes bit-exact reproduction to `options={"map": "serial"}` and documents parallel replay as reproducing to floating-point tolerance. The `test_record_mcsolve_seeds_round_trip_reproduces` docstring, which still asserted the pre-#75 claim that seed→trajectory assignment is unstable under the parallel map, is reconciled (assignment is stable; only summation order isn't).

Wording note: qutip 5.3.1's actual `MCSolver` default map is `serial` — the previous comment (and the issue text) called parallel "the default", which was itself inaccurate; the new wording says so explicitly.

Adds a companion test exercising `map: parallel` with `atol=1e-12` (measured deviation ≤2 ULP ≈ 4e-16, so wide margin, still tight enough to catch a real seed-replay regression where max|Δ| reaches 2.0). Flake evidence: 400 in-process runs + 15 fresh-process pytest invocations, zero failures. Suite: 677 passed, 17 skipped, 13 xpassed.