### PR TITLE
fix(cunqa): bound qraise's own hang, add Phase 0 integration test

### DIFF
--- a/marqov/executors/cunqa.py
+++ b/marqov/executors/cunqa.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import uuid
 from collections import Counter
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
@@ -224,18 +225,49 @@ class CUNQAExecutor(BaseExecutor):
         qiskit_circuit = await asyncio.to_thread(circuit.to_qiskit)
         qiskit_circuit = add_measure_all(qiskit_circuit)
 
-        family = await asyncio.to_thread(
-            self._client.qraise,
-            cfg.n_qpus,
-            cfg.walltime,
-            simulator=cfg.simulator,
-            co_located=cfg.co_located,
-            classical_comm=cfg.classical_comm,
-            quantum_comm=cfg.quantum_comm,
-            mem_per_qpu=cfg.mem_per_qpu_gb,
-        )
+        # Generated up front, not read from qraise's return value: CUNQA's
+        # real qraise() blocks internally (polling squeue until the job is
+        # RUNNING with every vQPU registered) with NO timeout of its own —
+        # unlike the fake client used in the tests below, which returns
+        # instantly. If that real call never returns (a stuck node, a job
+        # that never reaches RUNNING), we still need a family name to hand
+        # to qdrop for cleanup — which we can't get from a call that never
+        # returned. Passing our own family through to qraise's `family=`
+        # kwarg makes this available regardless of whether qraise itself
+        # completes in time.
+        family = f"marqov-{uuid.uuid4().hex[:12]}"
         start = time.monotonic()
         try:
+            try:
+                await asyncio.wait_for(
+                    asyncio.to_thread(
+                        self._client.qraise,
+                        cfg.n_qpus,
+                        cfg.walltime,
+                        simulator=cfg.simulator,
+                        co_located=cfg.co_located,
+                        classical_comm=cfg.classical_comm,
+                        quantum_comm=cfg.quantum_comm,
+                        mem_per_qpu=cfg.mem_per_qpu_gb,
+                        family=family,
+                    ),
+                    timeout=cfg.startup_timeout_s,
+                )
+            except asyncio.TimeoutError as e:
+                # asyncio.wait_for abandoning the future does NOT stop the
+                # underlying thread — the real qraise() call may still be
+                # running in the background, polling squeue forever, if
+                # the Slurm job never reaches RUNNING. Best-effort cleanup
+                # via _teardown (below) at least issues qdrop for this
+                # family; the orphaned thread itself is a known, accepted
+                # residual gap (see _teardown's docstring for the same
+                # pattern applied to cancellation).
+                raise TimeoutError(
+                    f"qraise did not return within {cfg.startup_timeout_s}s "
+                    f"for family {family!r} — the underlying call may still "
+                    f"be running in the background"
+                ) from e
+
             qpus = await self._wait_for_qpus_ready(family, cfg)
             circuits = [qiskit_circuit.copy() for _ in qpus]
             jobs = await asyncio.to_thread(self._client.run, circuits, qpus, shots=shots_per_qpu)

--- a/tests/integration/test_cunqa_parallelcluster.py
+++ b/tests/integration/test_cunqa_parallelcluster.py
@@ -1,0 +1,56 @@
+"""End-to-end smoke test: a real no-comm QPE run distributed across CUNQA
+vQPUs on a live AWS ParallelCluster.
+
+Skipped unless MARQOV_CUNQA_INTEGRATION=1 is set. This test spends real
+Slurm allocation time and should not run in CI by default.
+
+The circuit here is the same tests/_qpe_reference.build_no_comm_qpe_circuit
+used by test_cunqa_qpe_reference_circuit.py, which already proves the
+exponent convention and the Circuit.from_qiskit round-trip are both correct
+using only a local qiskit-aer simulation, zero cluster dependency. If this
+test ever fails, check squeue/sacct and CUNQAExecutor's behavior first, not
+the circuit -- its correctness is independently established and re-checked
+on every plain `pytest` run. Note this test does NOT call add_measure_all
+itself -- CUNQAExecutor.execute() does that internally; passing an
+already-measured circuit here would be wrong (Circuit.from_qiskit would
+just strip it again on the way through anyway)."""
+import asyncio
+import logging
+import os
+
+import pytest
+
+from marqov.circuits import Circuit
+from marqov.executors import CUNQAExecutor, CUNQAExecutorConfig
+from tests._qpe_reference import build_no_comm_qpe_circuit, expected_phase_bin
+
+logger = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MARQOV_CUNQA_INTEGRATION") != "1",
+    reason="requires a live CUNQA cluster; set MARQOV_CUNQA_INTEGRATION=1 to run",
+)
+
+
+def test_no_comm_qpe_recovers_correct_phase_at_n4() -> None:
+    n_counting_qubits = 4
+    true_phase = 0.3125  # = 5/16, exactly representable at n=4
+    expected_bin = expected_phase_bin(n_counting_qubits, true_phase)
+
+    qiskit_circuit = build_no_comm_qpe_circuit(n_counting_qubits, true_phase)
+    circuit = Circuit.from_qiskit(qiskit_circuit)
+
+    config = CUNQAExecutorConfig(n_qpus=4, walltime="00:10:00", mem_per_qpu_gb=4)
+    executor = CUNQAExecutor(config)  # real cunqa client, no injected double
+
+    result = asyncio.run(executor.execute(circuit, shots=1000))
+
+    modal_outcome = max(result.counts, key=result.counts.get)
+    assert modal_outcome == expected_bin, (
+        f"expected modal bin {expected_bin} ({true_phase=}), got {modal_outcome} "
+        f"from counts={result.counts}"
+    )
+
+    # First live check of the seeding gap flagged in Task 1: if CUNQA seeds
+    # every vQPU identically by default, all 4 entries here will be equal.
+    logger.warning("per-vQPU counts (check for identical entries): %s", result.metadata["per_qpu_counts"])

--- a/tests/test_cunqa_executor.py
+++ b/tests/test_cunqa_executor.py
@@ -35,7 +35,10 @@ class _FakeCunqaClient:
 
     def qraise(self, n_qpus: int, walltime: str, **kwargs: Any) -> str:
         self.qraise_calls.append({"n_qpus": n_qpus, "walltime": walltime, **kwargs})
-        return "test-family"
+        # Real CUNQA echoes back the caller-supplied family (falling back to
+        # the job id only when none is given) -- matched here since the
+        # executor now always passes one explicitly.
+        return kwargs.get("family") or "test-family"
 
     def get_QPUs(self, co_located: bool, family: str) -> list[str]:
         self.get_qpus_calls.append({"co_located": co_located, "family": family})
@@ -126,7 +129,10 @@ async def test_execute_forwards_config_to_qraise() -> None:
 
     await executor.execute(bell_state(), shots=500)
 
-    assert fake_client.qraise_calls[0] == {
+    call = fake_client.qraise_calls[0]
+    family = call.pop("family")
+    assert family.startswith("marqov-")
+    assert call == {
         "n_qpus": 2,
         "walltime": "00:07:00",
         "simulator": "Aer",
@@ -158,7 +164,7 @@ async def test_execute_raises_timeout_if_qpus_never_register() -> None:
     with pytest.raises(TimeoutError, match="registered"):
         await executor.execute(bell_state(), shots=1000)
 
-    assert fake_client.dropped == ["test-family"]
+    assert fake_client.dropped == [fake_client.qraise_calls[0]["family"]]
 
 
 @pytest.mark.asyncio
@@ -184,7 +190,7 @@ async def test_execute_always_drops_qpus_even_on_run_failure() -> None:
     with pytest.raises(RuntimeError, match="simulated cluster failure"):
         await executor.execute(bell_state(), shots=1000)
 
-    assert fake_client.dropped == ["test-family"]
+    assert fake_client.dropped == [fake_client.qraise_calls[0]["family"]]
 
 
 @pytest.mark.asyncio
@@ -205,7 +211,7 @@ async def test_execute_drops_qpus_on_cancellation() -> None:
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    assert fake_client.dropped == ["test-family"]
+    assert fake_client.dropped == [fake_client.qraise_calls[0]["family"]]
 
 
 @pytest.mark.asyncio
@@ -232,7 +238,7 @@ async def test_execute_survives_repeated_cancellation_during_teardown() -> None:
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    assert fake_client.dropped == ["test-family"]
+    assert fake_client.dropped == [fake_client.qraise_calls[0]["family"]]
 
 
 @pytest.mark.asyncio
@@ -250,6 +256,33 @@ async def test_execute_qdrop_failure_does_not_mask_original_exception() -> None:
 
     with pytest.raises(RuntimeError, match="original failure: circuit rejected"):
         await executor.execute(bell_state(), shots=1000)
+
+
+@pytest.mark.asyncio
+async def test_execute_raises_timeout_if_qraise_itself_never_returns() -> None:
+    """Real CUNQA's qraise() blocks internally (polling squeue until the job
+    is RUNNING with every vQPU registered) with no timeout of its own —
+    unlike this fake, which normally returns instantly. If the Slurm job
+    never reaches RUNNING (a stuck node, insufficient capacity), that call
+    can hang forever. This must time out via cfg.startup_timeout_s rather
+    than hang the whole executor, and still attempt qdrop for cleanup using
+    the family generated before the call (qraise's own return value is
+    unusable here — it never returned one)."""
+
+    class _HangingQraiseClient(_FakeCunqaClient):
+        def qraise(self, n_qpus: int, walltime: str, **kwargs: Any) -> str:
+            time.sleep(2)
+            return super().qraise(n_qpus, walltime, **kwargs)
+
+    fake_client = _HangingQraiseClient(counts_per_qpu={})
+    config = CUNQAExecutorConfig(n_qpus=2, walltime="00:05:00", startup_timeout_s=0.1, poll_interval_s=0.01)
+    executor = CUNQAExecutor(config, client=fake_client)
+
+    with pytest.raises(TimeoutError, match="qraise did not return"):
+        await executor.execute(bell_state(), shots=1000)
+
+    assert len(fake_client.dropped) == 1
+    assert fake_client.dropped[0].startswith("marqov-")
 
 
 def test_config_defaults() -> None:


### PR DESCRIPTION
## Summary
- Real CUNQA's `qraise()` blocks internally (polling squeue until the job is RUNNING with every vQPU registered) with no timeout of its own -- discovered live when a Slurm job never reached RUNNING and the whole executor hung indefinitely
- Generate the family name up front (passed to qraise's own `family=` kwarg) instead of reading it from qraise's return value, and wrap the qraise call itself in `asyncio.wait_for(timeout=cfg.startup_timeout_s)` -- teardown/qdrop can still be attempted even if qraise itself never returns
- Adds `tests/integration/test_cunqa_parallelcluster.py` -- Phase 0's actual deliverable, verified passing against the live cunqa-poc cluster (1 passed in 14.41s, all 4 vQPUs recovering the exact expected phase bin)

## Test plan
- `pytest tests/test_cunqa_executor.py tests/test_cunqa_qpe_reference_circuit.py -v` -- 18/18 passed
- `ruff check` clean
- Integration test verified live against real cluster (cluster since torn down, EFS retained)