### PR TITLE
docs(changelog): cite marqov-sdk#107 on the execute_analog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ release.
   Azure Quantum, CUDA-Q, and classical heterogeneous-compute systems (Kubernetes, MLIR, XLA, Ray,
   Slurm) all handle this same digital/analog split confirmed the pattern: shared job-lifecycle
   contract, paradigm-native program types — never one flat representation for both.
+  (marqov-sdk#107)
 
 - **`normalized_fidelity` and related application-level benchmarking
   metrics**, in `marqov/benchmarking/`. The Lubinski et al. / QED-C metric


### PR DESCRIPTION
One-line fix. Every other entry in the `0.5.1` changelog block carries its PR reference; the `QiliSDKExecutor.execute_analog()` entry was the only one without one.

Documentation-only, no code touched. The entry is in an already-shipped block, so this is a fix-forward on the prose rather than a change to what 0.5.1 contains.