### PR TITLE
feat(executors): add CUNQAExecutor for distributed-QC runs on Slurm

### DIFF
--- a/marqov/executors/__init__.py
+++ b/marqov/executors/__init__.py
@@ -5,6 +5,7 @@ This module provides executors for running quantum circuits on various backends.
 Available executors:
 - LocalExecutor: QuantumFlow simulator (no cloud required)
 - CudaqExecutor: NVIDIA CUDA-Q (GPU/CPU statevector, direct IQM)
+- CUNQAExecutor: CESGA CUNQA distributed-QC emulator (Slurm-based vQPUs)
 - BraketExecutor: AWS Braket (simulators and QPUs)
 - AzureQuantumExecutor: Azure Quantum (Quantinuum, PASQAL, IonQ, Rigetti)
 - QuantinuumExecutor: Quantinuum devices and emulators (via pytket-quantinuum)
@@ -26,6 +27,7 @@ from marqov.executors.azure import AzureQuantumExecutor, AzureQuantumExecutorCon
 from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
 from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
 from marqov.executors.cudaq import CudaqExecutor, CudaqExecutorConfig
+from marqov.executors.cunqa import CUNQAExecutor, CUNQAExecutorConfig
 from marqov.executors.factory import ExecutorFactory
 from marqov.executors.ibm import IBMExecutor, IBMExecutorConfig
 from marqov.executors.ionq import IonQExecutor, IonQExecutorConfig
@@ -41,6 +43,8 @@ __all__ = [
     "BaseExecutor",
     "BraketExecutor",
     "BraketExecutorConfig",
+    "CUNQAExecutor",
+    "CUNQAExecutorConfig",
     "CudaqExecutor",
     "CudaqExecutorConfig",
     "DeviceStatus",

--- a/marqov/executors/cunqa.py
+++ b/marqov/executors/cunqa.py
@@ -1,0 +1,331 @@
+"""CUNQA executor for running circuits distributed across vQPUs on a Slurm cluster.
+
+CUNQA (CESGA, Apache-2.0) is a distributed quantum-computing emulator that
+runs vQPUs as Slurm tasks. This executor launches a family of vQPUs via
+``qraise``, splits the requested shots evenly across them, gathers and merges
+results, and always tears the family down with ``qdrop`` — including on
+failure or cancellation, so a crashed or timed-out run doesn't strand Slurm
+allocations.
+
+This targets Phase 0 of the CUNQA PoC (docs/plans/marqov-cunqa-poc.md in
+marqov-research): correctness only, N≈4, no failover/reproducibility/scaling
+logic yet.
+
+Example:
+    >>> from marqov.circuits import bell_state
+    >>> from marqov.executors import CUNQAExecutor, CUNQAExecutorConfig
+    >>>
+    >>> config = CUNQAExecutorConfig(n_qpus=2, walltime="00:05:00")
+    >>> executor = CUNQAExecutor(config)
+    >>> result = await executor.execute(bell_state(), shots=1000)
+    >>> print(result.counts)
+
+``cunqa`` is an optional dependency, and only importable on a machine with
+CUNQA built and on ``sys.path``. CUNQA has no PyPI wheel — ``pip install
+marqov[cunqa]`` only installs the Qiskit pin, not CUNQA itself.
+
+API surface verified 2026-08-21 directly against CESGA-Quantum-Spain/cunqa
+source (cunqa/qpu.py, cunqa/qjob.py, cunqa/result.py, and the qraise C++
+backend on `main`). Confirmed real shape:
+- ``from cunqa.qpu import qraise, get_QPUs, run, qdrop``
+- ``from cunqa.qjob import gather``
+- ``qraise(n, t, *, family=None, co_located=True, mem_per_qpu=None, ...) -> str``
+  (returns the family name). ``mem_per_qpu`` is opt-in — if omitted, the
+  generated sbatch script has NO memory request at all. Units confirmed GB
+  at ``cunqa/qpu.py:382-383`` — Python appends the ``"G"`` suffix itself
+  (``f"--mem-per-qpu={mem_per_qpu}G"``) before shelling out. Note this is
+  the PYTHON path's units; a raw CLI invocation of the C++ binary directly
+  is a DIFFERENT code path with unverified flag spelling/units — see the
+  smoke-test note in the marqov-research plan's Task 3.
+- ``get_QPUs(co_located: bool = False, family: str | None = None) -> list``
+- ``run(circuits, qpus, param_values=None, **run_args) -> list`` — no
+  documented ``seed`` kwarg (Phase 1 scope, not wired in here)
+- ``gather(qjobs) -> list`` of results exposing ``.counts`` as a
+  **property**, not a ``.get_counts()`` method. Note this is CUNQA's own
+  result serialization — established for CUNQA specifically, not inherited
+  from qiskit-aer's key format, even though CUNQA wraps a modified Aer
+  internally. If a live run's modal outcome doesn't match the Aer-verified
+  expected bin, check the key format first (hex vs binary, single string
+  vs space-separated per-register) before suspecting the circuit itself.
+- ``qdrop(*families: str, remove_logs: bool = False)``
+
+``Circuit.to_qiskit()`` returns the gate sequence only — Marqov's ``Circuit``
+IR has no measurement concept at all (confirmed: ``_SKIP_INSTRUCTIONS``
+discards ``measure`` on the way in via ``from_qiskit``, and ``to_qiskit()``
+is a bare unitary transpile with no measurement synthesis). Every executor
+in this codebase is responsible for adding its own measurements —
+``RigettiExecutor._build_measured_program`` is the existing precedent this
+follows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
+
+if TYPE_CHECKING:
+    from marqov.circuits import Circuit
+
+logger = logging.getLogger(__name__)
+
+
+def add_measure_all(qiskit_circuit: Any) -> Any:
+    """Return a copy of ``qiskit_circuit`` with a classical register added
+    and every qubit measured into it.
+
+    Marqov's ``Circuit.to_qiskit()`` never carries measurements (see module
+    docstring) — this is the CUNQA equivalent of
+    ``RigettiExecutor._build_measured_program``'s "measure every qubit"
+    step. Exposed as a module-level function (not a private method) so
+    tests can apply the exact same transformation the executor uses,
+    instead of duplicating the logic and risking drift.
+
+    Raises:
+        ValueError: if the circuit already has any classical bits.
+            ``Circuit.to_qiskit()`` never produces one (it's unitary-only)
+            — this is the only input shape this function ever legitimately
+            receives, so any pre-existing clbits are rejected outright
+            rather than silently tolerated.
+    """
+    from qiskit import ClassicalRegister
+
+    measured = qiskit_circuit.copy()
+    if measured.num_clbits:
+        raise ValueError(
+            f"expected a measurement-free circuit, got one with {measured.num_clbits} clbits"
+        )
+    measured.add_register(ClassicalRegister(measured.num_qubits, "c"))
+    measured.measure(range(measured.num_qubits), range(measured.num_qubits))
+    return measured
+
+
+class CunqaClient(Protocol):
+    """The subset of CUNQA's Python API this executor calls.
+
+    CUNQA itself exposes these as free functions in ``cunqa.qpu`` /
+    ``cunqa.qjob``, not methods on an object — ``_CunqaModuleClient`` below
+    adapts them to this Protocol so the executor can depend on an injectable
+    interface instead of importing the module directly.
+    """
+
+    def qraise(self, n_qpus: int, walltime: str, **kwargs: Any) -> str: ...
+    def get_QPUs(self, co_located: bool, family: str) -> list[Any]: ...
+    def run(self, circuits: list[Any], qpus: list[Any], **run_args: Any) -> list[Any]: ...
+    def gather(self, jobs: list[Any]) -> list[Any]: ...
+    def qdrop(self, family: str) -> None: ...
+
+
+class _CunqaModuleClient:
+    """Adapts CUNQA's free functions (cunqa.qpu / cunqa.qjob) to CunqaClient.
+
+    A bare module object doesn't satisfy a self-bearing Protocol, and CUNQA's
+    functions live in two different submodules — this class is the seam that
+    makes both of those non-issues for the executor.
+    """
+
+    def __init__(self) -> None:
+        from cunqa.qjob import gather as _gather
+        from cunqa.qpu import get_QPUs as _get_QPUs
+        from cunqa.qpu import qdrop as _qdrop
+        from cunqa.qpu import qraise as _qraise
+        from cunqa.qpu import run as _run
+
+        self._qraise = _qraise
+        self._get_QPUs = _get_QPUs
+        self._run = _run
+        self._gather = _gather
+        self._qdrop = _qdrop
+
+    def qraise(self, n_qpus: int, walltime: str, **kwargs: Any) -> str:
+        return self._qraise(n_qpus, walltime, **kwargs)
+
+    def get_QPUs(self, co_located: bool, family: str) -> list[Any]:
+        return self._get_QPUs(co_located=co_located, family=family)
+
+    def run(self, circuits: list[Any], qpus: list[Any], **run_args: Any) -> list[Any]:
+        return self._run(circuits, qpus, **run_args)
+
+    def gather(self, jobs: list[Any]) -> list[Any]:
+        return self._gather(jobs)
+
+    def qdrop(self, family: str) -> None:
+        self._qdrop(family)
+
+
+@dataclass
+class CUNQAExecutorConfig:
+    """Configuration for the CUNQA distributed-QC executor.
+
+    Attributes:
+        n_qpus: Number of vQPUs to raise for the run (Phase 0 target: N≈4).
+            Requested shots must be evenly divisible by n_qpus.
+        walltime: Slurm walltime for the vQPU allocation, ``HH:MM:SS``.
+        simulator: CUNQA backend simulator name (``"Aer"``, per README).
+        co_located: Whether vQPUs share a node (CUNQA README default: True).
+        classical_comm: Raise vQPUs with classical inter-vQPU communication.
+        quantum_comm: Raise vQPUs with quantum inter-vQPU communication.
+        mem_per_qpu_gb: Memory (GB) requested per vQPU, forwarded to
+            qraise's ``mem_per_qpu`` (confirmed GB units — see module
+            docstring). Required for ``EnableMemoryBasedScheduling`` to
+            have anything to enforce. Default is a conservative guess for a
+            handful of qubits, not CESGA's 15GB default — right-size after
+            observing real usage on a live cluster.
+        startup_timeout_s: Max seconds to wait for all n_qpus vQPUs to
+            register after ``qraise`` before raising TimeoutError.
+        poll_interval_s: Seconds between readiness polls. Clamped so the
+            final poll never sleeps past startup_timeout_s.
+        seed: Reserved for Phase 1 (deterministic seeding). NOT wired into
+            ``run()`` yet — CUNQA's run() has no documented seed kwarg.
+    """
+
+    n_qpus: int = 4
+    walltime: str = "00:10:00"
+    simulator: str = "Aer"
+    co_located: bool = True
+    classical_comm: bool = False
+    quantum_comm: bool = False
+    mem_per_qpu_gb: int = 4
+    startup_timeout_s: float = 60.0
+    poll_interval_s: float = 1.0
+    seed: int = 0
+
+
+class CUNQAExecutor(BaseExecutor):
+    """Runs circuits distributed across CUNQA vQPUs on a Slurm cluster.
+
+    Shot-parallel semantics: the requested ``shots`` are split evenly across
+    ``n_qpus`` vQPUs (matching the CUNQA paper's no-comm scaling benchmark),
+    not run independently per vQPU. Counts are merged across all vQPUs.
+    """
+
+    def __init__(self, config: CUNQAExecutorConfig, client: CunqaClient | None = None) -> None:
+        self._config = config
+        self._client = client if client is not None else _CunqaModuleClient()
+
+    async def execute(self, circuit: "Circuit", shots: int = 1000, **kwargs: Any) -> ExecutionResult:
+        circuit = self._validate_circuit(circuit)
+        cfg = self._config
+
+        if shots % cfg.n_qpus != 0:
+            raise ValueError(
+                f"shots ({shots}) must be evenly divisible by n_qpus ({cfg.n_qpus}) "
+                f"for Phase 0's shot-parallel split — remainder handling is not yet built"
+            )
+        shots_per_qpu = shots // cfg.n_qpus
+
+        qiskit_circuit = await asyncio.to_thread(circuit.to_qiskit)
+        qiskit_circuit = add_measure_all(qiskit_circuit)
+
+        family = await asyncio.to_thread(
+            self._client.qraise,
+            cfg.n_qpus,
+            cfg.walltime,
+            simulator=cfg.simulator,
+            co_located=cfg.co_located,
+            classical_comm=cfg.classical_comm,
+            quantum_comm=cfg.quantum_comm,
+            mem_per_qpu=cfg.mem_per_qpu_gb,
+        )
+        start = time.monotonic()
+        try:
+            qpus = await self._wait_for_qpus_ready(family, cfg)
+            circuits = [qiskit_circuit.copy() for _ in qpus]
+            jobs = await asyncio.to_thread(self._client.run, circuits, qpus, shots=shots_per_qpu)
+            results = await asyncio.to_thread(self._client.gather, jobs)
+        finally:
+            await self._teardown(family)
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        merged_counts: Counter[str] = Counter()
+        per_qpu_counts: list[dict[str, int]] = []
+        for result in results:
+            merged_counts.update(result.counts)
+            per_qpu_counts.append(dict(result.counts))
+        counts = dict(merged_counts)
+
+        total = sum(counts.values())
+        if total != shots:
+            raise RuntimeError(
+                f"shot conservation violated: expected {shots} total shots "
+                f"({cfg.n_qpus} vQPUs x {shots_per_qpu} each), got {total} (counts={counts})"
+            )
+
+        return ExecutionResult(
+            counts=counts,
+            backend=self.name,
+            execution_time_ms=elapsed_ms,
+            shots=shots,
+            raw_result=results,
+            metadata={
+                "n_qpus": cfg.n_qpus,
+                "family": family,
+                "shots_per_qpu": shots_per_qpu,
+                "per_qpu_counts": per_qpu_counts,
+            },
+        )
+
+    async def _teardown(self, family: str) -> None:
+        # Teardown must happen on the failure AND cancellation path.
+        #
+        # In plain asyncio a single cancel() delivers CancelledError once;
+        # a bare `await qdrop(...)` here would normally still complete
+        # fine. shield exists for the narrower, real case that matters in
+        # production: a SECOND cancellation arriving during cleanup itself
+        # (Temporal activity timeouts and asyncio.wait_for-style wrappers
+        # do exactly this). shield protects the qdrop call from that
+        # repeated cancellation, but only guarantees "not cancelled
+        # *again*", not "definitely awaited to completion" — so on a
+        # CancelledError raised THROUGH the shield, we must still wait for
+        # the still-running drop before re-raising, rather than abandoning
+        # it as an orphaned, unretrieved-exception task. That follow-up
+        # wait is ITSELF shielded too, for the same reason.
+        #
+        # Known, accepted residual gap: a THIRD cancellation landing on
+        # that second shielded await still isn't caught by `except
+        # Exception` there — CancelledError would propagate from it and
+        # leave `drop` orphaned (though still shielded and running to
+        # completion). Three nested cancellations during one teardown is
+        # past the point of worthwhile hardening.
+        #
+        # Also: CancelledError is a BaseException (since Python 3.8), not
+        # an Exception — a bare `except Exception` does NOT catch it,
+        # which is why it needs its own clause, separate from the generic
+        # log-and-swallow handler below.
+        drop = asyncio.ensure_future(asyncio.to_thread(self._client.qdrop, family))
+        try:
+            await asyncio.shield(drop)
+        except asyncio.CancelledError:
+            try:
+                await asyncio.shield(drop)
+            except Exception:
+                logger.exception(
+                    "qdrop failed for family %s; allocation may be stranded", family
+                )
+            raise
+        except Exception:
+            logger.exception(
+                "qdrop failed for family %s; allocation may be stranded", family
+            )
+
+    async def _wait_for_qpus_ready(self, family: str, cfg: CUNQAExecutorConfig) -> list[Any]:
+        deadline = time.monotonic() + cfg.startup_timeout_s
+        qpus: list[Any] = []
+        while time.monotonic() < deadline:
+            qpus = await asyncio.to_thread(self._client.get_QPUs, cfg.co_located, family)
+            if len(qpus) >= cfg.n_qpus:
+                return qpus
+            remaining = deadline - time.monotonic()
+            await asyncio.sleep(min(cfg.poll_interval_s, max(0.0, remaining)))
+        raise TimeoutError(
+            f"{len(qpus)}/{cfg.n_qpus} vQPUs registered within {cfg.startup_timeout_s}s "
+            f"for family {family!r}"
+        )
+
+    async def get_status(self) -> DeviceStatus:
+        return DeviceStatus.always_online()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,11 @@ dev = [
     # tests (tests/qutip/test_record.py). Not a runtime dependency — record.py
     # duck-types the qutip Result and never imports qutip itself.
     "qutip>=5.3.0,<6.0.0",
+    # Test-only: tests/test_cunqa_qpe_reference_circuit.py simulates the QPE
+    # reference circuit directly via AerSimulator to verify it independently
+    # of any live CUNQA cluster. Not a runtime dependency of cunqa.py itself
+    # (CUNQA wraps its own Aer internally, on the cluster).
+    "qiskit-aer>=0.14.0",
 ]
 qiskit = [
     "qiskit>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,11 @@ rigetti = [
 qilisdk = [
     "qilisdk>=0.2.1",
 ]
+cunqa = [
+    "qiskit==1.2.4",  # CUNQA's pinned Qiskit version — exact match, not a floor.
+                      # This extra does NOT install cunqa itself — no PyPI wheel exists;
+                      # it must be built from source (see marqov-research's CUNQA PoC infra).
+]
 all = [
     "qiskit>=1.0.0",
     "qiskit-ibm-runtime>=0.20.0",

--- a/tests/_qpe_reference.py
+++ b/tests/_qpe_reference.py
@@ -1,0 +1,47 @@
+"""Shared no-comm QPE circuit builder for the CUNQA PoC's Phase 0 tests.
+
+Used by both tests/test_cunqa_qpe_reference_circuit.py (pure-Python,
+no-cluster verification) and tests/integration/test_cunqa_parallelcluster.py
+(the real cluster-gated run). A single source avoids the two tests drifting
+apart, which duplicating this function across both files would risk.
+"""
+
+import math
+
+from qiskit import QuantumCircuit
+from qiskit.circuit.library import QFT
+
+
+def build_no_comm_qpe_circuit(n_counting_qubits: int, phase: float) -> QuantumCircuit:
+    """Standard textbook QPE: n counting qubits + 1 eigenstate qubit.
+
+    Exponent convention (2**q on counting qubit q) verified against Qiskit's
+    QFT(inverse=True): gives the exact expected bin in 2000/2000 shots at
+    phase=5/16, n=4 (see test_cunqa_qpe_reference_circuit.py). Matches the
+    structure of arXiv:2511.05209's QPE benchmark. Uses n=4 here for the
+    Phase 0 smoke test, NOT the paper's n=16 — that's a Phase 3 scaling
+    concern.
+    """
+    qc = QuantumCircuit(n_counting_qubits + 1)
+    qc.x(n_counting_qubits)  # eigenstate qubit starts in |1>
+
+    for q in range(n_counting_qubits):
+        qc.h(q)
+
+    for q in range(n_counting_qubits):
+        angle = 2 * math.pi * phase * (2**q)
+        qc.cp(angle, q, n_counting_qubits)
+
+    qc.append(QFT(n_counting_qubits, inverse=True), range(n_counting_qubits))
+    return qc
+
+
+def expected_phase_bin(n_counting_qubits: int, phase: float) -> str:
+    """The expected measurement bitstring for build_no_comm_qpe_circuit's
+    output once every qubit is measured (marqov.executors.cunqa.add_measure_all).
+
+    Leftmost bit is the eigenstate qubit (index n_counting_qubits) — always
+    |1>, followed by the n-bit phase estimate. Confirmed empirically
+    (2000/2000 exact match via qiskit-aer).
+    """
+    return "1" + format(round(phase * (2**n_counting_qubits)), f"0{n_counting_qubits}b")

--- a/tests/test_cunqa_executor.py
+++ b/tests/test_cunqa_executor.py
@@ -1,0 +1,266 @@
+"""Tests for the CUNQA distributed-QC executor.
+
+Uses an injected CunqaClient double so these tests never launch a real Slurm
+job or need a cluster.
+"""
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from marqov.circuits import bell_state
+from marqov.executors import CUNQAExecutor, ExecutionResult
+from marqov.executors.cunqa import CUNQAExecutorConfig
+
+_FAST_POLL = {"startup_timeout_s": 5.0, "poll_interval_s": 0.01}
+
+
+class _FakeCunqaResult:
+    def __init__(self, counts: dict[str, int]) -> None:
+        self.counts = counts
+
+
+class _FakeCunqaClient:
+    def __init__(self, counts_per_qpu: dict[str, int], *, ready_after_polls: int = 0) -> None:
+        self._counts_per_qpu = counts_per_qpu
+        self._ready_after_polls = ready_after_polls
+        self._poll_count = 0
+        self.qraise_calls: list[dict[str, Any]] = []
+        self.get_qpus_calls: list[dict[str, Any]] = []
+        self.run_calls: list[dict[str, Any]] = []
+        self.submitted_circuits: list[Any] = []
+        self.dropped: list[str] = []
+
+    def qraise(self, n_qpus: int, walltime: str, **kwargs: Any) -> str:
+        self.qraise_calls.append({"n_qpus": n_qpus, "walltime": walltime, **kwargs})
+        return "test-family"
+
+    def get_QPUs(self, co_located: bool, family: str) -> list[str]:
+        self.get_qpus_calls.append({"co_located": co_located, "family": family})
+        self._poll_count += 1
+        n_qpus = self.qraise_calls[-1]["n_qpus"]
+        if self._poll_count <= self._ready_after_polls:
+            return []
+        return [f"qpu-{i}" for i in range(n_qpus)]
+
+    def run(self, circuits: list[Any], qpus: list[Any], **run_args: Any) -> list[Any]:
+        self.run_calls.append({"n_circuits": len(circuits), "n_qpus": len(qpus), **run_args})
+        self.submitted_circuits = circuits
+        return [f"job-{i}" for i in range(len(qpus))]
+
+    def gather(self, jobs: list[Any]) -> list[_FakeCunqaResult]:
+        return [_FakeCunqaResult(dict(self._counts_per_qpu)) for _ in jobs]
+
+    def qdrop(self, family: str) -> None:
+        self.dropped.append(family)
+
+
+@pytest.mark.asyncio
+async def test_execute_splits_shots_and_merges_counts_across_qpus() -> None:
+    fake_client = _FakeCunqaClient(counts_per_qpu={"00": 128, "11": 122})
+    config = CUNQAExecutorConfig(n_qpus=4, walltime="00:05:00", **_FAST_POLL)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    result = await executor.execute(bell_state(), shots=1000)
+
+    assert isinstance(result, ExecutionResult)
+    assert result.counts == {"00": 512, "11": 488}
+    assert result.backend == "CUNQAExecutor"
+    assert result.shots == 1000
+    assert sum(result.counts.values()) == 1000
+    assert result.metadata["per_qpu_counts"] == [{"00": 128, "11": 122}] * 4
+
+
+@pytest.mark.asyncio
+async def test_execute_submits_measured_circuits() -> None:
+    fake_client = _FakeCunqaClient(counts_per_qpu={"00": 128, "11": 122})
+    config = CUNQAExecutorConfig(n_qpus=4, walltime="00:05:00", **_FAST_POLL)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    await executor.execute(bell_state(), shots=1000)
+
+    submitted = fake_client.submitted_circuits[0]
+    assert submitted.num_clbits == submitted.num_qubits
+    assert any(inst.operation.name == "measure" for inst in submitted.data)
+
+
+@pytest.mark.asyncio
+async def test_execute_passes_shots_per_qpu_not_total_to_run() -> None:
+    fake_client = _FakeCunqaClient(counts_per_qpu={"00": 128, "11": 122})
+    config = CUNQAExecutorConfig(n_qpus=4, walltime="00:05:00", **_FAST_POLL)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    await executor.execute(bell_state(), shots=1000)
+
+    assert fake_client.run_calls[0]["shots"] == 250
+    assert fake_client.run_calls[0]["n_circuits"] == 4
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_shots_not_evenly_divisible_by_n_qpus() -> None:
+    fake_client = _FakeCunqaClient(counts_per_qpu={"0": 1})
+    config = CUNQAExecutorConfig(n_qpus=3, walltime="00:05:00", **_FAST_POLL)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    with pytest.raises(ValueError, match="evenly divisible"):
+        await executor.execute(bell_state(), shots=1000)
+
+    assert fake_client.qraise_calls == []
+
+
+@pytest.mark.asyncio
+async def test_execute_forwards_config_to_qraise() -> None:
+    fake_client = _FakeCunqaClient(counts_per_qpu={"00": 250})
+    config = CUNQAExecutorConfig(
+        n_qpus=2,
+        walltime="00:07:00",
+        simulator="Aer",
+        co_located=False,
+        classical_comm=True,
+        mem_per_qpu_gb=8,
+        **_FAST_POLL,
+    )
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    await executor.execute(bell_state(), shots=500)
+
+    assert fake_client.qraise_calls[0] == {
+        "n_qpus": 2,
+        "walltime": "00:07:00",
+        "simulator": "Aer",
+        "co_located": False,
+        "classical_comm": True,
+        "quantum_comm": False,
+        "mem_per_qpu": 8,
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_waits_for_qpus_to_register_before_running() -> None:
+    fake_client = _FakeCunqaClient(counts_per_qpu={"00": 500}, ready_after_polls=2)
+    config = CUNQAExecutorConfig(n_qpus=2, walltime="00:05:00", **_FAST_POLL)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    result = await executor.execute(bell_state(), shots=1000)
+
+    assert fake_client.get_qpus_calls
+    assert result.counts == {"00": 1000}
+
+
+@pytest.mark.asyncio
+async def test_execute_raises_timeout_if_qpus_never_register() -> None:
+    fake_client = _FakeCunqaClient(counts_per_qpu={}, ready_after_polls=10**6)
+    config = CUNQAExecutorConfig(n_qpus=2, walltime="00:05:00", startup_timeout_s=0.05, poll_interval_s=0.01)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    with pytest.raises(TimeoutError, match="registered"):
+        await executor.execute(bell_state(), shots=1000)
+
+    assert fake_client.dropped == ["test-family"]
+
+
+@pytest.mark.asyncio
+async def test_execute_raises_shot_conservation_error_on_count_mismatch() -> None:
+    fake_client = _FakeCunqaClient(counts_per_qpu={"00": 50, "11": 50})
+    config = CUNQAExecutorConfig(n_qpus=2, walltime="00:05:00", **_FAST_POLL)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    with pytest.raises(RuntimeError, match="shot conservation"):
+        await executor.execute(bell_state(), shots=1000)
+
+
+@pytest.mark.asyncio
+async def test_execute_always_drops_qpus_even_on_run_failure() -> None:
+    class _RaisingClient(_FakeCunqaClient):
+        def run(self, circuits: list[Any], qpus: list[Any], **run_args: Any) -> list[Any]:
+            raise RuntimeError("simulated cluster failure")
+
+    fake_client = _RaisingClient(counts_per_qpu={})
+    config = CUNQAExecutorConfig(n_qpus=2, walltime="00:05:00", **_FAST_POLL)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    with pytest.raises(RuntimeError, match="simulated cluster failure"):
+        await executor.execute(bell_state(), shots=1000)
+
+    assert fake_client.dropped == ["test-family"]
+
+
+@pytest.mark.asyncio
+async def test_execute_drops_qpus_on_cancellation() -> None:
+    class _SlowRunClient(_FakeCunqaClient):
+        def run(self, circuits: list[Any], qpus: list[Any], **run_args: Any) -> list[Any]:
+            time.sleep(0.5)
+            return super().run(circuits, qpus, **run_args)
+
+    fake_client = _SlowRunClient(counts_per_qpu={"00": 500})
+    config = CUNQAExecutorConfig(n_qpus=2, walltime="00:05:00", **_FAST_POLL)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    task = asyncio.create_task(executor.execute(bell_state(), shots=1000))
+    await asyncio.sleep(0.05)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert fake_client.dropped == ["test-family"]
+
+
+@pytest.mark.asyncio
+async def test_execute_survives_repeated_cancellation_during_teardown() -> None:
+    class _SlowRunAndDropClient(_FakeCunqaClient):
+        def run(self, circuits: list[Any], qpus: list[Any], **run_args: Any) -> list[Any]:
+            time.sleep(0.2)
+            return super().run(circuits, qpus, **run_args)
+
+        def qdrop(self, family: str) -> None:
+            time.sleep(0.3)
+            super().qdrop(family)
+
+    fake_client = _SlowRunAndDropClient(counts_per_qpu={"00": 500})
+    config = CUNQAExecutorConfig(n_qpus=2, walltime="00:05:00", **_FAST_POLL)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    task = asyncio.create_task(executor.execute(bell_state(), shots=1000))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await asyncio.sleep(0.05)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert fake_client.dropped == ["test-family"]
+
+
+@pytest.mark.asyncio
+async def test_execute_qdrop_failure_does_not_mask_original_exception() -> None:
+    class _DoubleFailingClient(_FakeCunqaClient):
+        def run(self, circuits: list[Any], qpus: list[Any], **run_args: Any) -> list[Any]:
+            raise RuntimeError("original failure: circuit rejected")
+
+        def qdrop(self, family: str) -> None:
+            raise RuntimeError("qdrop also failed: cluster unreachable")
+
+    fake_client = _DoubleFailingClient(counts_per_qpu={})
+    config = CUNQAExecutorConfig(n_qpus=2, walltime="00:05:00", **_FAST_POLL)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    with pytest.raises(RuntimeError, match="original failure: circuit rejected"):
+        await executor.execute(bell_state(), shots=1000)
+
+
+def test_config_defaults() -> None:
+    config = CUNQAExecutorConfig()
+    assert config.n_qpus == 4
+    assert config.walltime == "00:10:00"
+    assert config.simulator == "Aer"
+    assert config.co_located is True
+    assert config.classical_comm is False
+    assert config.quantum_comm is False
+    assert config.mem_per_qpu_gb == 4
+    assert config.startup_timeout_s == 60.0
+    assert config.poll_interval_s == 1.0
+    assert config.seed == 0

--- a/tests/test_cunqa_qpe_reference_circuit.py
+++ b/tests/test_cunqa_qpe_reference_circuit.py
@@ -1,0 +1,72 @@
+"""Committed, re-runnable verification for the no-comm QPE circuit used by
+tests/integration/test_cunqa_parallelcluster.py.
+
+Pure-Python, no-cluster checks. Both circuit tests measure ALL qubits (via
+add_measure_all, the same helper CUNQAExecutor itself uses).
+"""
+
+from qiskit import ClassicalRegister, QuantumCircuit, transpile
+from qiskit_aer import AerSimulator
+
+from marqov.circuits import Circuit
+from marqov.executors.cunqa import add_measure_all
+from tests._qpe_reference import build_no_comm_qpe_circuit, expected_phase_bin
+
+
+def test_qpe_exponent_convention_recovers_correct_phase_bin() -> None:
+    """The bit-ordering check: 2**q on counting qubit q must pair correctly
+    with Qiskit's QFT(inverse=True) convention."""
+    n, phase = 4, 0.3125  # = 5/16, exactly representable at n=4
+    expected_bin = expected_phase_bin(n, phase)
+
+    qc = add_measure_all(build_no_comm_qpe_circuit(n, phase))
+    sim = AerSimulator()
+    tqc = transpile(qc, sim)
+    result = sim.run(tqc, shots=2000, seed_simulator=42).result()
+    counts = result.get_counts()
+
+    modal = max(counts, key=counts.get)
+    assert modal == expected_bin
+    assert counts[expected_bin] / 2000 > 0.95
+
+
+def test_from_qiskit_round_trip_still_recovers_correct_phase_bin() -> None:
+    """Semantic round-trip check: the actual property Task 4 depends on."""
+    n, phase = 4, 0.3125
+    expected_bin = expected_phase_bin(n, phase)
+
+    round_tripped = Circuit.from_qiskit(build_no_comm_qpe_circuit(n, phase)).to_qiskit()
+    measured = add_measure_all(round_tripped)
+
+    sim = AerSimulator()
+    tqc = transpile(measured, sim)
+    counts = sim.run(tqc, shots=2000, seed_simulator=42).result().get_counts()
+
+    assert counts[expected_bin] / 2000 > 0.95
+
+
+def test_add_measure_all_rejects_any_preexisting_classical_bits() -> None:
+    """add_measure_all must reject ANY input with clbits already present —
+    not just a partial register. Circuit.to_qiskit() never produces one
+    (it's unitary-only), so there's nothing legitimate to tolerate."""
+    import pytest
+
+    qc = QuantumCircuit(3)
+    qc.add_register(ClassicalRegister(1, "partial"))
+
+    with pytest.raises(ValueError, match="measurement-free"):
+        add_measure_all(qc)
+
+
+def test_add_measure_all_rejects_full_width_unmeasured_circuit() -> None:
+    """A circuit with a full-width classical register but zero measure
+    instructions must be rejected, not silently passed through unmeasured —
+    the bare-unitary bug this function exists to prevent."""
+    import pytest
+
+    qc = QuantumCircuit(3)
+    qc.add_register(ClassicalRegister(3, "c"))
+    qc.h(0)  # some gate, deliberately no .measure() call
+
+    with pytest.raises(ValueError, match="measurement-free"):
+        add_measure_all(qc)

--- a/uv.lock
+++ b/uv.lock
@@ -1482,6 +1482,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "qiskit-aer" },
     { name = "qutip" },
     { name = "ruff" },
 ]
@@ -1559,6 +1560,7 @@ requires-dist = [
     { name = "qiskit", marker = "extra == 'pytket'", specifier = ">=1.0.0" },
     { name = "qiskit", marker = "extra == 'qiskit'", specifier = ">=1.0.0" },
     { name = "qiskit", marker = "extra == 'quantinuum'", specifier = ">=1.0.0" },
+    { name = "qiskit-aer", marker = "extra == 'dev'", specifier = ">=0.14.0" },
     { name = "qiskit-ibm-runtime", marker = "extra == 'all'", specifier = ">=0.20.0" },
     { name = "qiskit-ibm-runtime", marker = "extra == 'ibm'", specifier = ">=0.20.0" },
     { name = "qiskit-qasm3-import", marker = "extra == 'all'", specifier = ">=0.5.0" },


### PR DESCRIPTION
## Summary
- Adds `CUNQAExecutor`/`CUNQAExecutorConfig` — runs circuits distributed across CESGA CUNQA vQPUs on a Slurm cluster, following the existing `RigettiExecutor` pattern
- Raises a family of vQPUs via `qraise`, splits requested shots evenly across them (shot-parallel, matching the CUNQA paper's no-comm scaling benchmark), gathers/merges results, always tears down via `qdrop` including on failure or cancellation
- Marqov's `Circuit` IR carries no measurement concept — this executor adds its own measurements before submitting (`add_measure_all`), same as `RigettiExecutor` does

## Verification
API surface verified directly against CESGA-Quantum-Spain/cunqa source (not assumed) — submodule import paths, `.counts` as a property not a method, `mem_per_qpu`'s GB units, `qraise`'s opt-in memory request. Went through several rounds of adversarial review that caught and fixed: a wrong initial API surface, a QFT bit-ordering bug, a missing-measurement bug (recurred 3x across different fixes — now has dedicated permanent test coverage), and an `asyncio` cancellation-masking bug in the teardown path.

17 unit tests against injected doubles, no live cluster required — all passing.

## Not in scope
- `ExecutorFactory` wiring (no `CUNQA` provider row exists in the platform DB yet, nothing needs it)
- Cluster-gated integration test (lands once a live CUNQA cluster exists — see the companion plan in `marqov-research`)

This is Phase 0 of the CUNQA PoC — see `docs/plans/marqov-cunqa-poc.md` and `docs/plans/2026-08-21-cunqa-poc-phase-0.md` in `marqov-research`.