### PR TITLE
fix: sync provider lists and pin them against drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ result = await executor.execute(circuit, shots=1000)
 | IonQ Direct | Available |
 | Rigetti QCS | Available |
 | Quantinuum | Available |
+| Quantum Brilliance | Available |
+| CUDA-Q | Available — not in `[all]` (GPU-heavy); install separately with `pip install "marqov[cudaq]"` |
 
 ---
 

--- a/marqov/__init__.py
+++ b/marqov/__init__.py
@@ -5,7 +5,8 @@ Marqov provides:
 - @task/@workflow decorators for defining workflows
 - Automatic parallelization of independent tasks
 - Temporal-backed workflow durability and scheduling
-- Multi-vendor execution (Braket, IBM, IonQ, Rigetti, Azure, Quantinuum, CUDA-Q)
+- Multi-vendor execution (AWS Braket, IBM Quantum, Azure Quantum, IonQ Direct,
+  Rigetti QCS, Quantinuum, CUDA-Q, Quantum Brilliance, Local)
 
 Quick Start with @task/@workflow:
     >>> from marqov import task, workflow, Circuit

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -136,8 +136,7 @@ class ExecutorFactory:
 
         raise ValueError(
             f"Unsupported provider: {provider}. "
-            f"Supported providers: AWS Braket, IBM Quantum, Azure Quantum, "
-            f"IonQ Direct, Rigetti QCS, Quantum Brilliance, CUDA-Q, Local."
+            f"Supported providers: {', '.join(cls.get_supported_providers())}."
         )
 
     @classmethod

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -1,5 +1,6 @@
 """Tests for marqov.executors module."""
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -877,3 +878,40 @@ class TestExecutorFactory:
             "Azure Quantum", "IonQ Direct", "Rigetti QCS", "Quantum Brilliance",
             "CUDA-Q",
         }
+
+    def test_unsupported_provider_error_lists_all_supported_providers(self) -> None:
+        """Regression (#85): the error message is built from get_supported_providers() at
+        raise time, so it can't silently drop a provider (it previously omitted
+        Quantinuum even though the Quantinuum branch was wired up)."""
+        with pytest.raises(ValueError, match="Unsupported provider") as exc_info:
+            ExecutorFactory.create_executor("nope", {"provider": "Not A Real Provider"})
+        message = str(exc_info.value)
+        for provider in ExecutorFactory.get_supported_providers():
+            assert provider in message, f"{provider!r} missing from error message: {message!r}"
+
+
+class TestProviderListDocSync:
+    """Regression (#85): the provider registry is the single source of truth, but the
+    package docstring and README table are hand-written prose that can't be generated
+    from it. Pin them here so the next provider added to the registry without updating
+    these surfaces fails CI instead of silently diverging."""
+
+    def test_package_docstring_mentions_every_provider(self) -> None:
+        """marqov/__init__.py's module docstring must name every supported provider."""
+        import marqov
+
+        doc = marqov.__doc__ or ""
+        for provider in ExecutorFactory.get_supported_providers():
+            assert provider in doc, f"{provider!r} missing from marqov/__init__.py docstring"
+
+    def test_readme_supported_backends_table_mentions_every_provider(self) -> None:
+        """README.md's "Supported Backends" table must have a row for every provider."""
+        readme_path = Path(__file__).resolve().parent.parent / "README.md"
+        readme = readme_path.read_text()
+
+        start = readme.index("## Supported Backends")
+        end = readme.index("\n---", start)
+        table = readme[start:end]
+
+        for provider in ExecutorFactory.get_supported_providers():
+            assert provider in table, f"{provider!r} missing from README Supported Backends table"


### PR DESCRIPTION
Closes #85.

`create_executor()`'s ValueError now builds its "Supported providers" text from `get_supported_providers()` at raise time (fixing the omitted Quantinuum), the `marqov/__init__.py` docstring names all 9 registry providers using their exact registry strings (was 7), and the README Supported Backends table gains Quantum Brilliance and CUDA-Q rows — with the CUDA-Q row documenting that it's excluded from `[all]` (GPU-heavy) and installed separately via `marqov[cudaq]`. `pyproject.toml` untouched per the issue's scoping decision.

Three new tests pin the surfaces that can't be generated from the registry: the error message, the package docstring, and the README table region must each name every provider the registry returns. Planted-regression check performed: removing the Quantum Brilliance README row makes exactly the README test fail with a targeted message; restored and re-verified. Suite: 679 passed, 17 skipped, 13 xpassed. Ruff/mypy clean on changed files.