### PR TITLE
fix(release): close four unexercised release-process footguns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,16 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
+          # TestPyPI also never allows a version to be reused; this keeps a
+          # repeated dry-run of the same X.Y.Z idempotent. Deliberately NOT set
+          # on publish-pypi, where a duplicate upload should be a hard failure.
+          skip-existing: true
 
   publish-pypi:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Both conditions: a dispatch against a tag ref sets github.ref to that tag,
+    # so the ref check alone would let a "TestPyPI dry-run" publish to real PyPI.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: pypi
     permissions: { id-token: write }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,12 @@
 # Releasing the Marqov SDK
 
-Everything before the `v*` tag push is reversible; the tag is the irreversible
-step (PyPI never lets a version be reused), so validate hard and tag last.
+Everything before the `v*` tag push is reversible **on real PyPI**; the tag is
+the irreversible step there (PyPI never lets a version be reused), so validate
+hard and tag last. One thing before the tag is *not* reversible: the step-3
+dry-run permanently claims `X.Y.Z` on **TestPyPI**, which runs the same
+Warehouse code and also never reuses a version. `publish-testpypi` sets
+`skip-existing: true` so a repeated dry-run at the same version is a no-op
+rather than a failure, but the first upload of a version is still one-way.
 
 > **How the tag publishes:** pushing a `v*` tag triggers
 > `.github/workflows/release.yml`, which builds the package and publishes it to
@@ -53,20 +58,34 @@ step (PyPI never lets a version be reused), so validate hard and tag last.
       uvx twine check dist/*
       ```
 - [ ] Push a `release/X.Y.Z` branch (version bumped, changelog dated).
+- [ ] CI (full suite) green on the branch, **before** the dry-run. `ci.yml` only
+      triggers on pull requests and pushes to `main`, not on a bare branch push,
+      so open a PR from the release branch to `main` to get a run (do not merge
+      it yet; it exists to trigger CI on the exact release SHA). This comes first
+      because the dry-run claims `X.Y.Z` on TestPyPI for good: confirm the SHA is
+      good before spending the version on it.
 - [ ] Dry-run: `gh workflow run release.yml --ref release/X.Y.Z` (TestPyPI only).
+      Dispatch against the **branch**, never against a tag ref.
 - [ ] `gh run watch <id> --exit-status` — build ✅, publish-testpypi ✅, publish-pypi skipped.
-- [ ] Validate the PUBLISHED artifact, not just the pipeline — install from TestPyPI
-      and import it (do it here, while it's still free):
+- [ ] Validate the PUBLISHED artifact, not just the pipeline. Fetch it from
+      TestPyPI and install it in a throwaway venv, keeping the two indexes in
+      **separate** resolution steps:
       ```
-      pip install --index-url https://test.pypi.org/simple/ \
-                  --extra-index-url https://pypi.org/simple/ marqov==X.Y.Z
+      python -m venv /tmp/marqov-testpypi && . /tmp/marqov-testpypi/bin/activate
+      # 1. The marqov artifact only, straight from TestPyPI. --no-deps means no
+      #    dependency is ever resolved against TestPyPI.
+      pip download --no-deps --index-url https://test.pypi.org/simple/ \
+                   marqov==X.Y.Z -d /tmp/marqov-testpypi-dist
+      # 2. Install that exact file; every dependency resolves from real PyPI.
+      pip install /tmp/marqov-testpypi-dist/marqov-X.Y.Z-py3-none-any.whl
       python -c "import marqov; print(marqov.__version__)"
+      deactivate
       ```
-      (`--extra-index-url` because dependencies aren't on TestPyPI.)
-- [ ] CI (full suite) green on the branch. `ci.yml` only triggers on pull
-      requests and pushes to `main`, not on a bare branch push, so open a PR
-      from the release branch to `main` to get a run (do not merge it yet;
-      it exists to trigger CI on the exact release SHA).
+      Do **not** point pip at both indexes at once (`--index-url` TestPyPI plus
+      `--extra-index-url` PyPI). That merges them into one resolution pool for
+      every dependency, and TestPyPI is public and uncurated: anyone can upload a
+      higher-versioned `numpy`/`scipy`/`requests` there and win the resolution.
+      This is PyPA's own documented dependency-confusion anti-pattern.
 
 ## 4. Cut the release
 - [ ] Fast-forward `main` to the release commit and push.
@@ -91,7 +110,10 @@ git push origin vX.Y.Z
 - [ ] Verify: real PyPI shows X.Y.Z, and a clean-venv `pip install marqov==X.Y.Z` imports.
 
 ## Rollback
-- **Before the tag:** nothing has been published — fix forward with a new commit.
+- **Before the tag:** nothing has been published to real PyPI, so fix forward
+  with a new commit. (A version already dry-run to TestPyPI stays claimed there;
+  `skip-existing: true` makes re-running the dry-run at that version a no-op, so
+  it does not block the fix.)
   Do **not** force-push the default branch: this repo has forks, and rewriting
   `main` hands everyone who cloned or forked divergent history.
 - **After the tag:** a PyPI version cannot be unpublished. Ship `X.Y.(Z+1)` with the fix.


### PR DESCRIPTION
`release.yml` and `RELEASING.md` carry four release-process bugs. None has caused a shipped-release incident (0.2.0 through 0.5.0 all shipped fine). That is evidence the specific failure modes have not happened yet, not that the logic is correct, so this is unexercised risk rather than a live incident. Release-blocking for the next cut, not a hotfix.

## What changed

**1. A dispatch against a tag ref could publish to real PyPI.** `publish-pypi` was gated on `startsWith(github.ref, 'refs/tags/v')` alone. `gh workflow run release.yml --ref v0.5.0` sets both `event_name == workflow_dispatch` and `github.ref == refs/tags/v0.5.0`, so `publish-pypi` fired despite the intent being "TestPyPI only". The documented flow (dispatch against `release/X.Y.Z`) never hits this, but nothing prevented dispatching against a tag, and PyPI versions can never be reused. Now `github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')`: two conditions on the irreversible job.

**2. `skip-existing: true` on `publish-testpypi`.** TestPyPI runs the same Warehouse code and also never reuses a version, so a repeated dry-run at the same version failed. Deliberately **not** added to `publish-pypi`, where a duplicate upload should stay a hard failure.

**3. "Everything before the tag is reversible" was false.** The step-3 dry-run permanently claims `X.Y.Z` on TestPyPI even if the release is abandoned. The claim is now scoped to real PyPI, in the opening paragraph and in the Rollback section, which carried the same wording.

**4. The TestPyPI validation install was a dependency-confusion vector.** It pointed pip at TestPyPI via `--index-url` and real PyPI via `--extra-index-url`, merging them into one resolution pool for every dependency, not just `marqov`. TestPyPI is public and uncurated: anyone can upload a higher-versioned `numpy`/`scipy`/`requests` there and win. This is PyPA's documented anti-pattern. Replaced with two separate resolution steps:

```
pip download --no-deps --index-url https://test.pypi.org/simple/ marqov==X.Y.Z -d <dir>
pip install <dir>/marqov-X.Y.Z-py3-none-any.whl
```

Step 1 touches TestPyPI for the marqov artifact only; step 2 installs that exact file, so every dependency resolves from real PyPI. This works during a dry run precisely because `marqov==X.Y.Z` is never resolved from an index in step 2.

**5. Checklist ordering.** "CI green on the branch" now comes before the dry-run dispatch, so a version is not burned on TestPyPI before the SHA is confirmed good.

## Verification

- Parsed `release.yml` with PyYAML and printed the resulting conditions back out: valid, and they say what was intended (`skip-existing` present on testpypi, absent on pypi).
- Hand-traced every trigger combination against the new condition:

| trigger | testpypi fires | pypi fires |
|---|---|---|
| tag push (real release) | no | yes |
| branch push | no | no |
| dispatch on a branch (dry-run) | yes | no |
| dispatch on a tag ref (the bug) | yes | **no** (was: yes) |

- Full suite: 750 passed, 17 skipped, 13 xpassed.
- `tools/check_urls.py` exits 0 (the 2 WARNs are the pre-existing auth-gated IonQ endpoints).

**What this does not cover:** none of it runs on GitHub's runners. The `if:` logic gets its live rehearsal at RELEASING.md step 3's dry-run (dispatch against `release/X.Y.Z`, confirm `publish-pypi` shows skipped) before it is ever load-bearing on a real tag. The `pip download`/`pip install` sequence likewise is not exercised until a real dry-run, since `marqov==X.Y.Z` has to exist on TestPyPI for it to run.

