### PR TITLE
docs: fix inaccurate docstrings in ibm.py and PlatformResult

### DIFF
--- a/marqov/executors/ibm.py
+++ b/marqov/executors/ibm.py
@@ -192,7 +192,7 @@ class IBMExecutor(BaseExecutor):
         Args:
             circuit: The quantum circuit to execute.
             shots: Number of measurement shots.
-            **kwargs: Additional options (e.g., optimization_level override).
+            **kwargs: Additional backend-specific options (currently unused).
 
         Returns:
             ExecutionResult with measurement counts and metadata.

--- a/marqov/platform/_models.py
+++ b/marqov/platform/_models.py
@@ -137,7 +137,7 @@ class PlatformInfo:
 class PlatformResult:
     """Measurement result for a completed platform job.
 
-    Wraps the raw JSON response body from the job-result endpoint.  The
+    Wraps the raw ``result`` field from the job status response.  The
     interface is intentionally consistent with
     :class:`marqov.executors.base.ExecutionResult` so SDK users see a
     familiar surface:
@@ -151,7 +151,8 @@ class PlatformResult:
       ``counts`` is ``None`` (server variance) rather than raising.
 
     Attributes:
-        raw: The unmodified JSON response dict from the server.
+        raw: The unmodified ``result`` dict from the job status response
+            (``resp["result"]``, or ``{}`` if absent).
     """
 
     raw: dict


### PR DESCRIPTION
Closes #87. Closes #88.

Two docstring corrections, zero behavior change (suite at baseline: 676 passed, 17 skipped, 13 xpassed):

- `ibm.py execute()`: the `**kwargs` line advertised an `optimization_level` override that the body never reads — now "Additional backend-specific options (currently unused)", matching the honest ionq/rigetti siblings. Documentation-only per the #87 scoping decision; the implement-or-remove question for IBM config options stays with #79.
- `PlatformResult`: the class docstring claimed `raw` holds the full response body from a "job-result endpoint" that doesn't exist; the only construction site (`job.py`) sets it to the `result` sub-dict of the job status response. Now aligned with `api-reference.md`'s accurate wording.