### PR TITLE
fix(docs): correct platform-client test citation, cancel() contract, and drop internal jargon

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ async def bell(shots):
     )
     return result.counts
 
-# @task's non-lattice call path runs fn(*args, **kwargs) directly, so an
-# async @task called bare returns an unawaited coroutine — drive it with
-# asyncio.run() instead of calling bell(1000) on its own.
+# An async @task called outside a @workflow isn't awaited automatically
+# (see marqov/workflows/decorators.py for details) — drive it with
+# asyncio.run() rather than calling bell(1000) bare.
 asyncio.run(bell(1000))
 """
 

--- a/docs/platform-client/error-handling.md
+++ b/docs/platform-client/error-handling.md
@@ -43,7 +43,7 @@ follows:
 - Otherwise `.message` is a generic fallback string (e.g. *"Job \<id\> failed
   (status='failed'). The server error_message is not returned by the status
   endpoint; check the platform dashboard for details."*) — this behaviour is
-  pinned by `tests/test_platform_job.py::test_job_failed_generic_message_when_no_result_error`.
+  pinned by `tests/test_platform_job.py::TestJobResultFailed::test_job_failed_generic_message_when_no_result_error`.
 
 Do not assume `.message` always carries the server's actual failure reason —
 check the platform dashboard for full detail when it doesn't.
@@ -90,14 +90,40 @@ except TimeoutError:
 
 ## Cancellation behaviour
 
-`job.cancel()` sends a best-effort cancellation request to the server and
-returns immediately without confirming the outcome. The server may have
-already moved the job to a terminal state, in which case the cancel request
-is a no-op.
+`job.cancel()` sends a cancellation request to the server. It does **not**
+swallow failures: any non-2xx response raises `MarqovPlatformError`, same as
+any other API call.
 
-A cancelled job ends in the `cancelled` state. When `result()` polls and
-encounters `cancelled`, it raises `JobFailed` (the job reached a terminal
-state that produced no result).
+> **The cancel endpoint is not yet confirmed on the platform.** `cancel()` is
+> implemented against a provisional path (see `job.cancel()` in
+> [`api-reference.md`](api-reference.md)) — until the platform ships a
+> confirmed cancellation route, calling it against the real service will
+> typically raise `MarqovPlatformError` rather than cancel the job.
+
+This matters for cleanup code. A pattern like:
+
+```python
+try:
+    result = job.result(timeout=120.0)
+finally:
+    job.cancel()
+```
+
+lets a raised `MarqovPlatformError` from `cancel()` escape the `finally`
+block and mask whatever exception (if any) was already propagating. If you
+want fire-and-forget cleanup, catch it explicitly:
+
+```python
+finally:
+    try:
+        job.cancel()
+    except MarqovPlatformError:
+        pass  # best-effort — cancellation isn't guaranteed to reach the server
+```
+
+If cancellation does succeed server-side, the job ends in the `cancelled`
+state. When `result()` polls and encounters `cancelled`, it raises
+`JobFailed` (the job reached a terminal state that produced no result).
 
 ---
 

--- a/docs/platform-client/getting-started.md
+++ b/docs/platform-client/getting-started.md
@@ -101,9 +101,8 @@ async def bell(shots):
     )
     return result.counts
 
-# @task's non-lattice call path runs `fn(*args, **kwargs)` directly (see
-# marqov/workflows/decorators.py) — for an async `@task` that returns an
-# unawaited coroutine unless the caller drives it, so wrap the call in
+# An async @task called outside a @workflow isn't awaited automatically
+# (see marqov/workflows/decorators.py for details) — drive it with
 # asyncio.run() rather than calling bell(1000) bare.
 asyncio.run(bell(1000))
 """

--- a/tests/test_platform_job.py
+++ b/tests/test_platform_job.py
@@ -223,7 +223,14 @@ class TestJobResultFailed:
         assert "circuit exceeds qubit limit" in str(exc_info.value)
 
     def test_job_failed_generic_message_when_no_result_error(self):
-        """JobFailed still raised even when result field has no error key."""
+        """JobFailed carries the generic fallback message when result has no error key.
+
+        Pins the exact fallback string quoted in
+        docs/platform-client/error-handling.md — this test is that doc's
+        cited provenance, so a wording change in
+        ``marqov/platform/job.py``'s fallback message must be a deliberate
+        edit to both.
+        """
         t = _make_transport()
         t.request.return_value = _status_payload("failed", result=None)
         job = _make_job(t)
@@ -231,8 +238,12 @@ class TestJobResultFailed:
         with pytest.raises(JobFailed) as exc_info:
             job.result()
 
-        # Confirm it raised JobFailed (the message may be generic)
         assert isinstance(exc_info.value, JobFailed)
+        assert exc_info.value.message == (
+            "Job job-abc failed (status='failed'). The server error_message "
+            "is not returned by the status endpoint; check the platform "
+            "dashboard for details."
+        )
 
     def test_raises_job_failed_on_dispatch_failed(self):
         """dispatch_failed is a server terminal state treated as JobFailed."""


### PR DESCRIPTION
Closes #89. Closes #90.

#89: error-handling.md's cited pytest node ID didn't collect (missing the `TestJobResultFailed` class segment) and the cited test only asserted the exception type. The node ID is fixed and the test now pins the exact generic-fallback message string, so the doc's provenance claim is true and any wording change to `job.py`'s fallback must be a deliberate two-place edit. The Cancellation section is rewritten to match `job.cancel()`'s real contract — raises `MarqovPlatformError` on any non-2xx, provisional server route — including a warning that `finally: job.cancel()` can mask a propagating exception, with the catch-and-swallow pattern shown for fire-and-forget use.

#90: the internal "non-lattice call path" jargon (and a grammatically broken sentence) in the getting-started.md and README quickstart comments is replaced by an identical one-line plain-language note in both places, pointing at `marqov/workflows/decorators.py` for the full explanation instead of maintaining two divergent copies. `grep` confirms no `non-lattice` occurrences remain.

Suite: 676 passed, 17 skipped, 13 xpassed (run twice, identical).