### PR TITLE
chore: add scoped-task issue template and repo guidance for coding agents

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -12,22 +12,23 @@ reporting a bug or requesting a feature, use those templates instead.
 
 **Evidence**
 What is verifiably wrong or missing. Cite exact files and symbols, and pin
-line numbers to a commit (`as of <sha>` — they drift). Show the verification,
-not the suspicion: the command you ran, the measurement you took, the test
-that fails. Claims that were only read for plausibility should say so.
+line numbers to a commit ("as of `<sha>`", since they drift). Show the
+verification, not the suspicion: the command you ran, the measurement you
+took, the test that fails. Claims that were only read for plausibility
+should say so.
 
-**Scope — decided**
-The chosen approach, including forks in the road that are already decided
-(so nobody re-litigates them silently). Name explicit non-goals: files or
+**Scope (decided)**
+The chosen approach, including forks in the road that are already decided,
+so nobody re-litigates them silently. Name explicit non-goals: files or
 behaviors this task must NOT touch, even if adjacent.
 
-**Scope — needs sign-off**
+**Scope (needs sign-off)**
 Anything to investigate and report back on before acting, and any option
 that requires maintainer approval before implementation (e.g. dependency or
 packaging changes). State the default to fall back to.
 
 **Acceptance criteria**
-How to prove the fix works — the verification method, not just the desired
+How to prove the fix works: the verification method, not just the desired
 state. Prefer checks that fail loudly if the fix regresses (a pinned test, a
 planted-regression check). Include escape hatches where relevant: what to
-ship if the ideal fix can't be verified reliably.
+ship if the ideal fix cannot be verified reliably.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,33 @@
+---
+name: Scoped task
+about: A fully-specified task with evidence, decided scope, and acceptance criteria (primarily for maintainer use)
+labels: ''
+---
+
+<!--
+This template is for tasks specified tightly enough that someone can pick
+them up and finish them without a clarification round-trip. If you're
+reporting a bug or requesting a feature, use those templates instead.
+-->
+
+**Evidence**
+What is verifiably wrong or missing. Cite exact files and symbols, and pin
+line numbers to a commit (`as of <sha>` — they drift). Show the verification,
+not the suspicion: the command you ran, the measurement you took, the test
+that fails. Claims that were only read for plausibility should say so.
+
+**Scope — decided**
+The chosen approach, including forks in the road that are already decided
+(so nobody re-litigates them silently). Name explicit non-goals: files or
+behaviors this task must NOT touch, even if adjacent.
+
+**Scope — needs sign-off**
+Anything to investigate and report back on before acting, and any option
+that requires maintainer approval before implementation (e.g. dependency or
+packaging changes). State the default to fall back to.
+
+**Acceptance criteria**
+How to prove the fix works — the verification method, not just the desired
+state. Prefer checks that fail loudly if the fix regresses (a pinned test, a
+planted-regression check). Include escape hatches where relevant: what to
+ship if the ideal fix can't be verified reliably.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# Marqov SDK — guidance for coding agents
+
+Conventions for working in this repo. Setup and architecture details live in
+[CONTRIBUTING.md](CONTRIBUTING.md); this file covers what an automated or
+AI-assisted contributor needs to work here without supervision.
+
+## Environment and tests
+
+- Never use system Python. Use the project venv (`.venv/bin/python`); see
+  CONTRIBUTING.md §Development Setup.
+- Run the full suite with `.venv/bin/python -m pytest` before considering any
+  change done. All tests must pass; do not skip or xfail a failing test to
+  get to green.
+- Ruff and mypy carry some pre-existing findings. Do not fix them in a PR
+  scoped to something else — but do keep your own changed lines clean.
+
+## Scope and style
+
+- Keep diffs scoped to the issue or task at hand. Adjacent cleanups belong in
+  their own PR.
+- Match the surrounding code's style, naming, and comment density.
+- Plain conventional commit messages (`fix(qutip): …`, `docs: …`,
+  `test(boundary): …`); no attribution footers or co-author lines.
+
+## Documentation is a contract
+
+Prose claims — in docs/, README, and docstrings — must be traceable to code.
+Before writing a claim (an API's behavior, a default value, a test citation,
+an install command), verify it against the source. If a doc cites a pytest
+node ID, run `pytest --collect-only` on it. Several tests pin doc/code sync
+(provider lists, the fallback-message wording); expect CI to fail if prose
+and code drift apart.
+
+## Architecture boundary
+
+Core SDK code (everything under `marqov/` except `marqov/platform/`) must
+never import `marqov.platform` — the platform client is a consumer of the
+core, never a dependency of it. This includes type-only imports under
+`if TYPE_CHECKING:`. The rule is enforced by
+`tests/test_platform_package.py::TestCoreDoesNotImportPlatform` and
+documented in `docs/design/platform-client-boundary.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Marqov SDK — guidance for coding agents
+# Marqov SDK: guidance for coding agents
 
 Conventions for working in this repo. Setup and architecture details live in
 [CONTRIBUTING.md](CONTRIBUTING.md); this file covers what an automated or
@@ -7,24 +7,24 @@ AI-assisted contributor needs to work here without supervision.
 ## Environment and tests
 
 - Never use system Python. Use the project venv (`.venv/bin/python`); see
-  CONTRIBUTING.md §Development Setup.
+  CONTRIBUTING.md, Development Setup.
 - Run the full suite with `.venv/bin/python -m pytest` before considering any
   change done. All tests must pass; do not skip or xfail a failing test to
   get to green.
 - Ruff and mypy carry some pre-existing findings. Do not fix them in a PR
-  scoped to something else — but do keep your own changed lines clean.
+  scoped to something else, but do keep your own changed lines clean.
 
 ## Scope and style
 
 - Keep diffs scoped to the issue or task at hand. Adjacent cleanups belong in
   their own PR.
 - Match the surrounding code's style, naming, and comment density.
-- Plain conventional commit messages (`fix(qutip): …`, `docs: …`,
-  `test(boundary): …`); no attribution footers or co-author lines.
+- Plain conventional commit messages (`fix(qutip): ...`, `docs: ...`,
+  `test(boundary): ...`); no attribution footers or co-author lines.
 
 ## Documentation is a contract
 
-Prose claims — in docs/, README, and docstrings — must be traceable to code.
+Prose claims in docs/, README, and docstrings must be traceable to code.
 Before writing a claim (an API's behavior, a default value, a test citation,
 an install command), verify it against the source. If a doc cites a pytest
 node ID, run `pytest --collect-only` on it. Several tests pin doc/code sync
@@ -34,7 +34,7 @@ and code drift apart.
 ## Architecture boundary
 
 Core SDK code (everything under `marqov/` except `marqov/platform/`) must
-never import `marqov.platform` — the platform client is a consumer of the
+never import `marqov.platform`: the platform client is a consumer of the
 core, never a dependency of it. This includes type-only imports under
 `if TYPE_CHECKING:`. The rule is enforced by
 `tests/test_platform_package.py::TestCoreDoesNotImportPlatform` and


### PR DESCRIPTION
Two additions that make well-specified work self-propagating:

- **`.github/ISSUE_TEMPLATE/task.md`** — a "Scoped task" template alongside the existing bug/feature ones: verified evidence (pinned to a commit SHA), decided scope with explicit non-goals, investigate-and-report gates for anything needing sign-off, and acceptance criteria that state the verification method. This is the format that let #82–#90 be picked up and fixed (PRs #91–#97) with zero clarification round-trips.
- **`CLAUDE.md`** — repo-root guidance for automated/AI-assisted contributors: venv + full-suite requirements, scoped-diff and commit conventions, the docs-must-trace-to-code rule, and the core→platform import boundary with a pointer to its enforcing test.

No code changes; suite unaffected.