### PR TITLE
feat(executors): add QiliSDKExecutor.execute_analog() for qilisdk annealing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ release.
   (uv locks the union of all extras together, so one platform-incompatible
   extra poisons the whole project, not just itself). (marqov-sdk#104)
 
+- **`QiliSDKExecutor.execute_analog()` — analog/annealing mode on qilisdk's local simulators.**
+  Runs Qilimanjaro's actual hardware differentiator (fluxonium quantum annealing) locally, via
+  `qilisdk.analog.Hamiltonian`/`Schedule` and the `AnalogEvolution` functional — no SpeQtrum
+  account needed here either. Deliberately not part of the shared `BaseExecutor` contract:
+  analog Hamiltonians have no Marqov-canonical representation the way digital gate circuits do
+  (`qilisdk`'s own program type — `Hamiltonian`/`Schedule` — is passed straight through), and no
+  other Marqov backend has an analog capability yet to unify against. A survey of how Braket,
+  Azure Quantum, CUDA-Q, and classical heterogeneous-compute systems (Kubernetes, MLIR, XLA, Ray,
+  Slurm) all handle this same digital/analog split confirmed the pattern: shared job-lifecycle
+  contract, paradigm-native program types — never one flat representation for both.
+
 - **`normalized_fidelity` and related application-level benchmarking
   metrics**, in `marqov/benchmarking/`. The Lubinski et al. / QED-C metric
   `max(0, (F_backend − F_uniform) / (1 − F_uniform))` normalizes out the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,43 @@ status. Job polling (queued → running → completed) is handled internally ins
 The default `BaseExecutor.get_status()` returns `DeviceStatus.always_online()`.
 Cloud backends should override this to query the provider's device status endpoint.
 
+### Exceptions to the shape
+
+Two executors deliberately deviate from "just implement `execute()`." If you're
+building something that might need a similar deviation, read these first rather
+than reinventing the reasoning.
+
+**`QiliSDKExecutor.execute_analog()`** (`marqov/executors/qilisdk.py`) — an
+additional method, outside the `BaseExecutor` contract, for running analog
+Hamiltonian evolution (`qilisdk.analog.Hamiltonian`/`Schedule`) rather than a
+gate-based `Circuit`. This isn't a shortcut — analog Hamiltonians and digital
+circuits are different mathematical objects, and every major platform (AWS
+Braket, Azure Quantum, NVIDIA CUDA-Q) keeps them as separate program types for
+the same reason, unifying only at the job-submission/result layer. If you add
+another analog-capable backend (D-Wave, QuEra), give it its own
+`execute_analog()`-shaped method rather than forcing a shared analog input type
+across backends — there's no portable representation for analog programs the
+way `Circuit` is portable across digital ones. `execute_analog()` still returns
+the same `ExecutionResult` as `execute()`, so only the input side is special.
+
+**`CUNQAExecutor`** (`marqov/executors/cunqa.py`) — implements `execute()`
+exactly like every other executor, but as of this writing is not wired into
+`ExecutorFactory.create_executor()`'s provider dispatch. Construct it directly
+until that's done; check `factory.py` for whether this note is still accurate
+before relying on it.
+
+**`qilisdk` and `qristal` aren't `marqov[...]` extras.** Both are installed
+separately (`pip install qilisdk`, or build `qristal` from source/Docker for
+Quantum Brilliance) rather than declared in `[project.optional-dependencies]`.
+For `qristal` it's simply not on PyPI. For `qilisdk`, a formal extra was tried
+and reverted: `uv` locks the union of all declared extras together, so
+`qilisdk`'s numpy floor conflicting with marqov's own numpy ceiling made the
+*entire* `uv.lock` unresolvable — even scoped with a `sys_platform == "darwin"`
+marker, and even for developers who never requested the extra. If a new
+backend's own dependencies don't nest cleanly inside marqov's core pins across
+every platform `uv` resolves for, don't fight `uv`'s marker-forking behavior —
+document a manual `pip install` instead.
+
 ## §3 — Adding a New Executor
 
 1. Create `marqov/executors/<name>.py` with a config dataclass and executor class:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ result = await executor.execute(circuit, shots=1000)
 | Quantinuum | Available |
 | Quantum Brilliance | Available — requires `qristal` installed separately (not on PyPI, no `marqov[...]` extra); build from source or use the Docker image: https://qristal.readthedocs.io/ |
 | CUDA-Q | Available — not in `[all]` (GPU-heavy); install separately with `pip install "marqov[cudaq]"` |
-| Qilimanjaro (qilisdk local simulators) | Available — not on PyPI as a `marqov[...]` extra (like Quantum Brilliance): `qilisdk`'s numpy floor is incompatible with marqov's own numpy ceiling outside a narrow macOS overlap window. Install separately: `pip install qilisdk`. |
+| Qilimanjaro (qilisdk local simulators — digital `execute()` and analog `execute_analog()`) | Available — not on PyPI as a `marqov[...]` extra (like Quantum Brilliance): `qilisdk`'s numpy floor is incompatible with marqov's own numpy ceiling outside a narrow macOS overlap window. Install separately: `pip install qilisdk`. |
 | CESGA CUNQA (distributed-QC emulator, Slurm-based) | Available — not on PyPI at all (no wheel; build from source, see `CESGA-Quantum-Spain/cunqa`) and not a `marqov[...]` extra: CUNQA's exact `qiskit==1.2.4` pin would downgrade the whole project's lockfile if included in `[project.optional-dependencies]`, same class of problem `qilisdk` had. Install `qiskit==1.2.4` separately in the environment where CUNQA is built. |
 
 ---

--- a/marqov/executors/qilisdk.py
+++ b/marqov/executors/qilisdk.py
@@ -13,12 +13,18 @@ marqov's own dependency lock.
 See https://github.com/qilimanjaro-tech/qilisdk.
 """
 
+from __future__ import annotations
+
 import time
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from marqov.circuits import Circuit
 from marqov.executors.base import BaseExecutor, ExecutionResult
+
+if TYPE_CHECKING:
+    from qilisdk.analog import Schedule
+    from qilisdk.core.qtensor import InitialState, QTensor
 
 # Extra pip-install hint appended to the ImportError for backends with their
 # own optional dependency beyond the base `qilisdk` package.
@@ -53,6 +59,22 @@ class QiliSDKExecutor(BaseExecutor):
 
     For the pure-Python reference simulator instead of QiliSim:
         >>> executor = QiliSDKExecutor(QiliSDKExecutorConfig(simulator="qutip"))
+
+    `execute_analog()` additionally exposes qilisdk's analog/annealing mode
+    (`Hamiltonian`/`Schedule`/`AnalogEvolution`) — Qilimanjaro's actual
+    hardware differentiator (fluxonium quantum annealing), simulated locally.
+    This is deliberately qilisdk-specific, not part of the shared
+    `BaseExecutor` contract: analog Hamiltonians don't have a Marqov-canonical
+    representation the way digital gate circuits do, and no other Marqov
+    backend has an analog capability yet to unify against. See
+    `qilisdk.analog.Hamiltonian`/`Schedule` for the program-building API.
+
+        >>> from qilisdk.analog import Hamiltonian, Schedule, PauliX, PauliZ
+        >>> driver = Hamiltonian({(PauliX(0),): 1.0, (PauliX(1),): 1.0})
+        >>> problem = Hamiltonian({(PauliZ(0), PauliZ(1)): 1.0})
+        >>> schedule = Schedule.linear(driver, problem, total_time=5.0, dt=0.05)
+        >>> result = await executor.execute_analog(schedule, shots=500)
+        >>> print(result.counts)  # ground-state-biased, e.g. {"00": ~250, "11": ~250, ...}
     """
 
     def __init__(self, config: QiliSDKExecutorConfig | None = None) -> None:
@@ -126,6 +148,60 @@ class QiliSDKExecutor(BaseExecutor):
             shots=shots,
             raw_result=result,
             metadata={"simulator": self.config.simulator},
+        )
+
+    async def execute_analog(
+        self,
+        schedule: Schedule,
+        shots: int = 1000,
+        initial_state: InitialState | QTensor | None = None,
+        **kwargs: Any,
+    ) -> ExecutionResult:
+        """Run a qilisdk analog (Hamiltonian-evolution) program on a local simulator.
+
+        Unlike `execute()`, this takes a qilisdk `Schedule` directly — there's
+        no Marqov-canonical analog representation to translate from. Build
+        the schedule with `qilisdk.analog.Hamiltonian`/`Schedule` (e.g.
+        `Schedule.linear(driver, problem, total_time, dt)` for a standard
+        anneal) and pass it straight through.
+
+        Args:
+            schedule: A qilisdk `Schedule` describing the time-dependent
+                Hamiltonian to evolve under.
+            shots: Number of measurement shots.
+            initial_state: Starting state — a qilisdk `InitialState` enum
+                value or an explicit `QTensor`. Defaults to
+                `InitialState.UNIFORM` (equal superposition), the standard
+                starting point for a transverse-field-driver anneal.
+            **kwargs: Additional options (ignored today).
+
+        Returns:
+            ExecutionResult with measurement counts.
+        """
+        from qilisdk.core.qtensor import InitialState as _InitialState
+        from qilisdk.functionals import AnalogEvolution
+        from qilisdk.readout import Readout
+
+        if initial_state is None:
+            initial_state = _InitialState.UNIFORM
+
+        start_time = time.perf_counter()
+
+        evolution = AnalogEvolution(schedule=schedule, initial_state=initial_state)
+        readout = Readout().with_sampling(nshots=shots)
+
+        result = self._backend.execute(evolution, readout)
+        counts = result.get_samples()
+
+        execution_time_ms = (time.perf_counter() - start_time) * 1000
+
+        return ExecutionResult(
+            counts=counts,
+            backend=f"qilisdk-{self.config.simulator}",
+            execution_time_ms=execution_time_ms,
+            shots=shots,
+            raw_result=result,
+            metadata={"simulator": self.config.simulator, "mode": "analog"},
         )
 
     def _to_qilisdk_circuit(self, circuit: Circuit) -> Any:

--- a/tests/test_qilisdk_analog_executor.py
+++ b/tests/test_qilisdk_analog_executor.py
@@ -1,0 +1,93 @@
+"""Tests for QiliSDKExecutor.execute_analog (Qilimanjaro analog/annealing mode)."""
+
+import pytest
+
+qilisdk = pytest.importorskip("qilisdk")
+
+from qilisdk.analog import Hamiltonian, PauliX, PauliZ, Schedule
+from qilisdk.core.qtensor import InitialState
+
+from marqov.executors import ExecutionResult, QiliSDKExecutor
+
+
+class TestQiliSDKExecutorAnalog:
+    """Tests for QiliSDKExecutor.execute_analog."""
+
+    @pytest.mark.asyncio
+    async def test_execute_analog_returns_result(self) -> None:
+        """execute_analog returns an ExecutionResult tagged as analog."""
+        executor = QiliSDKExecutor()
+        driver = Hamiltonian({(PauliX(0),): 1.0})
+        problem = Hamiltonian({(PauliZ(0),): 1.0})
+        schedule = Schedule.linear(driver, problem, total_time=2.0, dt=0.1)
+
+        result = await executor.execute_analog(schedule, shots=100)
+
+        assert isinstance(result, ExecutionResult)
+        assert result.backend == "qilisdk-qilisim"
+        assert result.shots == 100
+        assert result.metadata == {"simulator": "qilisim", "mode": "analog"}
+
+    @pytest.mark.asyncio
+    async def test_execute_analog_constant_schedule_is_deterministic(self) -> None:
+        """A diagonal Hamiltonian on a computational basis state never flips it."""
+        executor = QiliSDKExecutor()
+        problem = Hamiltonian({(PauliZ(0), PauliZ(1)): 1.0})
+        schedule = Schedule.constant(problem, total_time=3.0, dt=0.1)
+
+        result = await executor.execute_analog(
+            schedule, shots=200, initial_state=InitialState.ZERO
+        )
+
+        assert result.counts == {"00": 200}
+
+    @pytest.mark.asyncio
+    async def test_execute_analog_anneal_biases_toward_ground_state(self) -> None:
+        """A transverse-field-driver -> ZZ-coupling anneal favors 00/11 over 01/10.
+
+        Physical sanity check: annealing from a driver Hamiltonian (favors
+        superposition) to a ferromagnetic ZZ problem Hamiltonian (favors
+        aligned spins) should concentrate probability on the ground-state
+        manifold {00, 11}, not the excited states {01, 10}.
+        """
+        executor = QiliSDKExecutor()
+        driver = Hamiltonian({(PauliX(0),): 1.0, (PauliX(1),): 1.0})
+        problem = Hamiltonian({(PauliZ(0), PauliZ(1)): 1.0})
+        schedule = Schedule.linear(driver, problem, total_time=5.0, dt=0.05)
+
+        result = await executor.execute_analog(
+            schedule, shots=500, initial_state=InitialState.UNIFORM
+        )
+
+        ground_state_counts = result.counts.get("00", 0) + result.counts.get("11", 0)
+        excited_state_counts = result.counts.get("01", 0) + result.counts.get("10", 0)
+        assert ground_state_counts > excited_state_counts
+
+    @pytest.mark.asyncio
+    async def test_execute_analog_default_initial_state_is_uniform(self) -> None:
+        """Omitting initial_state doesn't error and defaults to UNIFORM."""
+        executor = QiliSDKExecutor()
+        driver = Hamiltonian({(PauliX(0),): 1.0})
+        problem = Hamiltonian({(PauliZ(0),): 1.0})
+        schedule = Schedule.linear(driver, problem, total_time=1.0, dt=0.1)
+
+        result = await executor.execute_analog(schedule, shots=50)
+
+        assert sum(result.counts.values()) == 50
+
+    @pytest.mark.asyncio
+    async def test_execute_analog_qutip_backend(self) -> None:
+        """The qutip reference simulator runs analog evolution too."""
+        pytest.importorskip("qutip")
+        from marqov.executors.qilisdk import QiliSDKExecutorConfig
+
+        executor = QiliSDKExecutor(QiliSDKExecutorConfig(simulator="qutip"))
+        problem = Hamiltonian({(PauliZ(0), PauliZ(1)): 1.0})
+        schedule = Schedule.constant(problem, total_time=3.0, dt=0.1)
+
+        result = await executor.execute_analog(
+            schedule, shots=100, initial_state=InitialState.ZERO
+        )
+
+        assert result.backend == "qilisdk-qutip"
+        assert result.counts == {"00": 100}

--- a/tests/test_qilisdk_executor.py
+++ b/tests/test_qilisdk_executor.py
@@ -4,9 +4,9 @@ import pytest
 
 qilisdk = pytest.importorskip("qilisdk")
 
-from marqov.circuits import Circuit, bell_state, ghz_state  # noqa: E402
-from marqov.executors import ExecutionResult, ExecutorFactory, QiliSDKExecutor  # noqa: E402
-from marqov.executors.qilisdk import QiliSDKExecutorConfig  # noqa: E402
+from marqov.circuits import Circuit, bell_state, ghz_state
+from marqov.executors import ExecutionResult, ExecutorFactory, QiliSDKExecutor
+from marqov.executors.qilisdk import QiliSDKExecutorConfig
 
 
 class TestQiliSDKExecutor:


### PR DESCRIPTION
## Summary
- Adds `QiliSDKExecutor.execute_analog()` — runs Qilimanjaro's actual hardware differentiator (fluxonium quantum annealing) locally via `qilisdk`'s `Hamiltonian`/`Schedule`/`AnalogEvolution` API. No SpeQtrum account needed.
- Deliberately kept qilisdk-specific rather than added to the shared `BaseExecutor` contract: analog Hamiltonians have no Marqov-canonical representation the way digital circuits do, and no other backend has an analog capability yet to unify against. This matches how Braket, Azure Quantum, and CUDA-Q all keep digital and analog as separate program types too — confirmed via a competitor/classical-HPC-precedent research pass before building this.
- Adds a new "Exceptions to the shape" section to `CONTRIBUTING.md` documenting this and CUNQA's not-yet-wired-into-the-factory status, so future contributors don't have to reconstruct the reasoning from git history.
- Part of the still-unreleased `0.5.0` — extends that changelog entry rather than adding a new version bump.

## Test plan
- [x] New test file `tests/test_qilisdk_analog_executor.py` — includes a physical sanity check (a transverse-field-driver → ZZ-coupling anneal actually biases toward the `00`/`11` ground-state manifold) and a fully deterministic case (`InitialState.ZERO` under a diagonal Hamiltonian never flips)
- [x] Verified against a real installed `qilisdk`, both `QiliSim` and `QutipBackend`
- [x] `pytest tests/test_qilisdk_analog_executor.py tests/test_qilisdk_executor.py tests/test_executors.py` — 81 passed
- [x] `ruff check` clean on all touched files