### PR TITLE
fix(platform): parse HTTP-date Retry-After + complete transport Raises block

### DIFF
--- a/marqov/platform/_transport.py
+++ b/marqov/platform/_transport.py
@@ -8,10 +8,12 @@ Error codes, status codes, and param names below follow the platform's HTTP API 
 
 from __future__ import annotations
 
+import datetime
 import os
 import time
 import typing
 import uuid
+from email.utils import parsedate_to_datetime
 from typing import Any
 
 import requests
@@ -41,6 +43,37 @@ _MAX_RETRIES = 3
 
 #: Initial backoff (seconds) between retries; doubles each attempt.
 _RETRY_BACKOFF_BASE = 0.5
+
+
+def _parse_retry_after(raw: str) -> int | None:
+    """Parse a ``Retry-After`` header value into whole seconds.
+
+    RFC 7231 §7.1.3 allows two forms:
+      - delta-seconds — a plain integer, e.g. ``"30"``.
+      - HTTP-date — e.g. ``"Wed, 21 Oct 2026 07:28:00 GMT"``, converted to a
+        delta against the current time and clamped to ``>= 0`` (a date in
+        the past never yields a negative wait).
+
+    Returns ``None`` if `raw` is neither a valid delta-seconds value nor a
+    parseable HTTP-date.
+    """
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        pass
+
+    try:
+        target = parsedate_to_datetime(raw)
+    except (ValueError, TypeError):
+        return None
+    # A malformed date without timezone info parses to a naive datetime;
+    # without a timezone we can't compute a reliable delta against an
+    # aware "now", so treat it as unparseable.
+    if target is None or target.tzinfo is None:
+        return None
+
+    delta = target - datetime.datetime.now(datetime.timezone.utc)
+    return max(0, int(delta.total_seconds()))
 
 
 # ---------------------------------------------------------------------------
@@ -149,8 +182,14 @@ class Transport:
             PaidBackendNotSupportedYet:  HTTP 422 ``analysis_required``.
             RateLimited:                 HTTP 429. ``retry_after`` is parsed
                                          from the ``Retry-After`` header when
-                                         present, else ``None`` — the header
-                                         is not required for this to raise.
+                                         present — either delta-seconds or an
+                                         RFC 7231 HTTP-date (converted to a
+                                         delta, clamped to ``>= 0``) — else
+                                         ``None``. The header is not required
+                                         for this to raise.
+            BackendUnavailable:          HTTP 422 ``backend_unknown`` /
+                                         ``backend_retired``.
+            InvalidProgram:              HTTP 400 or 422 ``validation_error``.
             MarqovPlatformError:         Any other non-2xx with an error body
                                          (``code`` preserved; never coerced to
                                          ``TransportError``).
@@ -276,10 +315,7 @@ class Transport:
             _retry_after_raw = resp.headers.get("Retry-After")
             _retry_after: int | None = None
             if _retry_after_raw is not None:
-                try:
-                    _retry_after = int(_retry_after_raw)
-                except (ValueError, TypeError):
-                    _retry_after = None
+                _retry_after = _parse_retry_after(_retry_after_raw)
             raise RateLimited(message, code=code, status=status, retry_after=_retry_after)
 
         # backend_unknown / backend_retired → BackendUnavailable

--- a/marqov/platform/errors.py
+++ b/marqov/platform/errors.py
@@ -110,9 +110,12 @@ class RateLimited(MarqovPlatformError):
     Back off and retry.  The :attr:`status` attribute will be ``429``.
 
     Attributes:
-        retry_after: Value of the ``Retry-After`` response header parsed as an
-            integer (seconds), or ``None`` if the header was absent or
-            non-numeric.
+        retry_after: Value of the ``Retry-After`` response header, in whole
+            seconds.  Accepts both the delta-seconds form (e.g. ``"30"``) and
+            the RFC 7231 HTTP-date form (e.g. ``"Wed, 21 Oct 2026 07:28:00
+            GMT"``) — the latter is converted to a delta against the current
+            time, clamped to ``>= 0``.  ``None`` if the header was absent or
+            unparseable.
     """
 
     def __init__(

--- a/tests/test_platform_transport.py
+++ b/tests/test_platform_transport.py
@@ -779,17 +779,61 @@ class TestRateLimitedBodyShapes:
 
         assert exc_info.value.retry_after is None
 
-    def test_retry_after_non_numeric_gives_none(self):
-        """Non-numeric Retry-After header (e.g. HTTP-date) → exc.retry_after is None."""
+    def test_retry_after_garbage_gives_none(self):
+        """Garbage Retry-After header (neither delta-seconds nor an HTTP-date)
+        → exc.retry_after is None.
+        """
         body = {"error": "Too many requests"}
         transport = Transport(api_key="marqey_test_x", base_url="http://test")
-        mock_resp = _mock_response(429, body, headers={"Retry-After": "Fri, 01 Aug 2026 00:00:00 GMT"})
+        mock_resp = _mock_response(429, body, headers={"Retry-After": "not-a-valid-value"})
 
         with patch.object(transport._session, "request", return_value=mock_resp):
             with pytest.raises(RateLimited) as exc_info:
                 transport.request("GET", "/api/jobs/abc/status")
 
         assert exc_info.value.retry_after is None
+
+    def test_retry_after_http_date_parsed_to_delta_seconds(self):
+        """RFC 7231 HTTP-date Retry-After header → parsed via
+        email.utils.parsedate_to_datetime and converted to a delta-seconds int.
+
+        e.g. ``Retry-After: Wed, 21 Oct 2026 07:28:00 GMT``.
+        """
+        import datetime
+        from email.utils import format_datetime
+
+        future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=120)
+        http_date = format_datetime(future, usegmt=True)
+
+        body = {"error": "Too many requests"}
+        transport = Transport(api_key="marqey_test_x", base_url="http://test")
+        mock_resp = _mock_response(429, body, headers={"Retry-After": http_date})
+
+        with patch.object(transport._session, "request", return_value=mock_resp):
+            with pytest.raises(RateLimited) as exc_info:
+                transport.request("GET", "/api/jobs/abc/status")
+
+        retry_after = exc_info.value.retry_after
+        assert retry_after is not None
+        # Allow a little slack for test-execution time between computing
+        # `future` and the delta being computed inside the transport.
+        assert 115 <= retry_after <= 120
+
+    def test_retry_after_http_date_in_past_clamped_to_zero(self):
+        """An HTTP-date Retry-After header already in the past is clamped to
+        0, never a negative number of seconds.
+        """
+        body = {"error": "Too many requests"}
+        transport = Transport(api_key="marqey_test_x", base_url="http://test")
+        mock_resp = _mock_response(
+            429, body, headers={"Retry-After": "Fri, 01 Aug 2025 00:00:00 GMT"}
+        )
+
+        with patch.object(transport._session, "request", return_value=mock_resp):
+            with pytest.raises(RateLimited) as exc_info:
+                transport.request("GET", "/api/jobs/abc/status")
+
+        assert exc_info.value.retry_after == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #86.

`Retry-After` now parses both RFC 7231 forms: delta-seconds as before, and the HTTP-date form via `email.utils.parsedate_to_datetime` (delta against current UTC time, clamped to ≥ 0; naive/malformed dates and garbage still yield `None`). Previously a date-form header silently became `retry_after=None`, so `time.sleep(exc.retry_after)` on the documented assumption crashed with TypeError.

The `request()` docstring's Raises block now documents `BackendUnavailable` (422 `backend_unknown`/`backend_retired`) and `InvalidProgram` (400/422 `validation_error`) alongside the existing entries, matching the actual mapping; `RateLimited.retry_after`'s attribute docs describe both accepted forms and the clamping.

Tests cover all four header shapes (integer seconds, valid HTTP-date, garbage, absent) plus past-date clamping to 0. Suite: 678 passed, 17 skipped, 13 xpassed.