### PR TITLE
fix(executors): conform result normalization to one contract

### DIFF
--- a/marqov/executors/_counts.py
+++ b/marqov/executors/_counts.py
@@ -1,0 +1,71 @@
+"""Shared measurement-count helpers.
+
+Vendors report results in two shapes: raw shot counts, or a probability
+histogram. Converting a histogram to counts must conserve the shot total —
+downstream code (expectation values, fidelity, SPAM correction) divides by
+``sum(counts.values())`` and assumes it equals the requested ``shots``.
+
+Naive per-bin rounding does not conserve: three bins at 1/3 of 1000 shots
+round to 333 each, losing a shot.
+"""
+
+from __future__ import annotations
+
+
+def allocate_counts(probabilities: dict[str, float], shots: int) -> dict[str, int]:
+    """Convert a probability histogram into counts summing exactly to ``shots``.
+
+    Uses the largest-remainder (Hamilton) method: floor every bin, then hand
+    the leftover shots to the largest fractional remainders first.
+
+    Keys are passed through untouched, so callers may use whatever key shape
+    the vendor gave them (bitstrings, state indices, ...). Bit-order
+    normalization is the caller's responsibility.
+
+    Args:
+        probabilities: Mapping of outcome key to probability. Probabilities are
+            assumed non-negative; they need not sum exactly to 1.
+        shots: The number of shots to allocate.
+
+    Returns:
+        Mapping of outcome key to integer count, summing to ``shots``. Bins
+        allocated zero counts are omitted. Empty when there is nothing to
+        allocate.
+    """
+    if not probabilities or shots <= 0:
+        return {}
+
+    counts: dict[str, int] = {}
+    remainders: dict[str, float] = {}
+    allocated = 0
+    for key, probability in probabilities.items():
+        exact = float(probability) * shots
+        base = int(exact)  # floor (probabilities are non-negative)
+        counts[key] = base
+        remainders[key] = exact - base
+        allocated += base
+
+    leftover = shots - allocated
+    if leftover > 0:
+        # Hand extra shots to the largest fractional remainders first. Cycles
+        # if the histogram is truncated and leftover exceeds the bin count.
+        ordered = sorted(remainders, key=lambda k: remainders[k], reverse=True)
+        for i in range(leftover):
+            counts[ordered[i % len(ordered)]] += 1
+    elif leftover < 0:
+        # Probabilities summed above 1: reclaim from the smallest remainders.
+        # The bound is computed ONCE, before the loop. Recomputing it inline
+        # is a live-lock trap: `-leftover` shrinks as shots are reclaimed, so
+        # the bound collapses toward `i` and the loop exits still
+        # over-allocated — reintroducing the total != shots defect.
+        ordered = sorted(remainders, key=lambda k: remainders[k])
+        limit = len(ordered) * (-leftover + 1)
+        i = 0
+        while leftover < 0 and i < limit:
+            key = ordered[i % len(ordered)]
+            if counts[key] > 0:
+                counts[key] -= 1
+                leftover += 1
+            i += 1
+
+    return {key: count for key, count in counts.items() if count > 0}

--- a/marqov/executors/braket.py
+++ b/marqov/executors/braket.py
@@ -28,6 +28,7 @@ import boto3
 from braket.aws import AwsDevice, AwsSession
 from braket.circuits import Circuit as BraketCircuit
 
+from marqov.executors._counts import allocate_counts
 from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
 
 if TYPE_CHECKING:
@@ -269,7 +270,11 @@ class BraketExecutor(BaseExecutor):
             # instead of raw shot counts. Convert to synthetic counts using shots.
             probs = getattr(result, 'measurement_probabilities', {}) or {}
             if probs:
-                counts = {bs: round(float(prob) * shots) for bs, prob in dict(probs).items()}
+                # Largest-remainder allocation, not round(): naive rounding does
+                # not conserve the shot total (three bins at 1/3 of 1000 shots
+                # round to 333 each = 999), and downstream code divides by the
+                # total assuming it equals `shots`.
+                counts = allocate_counts(dict(probs), shots)
 
         return ExecutionResult(
             counts=counts,

--- a/marqov/executors/ibm.py
+++ b/marqov/executors/ibm.py
@@ -172,14 +172,48 @@ class IBMExecutor(BaseExecutor):
         pub_result = result[0]
         data_bin = pub_result.data
 
-        # SamplerV2 returns BitArray in classical register fields
-        # Get the first classical register (typically "meas" or "c")
-        creg_names = [attr for attr in dir(data_bin) if not attr.startswith("_")]
-        if not creg_names:
+        # SamplerV2 returns a BitArray per classical register. Find it by
+        # capability (it exposes get_counts), NOT by taking dir()[0]: dir() is
+        # alphabetical and DataBin also exposes mapping helpers ('items',
+        # 'keys', 'ndim', 'shape', 'size', 'values'), so dir()[0] is 'items' —
+        # a bound method — for any register sorting after it (e.g. the 'meas'
+        # register that measure_all() creates).
+        keys = getattr(data_bin, "keys", None)
+        if callable(keys):
+            # Qiskit >= 1.2: DataBin declares its register names.
+            names = list(keys())
+        else:
+            names = [n for n in dir(data_bin) if not n.startswith("_")]
+
+        bit_arrays = [
+            candidate
+            for candidate in (getattr(data_bin, name, None) for name in names)
+            if hasattr(candidate, "get_counts")
+        ]
+
+        if not bit_arrays:
             return {}
 
-        bit_array = getattr(data_bin, creg_names[0])
-        return dict(bit_array.get_counts())
+        if len(bit_arrays) > 1:
+            # Each BitArray covers one register. Returning just the first one
+            # yields a bitstring narrower than the measurement, silently
+            # mis-indexing every downstream consumer (fidelity, SPAM,
+            # expectation values). Joining them needs a defined register order
+            # and a decision about whether the reversal applies within or
+            # across registers — so fail loudly rather than guess.
+            raise NotImplementedError(
+                f"Result has multiple classical registers ({len(bit_arrays)}); "
+                "Marqov cannot yet combine them into a single bitstring. "
+                "Use a single classical register (e.g. measure_all())."
+            )
+
+        # Qiskit is little-endian (qubit 0 = rightmost); Marqov's convention is
+        # qubit 0 = leftmost. Reverse, exactly as AzureQuantumExecutor does for
+        # the same framework.
+        return {
+            bitstring[::-1]: count
+            for bitstring, count in bit_arrays[0].get_counts().items()
+        }
 
     async def execute(
         self,

--- a/marqov/executors/ionq.py
+++ b/marqov/executors/ionq.py
@@ -34,6 +34,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from marqov.executors._counts import allocate_counts
 from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
 
 if TYPE_CHECKING:
@@ -228,37 +229,13 @@ class IonQExecutor(BaseExecutor):
         if not histogram:
             return {}
 
-        # Floor each bin and remember its fractional remainder.
-        counts: dict[str, int] = {}
-        remainders: dict[str, float] = {}
-        allocated = 0
-        for index, probability in histogram.items():
-            bitstring = format(int(index), f"0{num_qubits}b")
-            exact = float(probability) * shots
-            base = int(exact)  # floor (probabilities are non-negative)
-            counts[bitstring] = base
-            remainders[bitstring] = exact - base
-            allocated += base
-
-        # Distribute (or reclaim) the leftover shots so the total equals `shots`.
-        leftover = shots - allocated
-        if leftover > 0:
-            # Hand extra shots to the largest fractional remainders first.
-            ordered = sorted(remainders, key=lambda b: remainders[b], reverse=True)
-            for i in range(leftover):
-                counts[ordered[i % len(ordered)]] += 1
-        elif leftover < 0:
-            # Reclaim over-allocated shots from the smallest remainders first.
-            ordered = sorted(remainders, key=lambda b: remainders[b])
-            i = 0
-            while leftover < 0 and i < len(ordered) * (-leftover + 1):
-                bitstring = ordered[i % len(ordered)]
-                if counts[bitstring] > 0:
-                    counts[bitstring] -= 1
-                    leftover += 1
-                i += 1
-
-        return {bitstring: count for bitstring, count in counts.items() if count > 0}
+        # Map IonQ's state indices to bitstrings, then delegate the
+        # shot-conserving allocation to the shared helper (see _counts.py).
+        probabilities = {
+            format(int(index), f"0{num_qubits}b"): float(probability)
+            for index, probability in histogram.items()
+        }
+        return allocate_counts(probabilities, shots)
 
     async def execute(
         self,

--- a/tests/test_executor_result_conformance.py
+++ b/tests/test_executor_result_conformance.py
@@ -1,0 +1,242 @@
+"""Cross-executor conformance tests for measurement-result normalization.
+
+Every executor must return results in ONE shape, regardless of vendor:
+
+1. **Bit order** — qubit 0 is the LEFTMOST character of the bitstring.
+   This convention is stated in ``local.py``, ``rigetti.py``, ``ionq.py`` and
+   ``azure.py``; these tests pin it for every executor.
+
+2. **Shot conservation** — ``sum(counts.values()) == shots``. Downstream code
+   (expectation values, fidelity, SPAM correction) divides by the total and
+   assumes it equals the requested shot count.
+
+These tests call the executors' real normalization code. They deliberately do
+NOT re-implement the conversion inside the test — a test that reproduces the
+implementation passes even when the implementation is deleted.
+
+The canonical probe is an asymmetric 2-qubit outcome: X applied to qubit 0
+only, which must normalize to "10". Symmetric states (Bell, GHZ) are
+palindromes and cannot detect a reversal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+# Canonical probe: X on qubit 0 of a 2-qubit register.
+QUBIT0_EXCITED = "10"
+
+
+class TestAllocateCounts:
+    """The shared largest-remainder allocator."""
+
+    def test_conserves_shots_when_probabilities_sum_above_one(self) -> None:
+        """An unnormalized histogram must still allocate exactly `shots`.
+
+        Vendors do not always hand back a normalized histogram. Over-allocation
+        must be reclaimed fully, or the allocator reintroduces the very
+        "total != shots" defect it exists to prevent.
+        """
+        from marqov.executors._counts import allocate_counts
+
+        counts = allocate_counts({"00": 0.5, "01": 0.5, "10": 0.5, "11": 0.5}, shots=1000)
+
+        assert sum(counts.values()) == 1000
+
+    def test_conserves_shots_for_single_bin_above_one(self) -> None:
+        """A single bin with probability > 1 must not over-allocate."""
+        from marqov.executors._counts import allocate_counts
+
+        counts = allocate_counts({"a": 2.0}, shots=10)
+
+        assert sum(counts.values()) == 10
+
+
+class TestIBMBitOrder:
+    """IBMExecutor._extract_counts against a real Qiskit SamplerV2 result."""
+
+    @staticmethod
+    def _real_sampler_result() -> Any:
+        """Produce a genuine Qiskit PrimitiveResult for X(0) on 2 qubits.
+
+        Uses Qiskit's own local StatevectorSampler so the DataBin/BitArray
+        shapes are real, not hand-mocked.
+        """
+        from qiskit import QuantumCircuit
+        from qiskit.primitives import StatevectorSampler
+
+        qc = QuantumCircuit(2)
+        qc.x(0)
+        qc.measure_all()
+        return StatevectorSampler().run([qc], shots=100).result()
+
+    def test_extract_counts_places_qubit0_leftmost(self) -> None:
+        """X(0) must normalize to '10' (qubit 0 leftmost).
+
+        Qiskit reports this as '01' (qubit 0 rightmost). The executor is
+        responsible for converting to the Marqov convention, exactly as
+        AzureQuantumExecutor does for the same framework.
+        """
+        from marqov.executors.ibm import IBMExecutor
+
+        result = self._real_sampler_result()
+        counts = IBMExecutor._extract_counts(result)
+
+        assert counts == {QUBIT0_EXCITED: 100}
+
+    def test_multi_register_result_does_not_silently_drop_a_register(self) -> None:
+        """Two classical registers must not yield a 1-bit string for 2 qubits.
+
+        Selecting the first BitArray and ignoring the rest returns counts
+        narrower than the measurement, which mis-indexes every downstream
+        consumer (fidelity, SPAM, expectation values). Failing loudly is the
+        safe behaviour; silently returning half the data is not.
+        """
+        from qiskit import ClassicalRegister, QuantumCircuit
+        from qiskit.primitives import StatevectorSampler
+
+        from marqov.executors.ibm import IBMExecutor
+
+        reg_a, reg_b = ClassicalRegister(1, "a"), ClassicalRegister(1, "b")
+        qc = QuantumCircuit(2)
+        qc.add_register(reg_a)
+        qc.add_register(reg_b)
+        qc.x(0)
+        qc.measure(0, reg_a[0])
+        qc.measure(1, reg_b[0])
+        result = StatevectorSampler().run([qc], shots=100).result()
+
+        with pytest.raises(NotImplementedError, match="multiple classical registers"):
+            IBMExecutor._extract_counts(result)
+
+
+class TestRigettiBitOrder:
+    """RigettiExecutor._result_to_counts."""
+
+    def test_result_to_counts_places_qubit0_leftmost(self) -> None:
+        """Readout row [1, 0] (qubit 0 measured 1) must normalize to '10'."""
+        from marqov.executors.rigetti import RigettiExecutor
+
+        class _FakeResult:
+            def get_register_map(self) -> dict[str, list[list[int]]]:
+                return {"ro": [[1, 0]] * 100}
+
+        counts = RigettiExecutor._result_to_counts(_FakeResult(), num_qubits=2)
+
+        assert counts == {QUBIT0_EXCITED: 100}
+
+
+class TestIonQBitOrder:
+    """IonQExecutor._histogram_to_counts."""
+
+    def test_histogram_to_counts_places_qubit0_leftmost(self) -> None:
+        """State index 2 (binary '10') must normalize to '10'."""
+        from marqov.executors.ionq import IonQExecutor
+
+        counts = IonQExecutor._histogram_to_counts({"2": 1.0}, shots=100, num_qubits=2)
+
+        assert counts == {QUBIT0_EXCITED: 100}
+
+    def test_counts_sum_to_shots_for_non_terminating_probabilities(self) -> None:
+        """Thirds must still allocate exactly `shots` counts."""
+        from marqov.executors.ionq import IonQExecutor
+
+        third = 1.0 / 3.0
+        counts = IonQExecutor._histogram_to_counts(
+            {"0": third, "1": third, "2": third}, shots=1000, num_qubits=2
+        )
+
+        assert sum(counts.values()) == 1000
+
+    def test_counts_sum_to_shots_when_probabilities_sum_above_one(self) -> None:
+        """IonQ must conserve shots on an unnormalized histogram too."""
+        from marqov.executors.ionq import IonQExecutor
+
+        counts = IonQExecutor._histogram_to_counts(
+            {"0": 0.5, "1": 0.5, "2": 0.5, "3": 0.5}, shots=1000, num_qubits=2
+        )
+
+        assert sum(counts.values()) == 1000
+
+
+class TestBraketShotConservation:
+    """BraketExecutor's probability fallback, used when a QPU (e.g. IonQ
+    Forte-1) returns measurementProbabilities instead of raw counts."""
+
+    def test_probability_fallback_counts_sum_to_shots(self) -> None:
+        """Thirds must still allocate exactly `shots` counts."""
+        from marqov.circuits import Circuit
+        from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
+
+        third = 1.0 / 3.0
+
+        class _FakeResult:
+            measurement_counts: dict[str, int] = {}
+            measurement_probabilities = {"00": third, "01": third, "10": third}
+
+        class _FakeTask:
+            id = "arn:aws:braket:us-east-1:000000000000:quantum-task/fake"
+
+            def result(self) -> Any:
+                return _FakeResult()
+
+            def metadata(self) -> dict[str, Any]:
+                return {"executionDuration": 1}
+
+        class _FakeDevice:
+            name = "FakeDevice"
+
+            def run(self, *args: Any, **kwargs: Any) -> Any:
+                return _FakeTask()
+
+        executor = BraketExecutor(
+            BraketExecutorConfig(device_arn="arn:aws:braket:us-east-1::device/qpu/fake/Fake",
+                                 s3_bucket="bucket")
+        )
+        # Bypass the AWS session/device lookup; we are testing normalization only.
+        executor._get_device = lambda: asyncio.sleep(0, result=_FakeDevice())  # type: ignore[method-assign]
+
+        circuit = Circuit()
+        circuit.h(0)
+        result = asyncio.run(executor.execute(circuit, shots=1000))
+
+        assert sum(result.counts.values()) == 1000
+
+    def test_probability_fallback_preserves_braket_bit_order(self) -> None:
+        """Braket already reports qubit 0 leftmost; the fallback must not reorder."""
+        from marqov.circuits import Circuit
+        from marqov.executors.braket import BraketExecutor, BraketExecutorConfig
+
+        class _FakeResult:
+            measurement_counts: dict[str, int] = {}
+            measurement_probabilities = {QUBIT0_EXCITED: 1.0}
+
+        class _FakeTask:
+            id = "arn:aws:braket:us-east-1:000000000000:quantum-task/fake"
+
+            def result(self) -> Any:
+                return _FakeResult()
+
+            def metadata(self) -> dict[str, Any]:
+                return {"executionDuration": 1}
+
+        class _FakeDevice:
+            name = "FakeDevice"
+
+            def run(self, *args: Any, **kwargs: Any) -> Any:
+                return _FakeTask()
+
+        executor = BraketExecutor(
+            BraketExecutorConfig(device_arn="arn:aws:braket:us-east-1::device/qpu/fake/Fake",
+                                 s3_bucket="bucket")
+        )
+        executor._get_device = lambda: asyncio.sleep(0, result=_FakeDevice())  # type: ignore[method-assign]
+
+        circuit = Circuit()
+        circuit.h(0)
+        result = asyncio.run(executor.execute(circuit, shots=100))
+
+        assert result.counts == {QUBIT0_EXCITED: 100}


### PR DESCRIPTION
Three live defects in vendor result normalization, plus the conformance test that would have caught them.

**None of the 744 existing tests caught any of these.** The probe that finds them is asymmetric — X on qubit 0 must normalize to `"10"`. Bell and GHZ states are palindromes, so smoke tests pass while results are reversed.

## IBM — `_extract_counts`

Selected the classical register via `dir(data_bin)[0]`. `dir()` is alphabetical, and Qiskit 2.x `DataBin` also exposes `items`/`keys`/`ndim`/`shape`/`size`/`values` — so `dir()[0]` is `items`, a **bound method**, for any register sorting after it. Verified against real Qiskit 2.4.1:

```
measure_all (meas)   dir()[0]=items  -> AttributeError
creg named 'c'       dir()[0]=c      -> {'01': 100}   <- reversed
```

So it either crashed or returned reversed bitstrings depending on what the user named their register. Also silently dropped all but the first register on multi-register results, yielding a bitstring narrower than the measurement.

Now: selects by capability (`get_counts`), reverses to qubit-0-leftmost as `AzureQuantumExecutor` already does for the same framework, and raises on multiple registers rather than mis-indexing fidelity/SPAM downstream.

**This blocks #1367** — IBM enrollment cannot return counts for a `measure_all()` circuit. Identical logic is in the pinned production release `v0.4.0`, and the worker requirement is `qiskit>=1.0.0` unpinned.

## Braket — probability fallback

`round(prob * shots)` does not conserve the shot total: three bins at 1/3 of 1000 → **999**. Live path for IonQ Forte-1.

## IonQ — `_histogram_to_counts`

Over-allocated on unnormalized histograms — **1199** counts for 1000 shots. The reclaim loop recomputed its bound each iteration, so the limit collapsed as `leftover` shrank and it exited still over-allocated. Found by code review of this PR's first draft, after I had copied the same logic into the new shared helper.

## Shared helper

`marqov/executors/_counts.py::allocate_counts` — largest-remainder (Hamilton) allocation, used by both Braket and IonQ so the defect exists in one place. IonQ maps state indices to bitstrings and delegates.

## Tests

`tests/test_executor_result_conformance.py` — 10 tests calling the **real** normalization code against **real** vendor data (Qiskit's own `StatevectorSampler` for IBM), covering bit order and shot conservation.

```
751 passed, 20 skipped, 13 xpassed
```

## Known gap, tracked separately

`tests/test_azure_bitorder.py` never calls `AzureQuantumExecutor` — it re-implements the reversal inside the test and asserts on its own copy, so it stays green even if the production conversion is deleted. Azure is correct today, but untested in practice.

Context: #1680 (executor architecture epic). #608 audited this same class in March 2026 and applied a point fix without a test that calls the executor — which is why it recurred.