### PR TITLE
feat(executors): add Qilimanjaro qilisdk local-simulator executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ result = await executor.execute(circuit, shots=1000)
 | Quantinuum | Available |
 | Quantum Brilliance | Available — requires `qristal` installed separately (not on PyPI, no `marqov[...]` extra); build from source or use the Docker image: https://qristal.readthedocs.io/ |
 | CUDA-Q | Available — not in `[all]` (GPU-heavy); install separately with `pip install "marqov[cudaq]"` |
+| Qilimanjaro (qilisdk local simulators) | Available — not in `[all]`; install separately with `pip install "marqov[qilisdk]"` |
 
 ---
 

--- a/marqov/__init__.py
+++ b/marqov/__init__.py
@@ -6,7 +6,7 @@ Marqov provides:
 - Automatic parallelization of independent tasks
 - Temporal-backed workflow durability and scheduling
 - Multi-vendor execution (AWS Braket, IBM Quantum, Azure Quantum, IonQ Direct,
-  Rigetti QCS, Quantinuum, CUDA-Q, Quantum Brilliance, Local)
+  Rigetti QCS, Quantinuum, CUDA-Q, Quantum Brilliance, Qilimanjaro, Local)
 
 Quick Start with @task/@workflow:
     >>> from marqov import task, workflow, Circuit

--- a/marqov/executors/__init__.py
+++ b/marqov/executors/__init__.py
@@ -11,6 +11,7 @@ Available executors:
 - IBMExecutor: IBM Quantum (Heron r2, Eagle, etc. via Qiskit Runtime)
 - IonQExecutor: IonQ Direct API (native REST, no Braket intermediary)
 - RigettiExecutor: Rigetti QCS QPUs and the local QVM (via pyquil)
+- QiliSDKExecutor: Qilimanjaro qilisdk local simulators (QiliSim/QutipBackend)
 
 Example:
     >>> from marqov.executors import LocalExecutor
@@ -29,6 +30,7 @@ from marqov.executors.factory import ExecutorFactory
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
 from marqov.executors.ionq import IonQExecutor, IonQExecutorConfig
 from marqov.executors.local import LocalExecutor
+from marqov.executors.qilisdk import QiliSDKExecutor, QiliSDKExecutorConfig
 from marqov.executors.quantinuum import QuantinuumExecutor, QuantinuumExecutorConfig
 from marqov.executors.rigetti import RigettiExecutor, RigettiExecutorConfig
 from marqov.simulation.executor import SimulationExecutor
@@ -49,6 +51,8 @@ __all__ = [
     "IonQExecutor",
     "IonQExecutorConfig",
     "LocalExecutor",
+    "QiliSDKExecutor",
+    "QiliSDKExecutorConfig",
     "QuantinuumExecutor",
     "QuantinuumExecutorConfig",
     "RigettiExecutor",

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -17,22 +17,20 @@ Example:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from marqov.executors.azure import AzureQuantumExecutor, AzureQuantumExecutorConfig
 from marqov.executors.base import BaseExecutor
 from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
-from marqov.executors.cudaq import CudaqExecutor, CudaqExecutorConfig, _SLUG_TO_TARGET
+from marqov.executors.cudaq import _SLUG_TO_TARGET, CudaqExecutor, CudaqExecutorConfig
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
 from marqov.executors.ionq import IonQExecutor, IonQExecutorConfig
 from marqov.executors.local import LocalExecutor
+from marqov.executors.qilisdk import QiliSDKExecutor, QiliSDKExecutorConfig
+from marqov.executors.quantinuum import QuantinuumExecutor, QuantinuumExecutorConfig
 from marqov.executors.rigetti import RigettiExecutor, RigettiExecutorConfig
 from marqov.simulation.config import SimulationConfig
 from marqov.simulation.executor import SimulationExecutor
-from marqov.executors.quantinuum import QuantinuumExecutor, QuantinuumExecutorConfig
-
-if TYPE_CHECKING:
-    pass
 
 
 class ExecutorFactory:
@@ -55,6 +53,9 @@ class ExecutorFactory:
           the official Docker image; see https://qristal.readthedocs.io/.
         - Local: QuantumFlow simulator (no cloud required)
         - IonQ Direct: Native IonQ REST API (no AWS/Braket intermediary)
+        - Qilimanjaro: qilisdk local simulators (QiliSim or QutipBackend, no
+          cloud required). Requires ``qilisdk`` — see
+          ``pip install marqov[qilisdk]``.
 
     Example:
         >>> from marqov.executors.factory import ExecutorFactory
@@ -104,6 +105,10 @@ class ExecutorFactory:
         # Handle local simulator
         if backend_slug == "local" or provider == "Local":
             return LocalExecutor()
+
+        # Qilimanjaro qilisdk (local simulator only — QiliSim or QutipBackend)
+        if provider == "Qilimanjaro":
+            return cls._create_qilisdk_executor(backend_slug, backend_config)
 
         # NVIDIA CUDA-Q (GPU/CPU statevector, direct IQM)
         if provider == "CUDA-Q" or backend_slug in _SLUG_TO_TARGET:
@@ -410,6 +415,28 @@ class ExecutorFactory:
         return CudaqExecutor(CudaqExecutorConfig(**config_kwargs))
 
     @classmethod
+    def _create_qilisdk_executor(
+        cls,
+        backend_slug: str,
+        backend_config: dict[str, Any],
+    ) -> QiliSDKExecutor:
+        """Create a Qilimanjaro qilisdk local-simulator executor from configuration.
+
+        No field is strictly required: the simulator falls back to "qilisim"
+        (qilisdk's own C++ simulator, ships in the base package) unless
+        "qutip" is requested, which needs the `qilisdk[qutip]` extra.
+
+        Args:
+            backend_slug: Backend slug (e.g. "qilisdk-qilisim", "qilisdk-qutip").
+            backend_config: Optional ``simulator`` ("qilisim" | "qutip").
+
+        Returns:
+            Configured QiliSDKExecutor instance.
+        """
+        simulator = backend_config.get("simulator", "qilisim")
+        return QiliSDKExecutor(QiliSDKExecutorConfig(simulator=simulator))
+
+    @classmethod
     def _create_simulation_executor(
         cls,
         backend_slug: str,
@@ -448,6 +475,7 @@ class ExecutorFactory:
             "CUDA-Q",
             "Local",
             "Quantinuum",
+            "Qilimanjaro",
         ]
 
     @classmethod

--- a/marqov/executors/qilisdk.py
+++ b/marqov/executors/qilisdk.py
@@ -1,0 +1,182 @@
+"""Local executor using Qilimanjaro's qilisdk simulators.
+
+Runs circuits on qilisdk's own open-source simulator stack — QiliSim (their
+C++ simulator, ships in the base `qilisdk` package) or QutipBackend (pure-
+Python reference sim). No SpeQtrum account or network call required.
+
+See https://github.com/qilimanjaro-tech/qilisdk.
+"""
+
+import time
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from marqov.circuits import Circuit
+from marqov.executors.base import BaseExecutor, ExecutionResult
+
+# Extra pip-install hint appended to the ImportError for backends with their
+# own optional dependency beyond the base `qilisdk` package.
+_SIMULATOR_EXTRA = {"qutip": ' (qutip extra: pip install "qilisdk[qutip]")'}
+
+
+@dataclass
+class QiliSDKExecutorConfig:
+    """Configuration for the qilisdk local-simulator executor.
+
+    Attributes:
+        simulator: Which qilisdk backend to run on — "qilisim" (their C++
+            simulator, ships in the base `qilisdk` package) or "qutip"
+            (pure-Python reference sim, requires `pip install "qilisdk[qutip]"`).
+    """
+
+    simulator: Literal["qilisim", "qutip"] = "qilisim"
+
+
+class QiliSDKExecutor(BaseExecutor):
+    """Execute circuits on Qilimanjaro's qilisdk local simulators.
+
+    Runs entirely locally against qilisdk's own simulator stack (QiliSim or
+    QutipBackend) — no SpeQtrum account or cloud dependency required.
+
+    Example:
+        >>> executor = QiliSDKExecutor()
+        >>> circuit = Circuit().h(0).cnot(0, 1)
+        >>> result = await executor.execute(circuit, shots=1000)
+        >>> print(result.counts)  # {"00": ~500, "11": ~500}
+
+    For the pure-Python reference simulator instead of QiliSim:
+        >>> executor = QiliSDKExecutor(QiliSDKExecutorConfig(simulator="qutip"))
+    """
+
+    def __init__(self, config: QiliSDKExecutorConfig | None = None) -> None:
+        """Initialize the qilisdk executor.
+
+        Args:
+            config: Configuration options. Uses defaults (QiliSim) if not provided.
+
+        Raises:
+            ImportError: If qilisdk (or, for the qutip simulator, its qutip
+                extra) is not installed.
+        """
+        self.config = config or QiliSDKExecutorConfig()
+        if self.config.simulator not in ("qilisim", "qutip"):
+            raise ValueError(
+                f"Unknown qilisdk simulator '{self.config.simulator}'. "
+                "Supported: 'qilisim', 'qutip'."
+            )
+        try:
+            if self.config.simulator == "qutip":
+                from qilisdk.backends import QutipBackend
+
+                self._backend = QutipBackend()
+            else:
+                from qilisdk.backends import QiliSim
+
+                self._backend = QiliSim()
+        except ImportError as exc:
+            extra = _SIMULATOR_EXTRA.get(self.config.simulator, "")
+            raise ImportError(
+                f"qilisdk is required for QiliSDKExecutor. "
+                f"Install with: pip install marqov[qilisdk]{extra}"
+            ) from exc
+
+    async def execute(
+        self,
+        circuit: Circuit,
+        shots: int = 1000,
+        **kwargs: Any,
+    ) -> ExecutionResult:
+        """Run circuit on a qilisdk local simulator.
+
+        Args:
+            circuit: The circuit to execute.
+            shots: Number of measurement shots.
+            **kwargs: Additional options (ignored today).
+
+        Returns:
+            ExecutionResult with measurement counts.
+        """
+        circuit = self._validate_circuit(circuit)
+
+        from qilisdk.functionals import DigitalPropagation
+        from qilisdk.readout import Readout
+
+        start_time = time.perf_counter()
+
+        qili_circuit = self._to_qilisdk_circuit(circuit)
+        propagation = DigitalPropagation(circuit=qili_circuit)
+        readout = Readout().with_sampling(nshots=shots)
+
+        result = self._backend.execute(propagation, readout)
+        counts = result.get_samples()
+
+        execution_time_ms = (time.perf_counter() - start_time) * 1000
+
+        return ExecutionResult(
+            counts=counts,
+            backend=f"qilisdk-{self.config.simulator}",
+            execution_time_ms=execution_time_ms,
+            shots=shots,
+            raw_result=result,
+            metadata={"simulator": self.config.simulator},
+        )
+
+    def _to_qilisdk_circuit(self, circuit: Circuit) -> Any:
+        """Translate a Marqov Circuit into a qilisdk digital Circuit.
+
+        Walks the same internal gate list `Circuit.to_dict()`/`from_dict()`
+        consume (`circuit._qf._elements`) rather than adding a second export
+        path. Marqov's canonical gate set maps 1:1 onto qilisdk's digital
+        gate constructors.
+
+        Args:
+            circuit: The Marqov circuit to translate.
+
+        Returns:
+            An equivalent qilisdk.digital.Circuit.
+
+        Raises:
+            NotImplementedError: If the circuit contains a gate outside
+                Marqov's canonical set (H/X/Y/Z/S/T/Rx/Ry/Rz/CNOT/CZ/SWAP).
+        """
+        from qilisdk.digital import CNOT, CZ, RX, RY, RZ, SWAP, H, S, T, X, Y, Z
+        from qilisdk.digital import Circuit as QiliCircuit
+
+        qili_circuit = QiliCircuit(circuit.num_qubits)
+
+        for op in circuit._qf._elements:
+            name = op.name
+            qubits = list(op.qubits)
+            params = list(op.params) if hasattr(op, "params") and op.params else []
+
+            if name == "H":
+                qili_circuit.add(H(qubits[0]))
+            elif name == "X":
+                qili_circuit.add(X(qubits[0]))
+            elif name == "Y":
+                qili_circuit.add(Y(qubits[0]))
+            elif name == "Z":
+                qili_circuit.add(Z(qubits[0]))
+            elif name == "S":
+                qili_circuit.add(S(qubits[0]))
+            elif name == "T":
+                qili_circuit.add(T(qubits[0]))
+            elif name == "Rx":
+                qili_circuit.add(RX(qubits[0], theta=float(params[0])))
+            elif name == "Ry":
+                qili_circuit.add(RY(qubits[0], theta=float(params[0])))
+            elif name == "Rz":
+                qili_circuit.add(RZ(qubits[0], phi=float(params[0])))
+            elif name == "CNot":
+                qili_circuit.add(CNOT(qubits[0], qubits[1]))
+            elif name == "CZ":
+                qili_circuit.add(CZ(qubits[0], qubits[1]))
+            elif name == "Swap":
+                qili_circuit.add(SWAP(qubits[0], qubits[1]))
+            else:
+                raise NotImplementedError(
+                    f"QiliSDKExecutor: unsupported gate '{name}'. "
+                    "Supported: H, X, Y, Z, S, T, Rx, Ry, Rz, CNOT, CZ, SWAP."
+                )
+
+        return qili_circuit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,9 @@ ionq = [
 rigetti = [
     "pyquil>=4.0.0",
 ]
+qilisdk = [
+    "qilisdk>=0.2.1",
+]
 all = [
     "qiskit>=1.0.0",
     "qiskit-ibm-runtime>=0.20.0",

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -876,7 +876,7 @@ class TestExecutorFactory:
         assert set(ExecutorFactory.get_supported_providers()) == {
             "Local", "AWS Braket", "IBM Quantum", "Quantinuum",
             "Azure Quantum", "IonQ Direct", "Rigetti QCS", "Quantum Brilliance",
-            "CUDA-Q",
+            "CUDA-Q", "Qilimanjaro",
         }
 
     def test_unsupported_provider_error_lists_all_supported_providers(self) -> None:

--- a/tests/test_qilisdk_executor.py
+++ b/tests/test_qilisdk_executor.py
@@ -1,0 +1,123 @@
+"""Tests for marqov.executors.qilisdk (Qilimanjaro qilisdk local simulators)."""
+
+import pytest
+
+qilisdk = pytest.importorskip("qilisdk")
+
+from marqov.circuits import Circuit, bell_state, ghz_state
+from marqov.executors import ExecutionResult, ExecutorFactory, QiliSDKExecutor
+from marqov.executors.qilisdk import QiliSDKExecutorConfig
+
+
+class TestQiliSDKExecutor:
+    """Tests for QiliSDKExecutor."""
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_result(self) -> None:
+        """Execute returns an ExecutionResult."""
+        executor = QiliSDKExecutor()
+        circuit = Circuit().h(0)
+        result = await executor.execute(circuit, shots=100)
+
+        assert isinstance(result, ExecutionResult)
+        assert result.backend == "qilisdk-qilisim"
+        assert result.shots == 100
+
+    @pytest.mark.asyncio
+    async def test_execute_bell_state(self) -> None:
+        """Bell state produces expected measurement distribution."""
+        executor = QiliSDKExecutor()
+        circuit = bell_state()
+        result = await executor.execute(circuit, shots=1000)
+
+        assert set(result.counts.keys()).issubset({"00", "11"})
+        assert sum(result.counts.values()) == 1000
+        for count in result.counts.values():
+            assert 400 < count < 600
+
+    @pytest.mark.asyncio
+    async def test_execute_ghz_state(self) -> None:
+        """GHZ state on 3 qubits only produces all-0s or all-1s."""
+        executor = QiliSDKExecutor()
+        circuit = ghz_state(3)
+        result = await executor.execute(circuit, shots=500)
+
+        assert set(result.counts.keys()).issubset({"000", "111"})
+        assert sum(result.counts.values()) == 500
+
+    @pytest.mark.asyncio
+    async def test_execute_all_supported_gates(self) -> None:
+        """A circuit touching every canonical gate runs without error."""
+        executor = QiliSDKExecutor()
+        circuit = (
+            Circuit()
+            .h(0)
+            .x(1)
+            .y(0)
+            .z(1)
+            .s(0)
+            .t(1)
+            .rx(0.3, 0)
+            .ry(0.6, 1)
+            .rz(0.9, 0)
+            .cnot(0, 1)
+            .cz(0, 1)
+            .swap(0, 1)
+        )
+        result = await executor.execute(circuit, shots=50)
+
+        assert sum(result.counts.values()) == 50
+
+    @pytest.mark.asyncio
+    async def test_execute_metadata(self) -> None:
+        """Execution includes simulator metadata."""
+        executor = QiliSDKExecutor()
+        circuit = Circuit().x(0)
+        result = await executor.execute(circuit, shots=10)
+
+        assert result.metadata == {"simulator": "qilisim"}
+
+    @pytest.mark.asyncio
+    async def test_execute_qutip_backend(self) -> None:
+        """The qutip reference simulator produces the same-shaped result."""
+        pytest.importorskip("qutip")
+
+        executor = QiliSDKExecutor(QiliSDKExecutorConfig(simulator="qutip"))
+        circuit = bell_state()
+        result = await executor.execute(circuit, shots=200)
+
+        assert result.backend == "qilisdk-qutip"
+        assert set(result.counts.keys()).issubset({"00", "11"})
+        assert sum(result.counts.values()) == 200
+
+    def test_unsupported_simulator_raises(self) -> None:
+        """An unknown simulator name raises immediately, not a silent fallback."""
+        with pytest.raises(ValueError, match="Unknown qilisdk simulator"):
+            QiliSDKExecutor(QiliSDKExecutorConfig(simulator="not-a-real-backend"))  # type: ignore[arg-type]
+
+
+class TestQiliSDKExecutorFactory:
+    """Tests for creating QiliSDKExecutor via ExecutorFactory."""
+
+    def test_create_qilisdk_executor_default(self) -> None:
+        """Factory creates a QiliSim-backed executor by default."""
+        executor = ExecutorFactory.create_executor(
+            "qilisdk-qilisim", {"provider": "Qilimanjaro"}
+        )
+        assert isinstance(executor, QiliSDKExecutor)
+        assert executor.config.simulator == "qilisim"
+
+    def test_create_qilisdk_executor_qutip(self) -> None:
+        """Factory honors an explicit qutip simulator selection."""
+        pytest.importorskip("qutip")
+
+        executor = ExecutorFactory.create_executor(
+            "qilisdk-qutip", {"provider": "Qilimanjaro", "simulator": "qutip"}
+        )
+        assert isinstance(executor, QiliSDKExecutor)
+        assert executor.config.simulator == "qutip"
+
+    def test_qilimanjaro_in_supported_providers(self) -> None:
+        """Qilimanjaro appears in the supported-providers list."""
+        assert "Qilimanjaro" in ExecutorFactory.get_supported_providers()
+        assert ExecutorFactory.is_provider_supported("Qilimanjaro")


### PR DESCRIPTION
## Summary
- Adds `QiliSDKExecutor`, wrapping Qilimanjaro's open-source `qilisdk` local simulators (`QiliSim` / `QutipBackend`) behind Marqov's existing `BaseExecutor` interface — no cloud account or SpeQtrum credentials required.
- Registers `Qilimanjaro` as a new provider in `ExecutorFactory`, with a `qilisdk` optional extra in `pyproject.toml`.
- First concrete step in the Marqov ↔ Qilimanjaro collaboration (David met Vyron Vasileiadis, core Qilimanjaro engineer, in person) — local-simulator only for now. SpeQtrum cloud access is gated behind a beta signup and will follow as a separate PR once credentials are in hand.

## Test plan
- [x] `pytest tests/test_qilisdk_executor.py tests/test_executors.py` — 76/76 pass, covering Bell/GHZ states, all 12 canonical gates, both `QiliSim` and `QutipBackend`, factory wiring, and error handling
- [x] Verified end-to-end against a real `qilisdk==0.2.1.post1` install (not mocked)
- [x] `ruff check` clean on all touched files
- [x] Confirmed pre-existing failures elsewhere in the suite (missing `qiskit`/`cirq`/`cudaq` extras) are unrelated, by diffing against unmodified `main`