### PR TITLE
fix(qb): document qristal's external install requirement, raise actionable ImportError

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ result = await executor.execute(circuit, shots=1000)
 | IonQ Direct | Available |
 | Rigetti QCS | Available |
 | Quantinuum | Available |
-| Quantum Brilliance | Available |
+| Quantum Brilliance | Available — requires `qristal` installed separately (not on PyPI, no `marqov[...]` extra); build from source or use the Docker image: https://qristal.readthedocs.io/ |
 | CUDA-Q | Available — not in `[all]` (GPU-heavy); install separately with `pip install "marqov[cudaq]"` |
 
 ---

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -49,7 +49,10 @@ class ExecutorFactory:
         - Quantinuum: Quantinuum devices and emulators (via pytket-quantinuum)
         - Rigetti QCS: Native pyQuil submission to Rigetti QPUs or the local QVM
         - CUDA-Q: NVIDIA GPU/CPU simulation, or IQM hardware via CUDA-Q's IQM target
-        - Quantum Brilliance: routed through the local simulation backend
+        - Quantum Brilliance: routed through the local simulation backend.
+          Requires ``qristal`` to be installed separately — it is not on
+          PyPI and has no ``marqov[...]`` extra. Build it from source or use
+          the official Docker image; see https://qristal.readthedocs.io/.
         - Local: QuantumFlow simulator (no cloud required)
         - IonQ Direct: Native IonQ REST API (no AWS/Braket intermediary)
 

--- a/marqov/simulation/executor.py
+++ b/marqov/simulation/executor.py
@@ -56,13 +56,33 @@ class SimulationExecutor(BaseExecutor):
         )
 
 
+def _import_qristal_core() -> Any:
+    """Import ``qristal.core`` with an actionable error if it isn't installed.
+
+    ``qristal`` is not published on PyPI — there is no ``pip install
+    marqov[...]`` remedy. It must be built from source or run via Quantum
+    Brilliance's Docker image; see https://qristal.readthedocs.io/.
+    """
+    import importlib
+
+    try:
+        return importlib.import_module("qristal.core")
+    except ImportError as exc:
+        raise ImportError(
+            "qristal is required for Quantum Brilliance simulation backends "
+            "but is not installed. qristal is not distributed on PyPI, so "
+            "there is no 'pip install marqov[...]' extra for it — build it "
+            "from source or use the official Docker image. See Quantum "
+            "Brilliance's install instructions: "
+            "https://qristal.readthedocs.io/en/latest/rst/getting_started.html"
+        ) from exc
+
+
 def _run_simulation(
     qasm_str: str, shots: int, config: SimulationConfig
 ) -> ExecutionResult:
     """Execute simulation in a thread (blocking C++ call)."""
-    import importlib
-
-    qristal_core = importlib.import_module("qristal.core")
+    qristal_core = _import_qristal_core()
     session = qristal_core.session()
     session.init()
     session.acc = config.backend_id

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -10,7 +10,11 @@ from marqov.executors.factory import ExecutorFactory
 from marqov.simulation.backends import SIMULATION_BACKENDS
 from marqov.simulation.circuit_converter import convert_counts, count_qubits, ensure_measurements
 from marqov.simulation.config import SimulationConfig
-from marqov.simulation.executor import SimulationExecutor, _validate_qubit_limit
+from marqov.simulation.executor import (
+    SimulationExecutor,
+    _import_qristal_core,
+    _validate_qubit_limit,
+)
 from marqov.executors.quantinuum import QuantinuumExecutor
 
 
@@ -260,6 +264,25 @@ class TestGpuBackendRegistry:
         from marqov.simulation.backends import GPU_SIMULATION_BACKENDS
 
         assert "qb-sim-density-matrix" in GPU_SIMULATION_BACKENDS
+
+
+class TestQristalImportError:
+    """Tests for the actionable ImportError when qristal isn't installed."""
+
+    def test_import_error_is_actionable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When qristal.core is missing, _import_qristal_core gives install guidance."""
+        import importlib
+
+        real_import_module = importlib.import_module
+
+        def fake_import_module(name: str, *args, **kwargs):
+            if name == "qristal.core":
+                raise ModuleNotFoundError("No module named 'qristal'")
+            return real_import_module(name, *args, **kwargs)
+
+        monkeypatch.setattr(importlib, "import_module", fake_import_module)
+        with pytest.raises(ImportError, match="not distributed on PyPI"):
+            _import_qristal_core()
 
 
 class TestSimulationExecutor:


### PR DESCRIPTION
Closes #84.

Investigation (details on the issue): `qristal` is not on PyPI under any plausible name — it ships only as a source build (CMake, Ubuntu/WSL2 toolchain) or Docker image — so a `marqov[qb]` extra is not possible and `pyproject.toml` is deliberately untouched.

Instead: the factory docstring's Quantum Brilliance bullet and the README backend table now state the external install requirement, and `marqov/simulation/executor.py` wraps the `qristal.core` import so a missing install raises an actionable `ImportError` (explains there is no pip remedy, links Quantum Brilliance's install docs) instead of a bare `ModuleNotFoundError` mid-`execute()`. New test follows the existing CUDA-Q `_import_cudaq` missing-dependency test pattern. Suite: 677 passed, 17 skipped, 13 xpassed.

**Merge order note:** the README table row overlaps with the rows added by the #85 PR — merge that one first; this branch will then be rebased to fold the qristal note into its Quantum Brilliance row.