### PR TITLE
chore(release): bump version to 0.5.0 + date changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to the `marqov` SDK are documented here. This project follow
 still change between minor versions; `1.0.0` is reserved for the first API-stable
 release.
 
+## [0.5.0] — 2026-08-21
+
+### Added
+
+- **`QiliSDKExecutor` — a new `Qilimanjaro` provider running on `qilisdk`'s
+  local simulators.** Wraps `QiliSim` (their own C++ simulator, ships in the
+  base `qilisdk` package) or `QutipBackend` (pure-Python reference sim, via
+  `qilisdk`'s own `qutip` extra) behind the same `BaseExecutor` interface as
+  every other provider — no cloud account or SpeQtrum credentials required.
+  Marqov's canonical gate set (`H`/`X`/`Y`/`Z`/`S`/`T`/`Rx`/`Ry`/`Rz`/`CNOT`/
+  `CZ`/`SWAP`) translates 1:1 onto `qilisdk.digital` gate constructors; results
+  come back through `qilisdk`'s `SamplingReadoutResult.samples`. First step of
+  the Qilimanjaro integration — real-hardware/SpeQtrum access is a follow-up
+  once beta credentials are available.
+
+  `qilisdk` is installed separately (`pip install qilisdk`), not via a
+  `marqov[...]` extra, the same treatment as Quantum Brilliance's `qristal`:
+  `qilisdk` requires `numpy>=2.3` (macOS) / `>=2.4.1` (elsewhere), which only
+  overlaps marqov's own `numpy<2.4` core pin in the macOS `2.3.x` window. A
+  formal `marqov[qilisdk]` extra was tried and reverted — even scoped with a
+  `sys_platform == "darwin"` marker, its mere presence in
+  `[project.optional-dependencies]` made the *entire* `uv.lock` unresolvable
+  (uv locks the union of all extras together, so one platform-incompatible
+  extra poisons the whole project, not just itself). (marqov-sdk#104)
+
+- **`normalized_fidelity` and related application-level benchmarking
+  metrics**, in `marqov/benchmarking/`. The Lubinski et al. / QED-C metric
+  `max(0, (F_backend − F_uniform) / (1 − F_uniform))` normalizes out the
+  trivial uniform-noise baseline, alongside new `classical_fidelity`
+  (Bhattacharyya fidelity) and `fidelity_with_uniform` helpers. Where the
+  existing SPAM tooling measures per-qubit readout error, this measures how
+  faithfully a whole application's output distribution survives on real
+  hardware. Ported from Open QBench (Apache-2.0), attributed in the module.
+  (marqov-sdk#59)
+
+### Fixed
+
+- **Local backend format conversion ignored stray credentials.**
+  `_to_backend_format()` was missing the local-backend short-circuit that
+  `_get_provider_device()` and `run()` both already had, so `backend="local"`
+  with a leftover `ibm_token`/`azure_subscription_id` in params converted the
+  circuit to Qiskit while the device build stayed on Braket's
+  `LocalSimulator`, which doesn't accept it. (marqov-sdk#102)
+
+### Internal
+
+- **`uv.lock` regenerated across all extras** — the `cudaq` extra was declared
+  in `pyproject.toml` but never locked, so `uv sync --extra cudaq --frozen`
+  hit the network instead of resolving from the lock. Two gaps hit during the
+  0.4.1 release are now documented in `RELEASING.md`: a bare release-branch
+  push gets no CI run (open a PR against `main` instead), and the `pypi`
+  GitHub Environment's required-reviewer gate silently waits on approval.
+  (marqov-sdk#100)
+
 ## [0.4.1] — 2026-08-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ result = await executor.execute(circuit, shots=1000)
 | Quantinuum | Available |
 | Quantum Brilliance | Available — requires `qristal` installed separately (not on PyPI, no `marqov[...]` extra); build from source or use the Docker image: https://qristal.readthedocs.io/ |
 | CUDA-Q | Available — not in `[all]` (GPU-heavy); install separately with `pip install "marqov[cudaq]"` |
-| Qilimanjaro (qilisdk local simulators) | Available — not in `[all]`; install separately with `pip install "marqov[qilisdk]"` |
+| Qilimanjaro (qilisdk local simulators) | Available — not on PyPI as a `marqov[...]` extra (like Quantum Brilliance): `qilisdk`'s numpy floor is incompatible with marqov's own numpy ceiling outside a narrow macOS overlap window. Install separately: `pip install qilisdk`. |
 
 ---
 

--- a/marqov/__init__.py
+++ b/marqov/__init__.py
@@ -34,7 +34,7 @@ Simple circuit execution:
     >>> result = await executor.execute(circuit, shots=1000)
 """
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 
 # Re-export commonly used items for convenience
 from marqov.circuits import Circuit, bell_state, ghz_state

--- a/marqov/executors/factory.py
+++ b/marqov/executors/factory.py
@@ -54,8 +54,11 @@ class ExecutorFactory:
         - Local: QuantumFlow simulator (no cloud required)
         - IonQ Direct: Native IonQ REST API (no AWS/Braket intermediary)
         - Qilimanjaro: qilisdk local simulators (QiliSim or QutipBackend, no
-          cloud required). Requires ``qilisdk`` — see
-          ``pip install marqov[qilisdk]``.
+          cloud required). Requires ``qilisdk`` — installed separately
+          (``pip install qilisdk``), not via a ``marqov[...]`` extra: its
+          numpy floor is incompatible with marqov's own numpy ceiling outside
+          a narrow macOS overlap window, which would make it unresolvable as
+          a formal extra in marqov's dependency lock.
 
     Example:
         >>> from marqov.executors.factory import ExecutorFactory

--- a/marqov/executors/qilisdk.py
+++ b/marqov/executors/qilisdk.py
@@ -4,6 +4,12 @@ Runs circuits on qilisdk's own open-source simulator stack — QiliSim (their
 C++ simulator, ships in the base `qilisdk` package) or QutipBackend (pure-
 Python reference sim). No SpeQtrum account or network call required.
 
+`qilisdk` is installed separately (``pip install qilisdk``), not via a
+`marqov[...]` extra: its numpy floor (>=2.3 on macOS, >=2.4.1 elsewhere)
+is incompatible with marqov's own numpy<2.4 core pin outside a narrow
+macOS overlap window, which makes it unresolvable as a formal extra in
+marqov's own dependency lock.
+
 See https://github.com/qilimanjaro-tech/qilisdk.
 """
 
@@ -25,8 +31,9 @@ class QiliSDKExecutorConfig:
 
     Attributes:
         simulator: Which qilisdk backend to run on — "qilisim" (their C++
-            simulator, ships in the base `qilisdk` package) or "qutip"
-            (pure-Python reference sim, requires `pip install "qilisdk[qutip]"`).
+            simulator, ships in the base `qilisdk` package, `pip install
+            qilisdk`) or "qutip" (pure-Python reference sim, `pip install
+            "qilisdk[qutip]"`).
     """
 
     simulator: Literal["qilisim", "qutip"] = "qilisim"
@@ -77,7 +84,7 @@ class QiliSDKExecutor(BaseExecutor):
             extra = _SIMULATOR_EXTRA.get(self.config.simulator, "")
             raise ImportError(
                 f"qilisdk is required for QiliSDKExecutor. "
-                f"Install with: pip install marqov[qilisdk]{extra}"
+                f"Install with: pip install qilisdk{extra}"
             ) from exc
 
     async def execute(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,9 +102,6 @@ ionq = [
 rigetti = [
     "pyquil>=4.0.0",
 ]
-qilisdk = [
-    "qilisdk>=0.2.1",
-]
 all = [
     "qiskit>=1.0.0",
     "qiskit-ibm-runtime>=0.20.0",

--- a/tests/test_qilisdk_executor.py
+++ b/tests/test_qilisdk_executor.py
@@ -4,9 +4,9 @@ import pytest
 
 qilisdk = pytest.importorskip("qilisdk")
 
-from marqov.circuits import Circuit, bell_state, ghz_state
-from marqov.executors import ExecutionResult, ExecutorFactory, QiliSDKExecutor
-from marqov.executors.qilisdk import QiliSDKExecutorConfig
+from marqov.circuits import Circuit, bell_state, ghz_state  # noqa: E402
+from marqov.executors import ExecutionResult, ExecutorFactory, QiliSDKExecutor  # noqa: E402
+from marqov.executors.qilisdk import QiliSDKExecutorConfig  # noqa: E402
 
 
 class TestQiliSDKExecutor:


### PR DESCRIPTION
## Summary
Release prep for 0.5.0 — bundles everything merged since v0.4.1:
- feat: Qilimanjaro `qilisdk` local-simulator executor (#104)
- feat: `normalized_fidelity` / Lubinski-QED-C benchmarking metric (#59)
- fix: local backend format conversion ignored stray credentials (#102)
- chore: uv.lock regenerated + two release-runbook gaps documented (#100)

Also fixes a real bug found during release pre-flight: a formal `marqov[qilisdk]` extra is unresolvable via `uv` — its mere presence in `[project.optional-dependencies]` poisons the whole lockfile (even scoped with a `sys_platform == "darwin"` marker), because `qilisdk`'s numpy floor conflicts with marqov's own numpy ceiling almost everywhere. Documented as a separate `pip install qilisdk`, the same treatment as Quantum Brilliance's `qristal`.

This PR exists to trigger CI on the exact release SHA per `RELEASING.md` — **not to be merged yet**. `main` will be fast-forwarded to this commit once CI is green, ahead of the `v0.5.0` tag push.

## Test plan
- [x] Hygiene gate: `pytest tests/test_no_private_references.py`
- [x] Full suite with all extras + qilisdk: 733 passed, 0 failed
- [x] `tools/check_urls.py`: 11 clean, 4 warn (pre-existing, eyeballed), 0 non-resolving
- [x] `uv build` + `twine check dist/*`: both PASSED
- [x] TestPyPI dry-run (`release.yml` via `workflow_dispatch`): build ✅, publish-testpypi ✅, publish-pypi correctly skipped
- [x] Installed the **published** TestPyPI artifact into a clean venv, imported it, and ran a real Bell-state circuit end-to-end on `QiliSim` — confirmed working, not just built