### PR TITLE
Preserve workflow capture dependencies and return structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ release.
 
 ## [Unreleased]
 
+### Added
+
+- `WorkflowDispatch.capture()` exposes the existing graph and a process-local
+  return template for execution adapters, preserving names, plain containers,
+  constants and repeated task-result references. `WorkflowCapture.resolve_output`
+  reconstructs that value from completed node results without submitting work.
+  See [workflow capture](docs/workflow-capture.md) for supported forms and codec
+  responsibilities. Legacy `run()`/`start()` result transport is unchanged.
+
 ### Fixed
+
+- Task dependency extraction now follows nested list/tuple/dictionary values,
+  matching argument serialization, and deduplicates predecessors in encounter
+  order. Cyclic argument containers raise an explicit error.
+- **Behavior correction:** using an unresolved task proxy as a boolean now raises
+  `TypeError` instead of silently selecting the true branch during graph build.
+  Dynamic branching on task results requires an execution mechanism; Python
+  truthiness cannot implement it at capture time.
 
 - **`Circuit.from_qiskit`/`from_cirq`/`from_pyquil` silently discarded
   mid-circuit `measure`, `reset`, and `delay` instructions.** A terminal

--- a/docs/workflow-capture.md
+++ b/docs/workflow-capture.md
@@ -1,0 +1,72 @@
+# Workflow capture for execution adapters
+
+Calling an SDK `@workflow` executes its Python body to build a graph. Task calls
+record nodes and serialize their functions; they normally do not execute task
+bodies. Importing source, constructing the graph and serializing arbitrary Python
+objects can all execute user code. Hosted adapters must perform these operations
+inside their isolated execution environment, not in a privileged controller.
+
+`WorkflowDispatch.capture()` exports an already-built graph and its return
+template without rerunning the workflow or submitting tasks:
+
+```python
+from marqov import task, workflow
+
+@task
+def double(value):
+    return value * 2
+
+@workflow
+def calculate(value):
+    result = double(value)
+    return {"answer": result, "again": (result, "units"), "constant": 0.25}
+
+captured = calculate(3).capture()
+node_id = next(iter(captured.graph.nodes))
+# After an adapter has actually executed the task and obtained its result:
+assert captured.resolve_output({node_id: 6}) == {
+    "answer": 6, "again": (6, "units"), "constant": 0.25,
+}
+```
+
+`WorkflowCapture` and `TaskResultReference` are exported from `marqov.workflows`.
+The capture contains the existing `TransportGraph`, including task identity,
+function bytes, positional/keyword arguments, dependencies and **requested**
+configuration. Its `output` replaces task proxies with `TaskResultReference` and
+preserves plain lists, tuples, dictionaries, constants and repeated references.
+`resolve_output` substitutes completed node results; missing results raise
+`KeyError`. A constant-only return, including `None`, is retained.
+
+This is an in-process representation, **not a wire format**. The graph is mutable;
+opaque leaf values are shared rather than copied, and calling capture later reads
+the retained result object at that time. Adapters must select a versioned artifact
+codec and compatible runtime, validate dependencies and bounds, and retain their
+own stable execution identity. Random SDK node IDs identify this capture; running
+the workflow again is a new capture, not recovery of an accepted task attempt.
+Graph/function/argument/result data must not be assumed safe to deserialize in a
+trusted process. Neither requested configuration nor a capture grants authority.
+
+Argument dependency extraction now traverses list/tuple/dictionary values as
+recursively as SDK argument serialization. Repeated predecessors appear once,
+in first-occurrence order. Cyclic argument containers raise `ValueError`.
+
+Capture supports references in plain lists, tuples and dictionary values.
+Container subclasses, cyclic return containers, task references used directly as
+dictionary keys, nested workflow-dispatch outputs and awaitable outputs are
+explicitly rejected. Other Python objects, including numerical arrays, are opaque
+leaves; references hidden inside those objects are unsupported. Adapters must
+choose which opaque types their artifact codec accepts. Capture of an async
+workflow body is unsupported; ordinary async **task** functions can remain
+executable material for an adapter that supports them.
+
+An unresolved task proxy now raises `TypeError` if used as a boolean (for example
+`if task_result:`). Its truth value cannot select a branch before the task runs.
+This does not implement dynamic graph execution or all Python operations on
+unresolved results.
+
+The existing `run()`, `start()` and private legacy Temporal input builder retain
+their transport/result behavior. They do not consume the new return template;
+the shape-preserving contract is opt-in through `capture()`. A manually constructed
+`WorkflowDispatch` without a retained result refuses capture. SDK core remains
+independent of the optional hosted API client and requires no platform account to
+construct a capture.

--- a/marqov/workflows/__init__.py
+++ b/marqov/workflows/__init__.py
@@ -34,6 +34,7 @@ from marqov.workflows.decorators import (
     WorkflowDispatch,
 )
 from marqov.workflows.graph import TransportGraph, TaskProxy
+from marqov.workflows.capture import WorkflowCapture, TaskResultReference
 from marqov.workflows.temporal_workflow import JobWorkflow
 from marqov.workflows.runner import create_worker
 from marqov.workflows.activity import execute_task, prepare_node_inputs
@@ -65,6 +66,8 @@ __all__ = [
     "task",
     "workflow",
     "WorkflowDispatch",
+    "WorkflowCapture",
+    "TaskResultReference",
     "TransportGraph",
     "TaskProxy",
     "JobWorkflow",

--- a/marqov/workflows/capture.py
+++ b/marqov/workflows/capture.py
@@ -1,0 +1,89 @@
+"""Process-local workflow capture for execution adapters.
+
+Capture is executable material, not a JSON transport or permission to execute.
+Adapters choose their own artifact codecs, runtime isolation and policy checks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import inspect
+from typing import Any, Callable, Mapping
+
+from marqov.workflows.graph import TaskProxy, TransportGraph
+
+
+@dataclass(frozen=True)
+class TaskResultReference:
+    """Reference to a task result within one captured graph."""
+
+    node_id: str
+
+
+@dataclass(frozen=True)
+class WorkflowCapture:
+    """Graph plus return template, without submitting work or choosing a codec.
+
+    The graph includes callable bytes, arguments and requested task configuration.
+    It remains mutable; this object is not a durable or authoritative snapshot.
+    Lists, tuples and dictionary values in output preserve their structure;
+    non-container values are opaque leaves and are not copied or inspected.
+    """
+
+    graph: TransportGraph
+    output: Any
+
+    def resolve_output(self, results: Mapping[str, Any]) -> Any:
+        """Reconstruct the declared return value from completed node results.
+
+        Missing results raise KeyError. This performs no task execution. Only
+        use capture/material from code you trust or within its execution sandbox.
+        """
+        return _map_output(
+            self.output,
+            lambda value: (
+                results[value.node_id] if isinstance(value, TaskResultReference) else value
+            ),
+        )
+
+
+def _map_output(value: Any, leaf: Callable[[Any], Any], active: set[int] | None = None) -> Any:
+    if active is None:
+        active = set()
+    if type(value) not in (list, tuple, dict):
+        if isinstance(value, (list, tuple, dict)):
+            raise TypeError("Capture supports plain list, tuple and dict containers only")
+        return leaf(value)
+    identity = id(value)
+    if identity in active:
+        raise ValueError("Cyclic workflow return containers are not supported")
+    active.add(identity)
+    try:
+        if type(value) is dict:
+            if any(isinstance(key, (TaskProxy, TaskResultReference)) for key in value):
+                raise TypeError("Task references cannot be workflow return dictionary keys")
+            return {key: _map_output(item, leaf, active) for key, item in value.items()}
+        return type(value)(_map_output(item, leaf, active) for item in value)
+    finally:
+        active.remove(identity)
+
+
+def capture_output(graph: TransportGraph, result: Any) -> WorkflowCapture:
+    def reference(value: Any) -> Any:
+        if isinstance(value, TaskProxy):
+            if value._graph is not graph or value.node_id not in graph.nodes:
+                raise ValueError("Workflow output references a different graph")
+            return TaskResultReference(value.node_id)
+        # A nested dispatch is not a completed task result. Import lazily to keep
+        # this module independent of decorator initialization order.
+        from marqov.workflows.decorators import WorkflowDispatch
+
+        if isinstance(value, WorkflowDispatch):
+            raise TypeError("Nested workflow dispatch output is not supported by capture")
+        if inspect.isawaitable(value):
+            if inspect.iscoroutine(value):
+                value.close()
+            raise TypeError("Awaitable workflow output is not supported by capture")
+        return value
+
+    return WorkflowCapture(graph, _map_output(result, reference))

--- a/marqov/workflows/decorators.py
+++ b/marqov/workflows/decorators.py
@@ -25,9 +25,12 @@ from __future__ import annotations
 
 import base64
 from functools import wraps
-from typing import Any, Callable, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, overload
 
 import cloudpickle
+
+if TYPE_CHECKING:
+    from marqov.workflows.capture import WorkflowCapture
 
 from marqov.workflows.graph import (
     TaskConfig,
@@ -42,6 +45,7 @@ from marqov.workflows.graph import (
 
 T = TypeVar("T")
 F = TypeVar("F", bound=Callable[..., Any])
+_NO_CAPTURE_RESULT = object()
 
 
 def _serialize_arg(arg: Any) -> Any:
@@ -208,6 +212,8 @@ class WorkflowDispatch:
         name: str,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
+        *,
+        captured_result: Any = _NO_CAPTURE_RESULT,
     ) -> None:
         """Initialize the dispatch handle.
 
@@ -221,6 +227,21 @@ class WorkflowDispatch:
         self.name = name
         self._args = args
         self._kwargs = kwargs
+        self._captured_result = captured_result
+
+    def capture(self) -> WorkflowCapture:
+        """Export this already-built graph and its complete return structure.
+
+        No workflow body is rerun and no task is submitted. The returned object
+        contains executable material; an adapter must select an appropriate
+        isolated runtime and artifact codec. This is not the legacy Temporal
+        JSON transport and does not change run()/start() result semantics.
+        """
+        from marqov.workflows.capture import capture_output
+
+        if self._captured_result is _NO_CAPTURE_RESULT:
+            raise ValueError("Dispatch has no captured return value")
+        return capture_output(self.graph, self._captured_result)
 
     def visualize(self) -> str:
         """Return DOT format graph visualization.
@@ -490,6 +511,7 @@ def workflow(
                 name=workflow_name,
                 args=args,
                 kwargs=kwargs,
+                captured_result=result,
             )
 
         # Mark as workflow for introspection
@@ -501,4 +523,3 @@ def workflow(
     if func is not None:
         return decorator(func)
     return decorator
-

--- a/marqov/workflows/graph.py
+++ b/marqov/workflows/graph.py
@@ -114,6 +114,10 @@ class TaskProxy:
         """Return string representation."""
         return f"TaskProxy({self._node.func_name}, id={self._node.id})"
 
+    def __bool__(self) -> bool:
+        """An unresolved result cannot select a Python control-flow branch."""
+        raise TypeError("Cannot use an unresolved task result as a boolean")
+
 
 class TransportGraph:
     """Directed acyclic graph of task dependencies.
@@ -271,7 +275,11 @@ def generate_node_id() -> str:
 
 
 def extract_dependencies(args: tuple[Any, ...], kwargs: dict[str, Any]) -> list[str]:
-    """Extract node IDs from TaskProxy arguments.
+    """Extract unique node IDs recursively from TaskProxy arguments.
+
+    Traverses the same list, tuple and dictionary-value containers as argument
+    serialization, preserving first occurrence order. Cyclic containers fail
+    explicitly; custom objects are opaque leaves.
 
     Args:
         args: Positional arguments that may contain proxies.
@@ -282,21 +290,26 @@ def extract_dependencies(args: tuple[Any, ...], kwargs: dict[str, Any]) -> list[
     """
     deps: list[str] = []
 
-    for arg in args:
-        if isinstance(arg, TaskProxy):
-            deps.append(arg.node_id)
-        elif isinstance(arg, (list, tuple)):
-            for item in arg:
-                if isinstance(item, TaskProxy):
-                    deps.append(item.node_id)
+    seen: set[str] = set()
+    active: set[int] = set()
 
-    for value in kwargs.values():
+    def visit(value: Any) -> None:
         if isinstance(value, TaskProxy):
-            deps.append(value.node_id)
-        elif isinstance(value, (list, tuple)):
-            for item in value:
-                if isinstance(item, TaskProxy):
-                    deps.append(item.node_id)
+            if value.node_id not in seen:
+                seen.add(value.node_id)
+                deps.append(value.node_id)
+        elif isinstance(value, (list, tuple, dict)):
+            identity = id(value)
+            if identity in active:
+                raise ValueError("Cyclic task argument containers are not supported")
+            active.add(identity)
+            try:
+                for item in value.values() if isinstance(value, dict) else value:
+                    visit(item)
+            finally:
+                active.remove(identity)
+
+    visit(args)
+    visit(kwargs)
 
     return deps
-

--- a/tests/test_workflow_capture.py
+++ b/tests/test_workflow_capture.py
@@ -1,0 +1,175 @@
+"""Capture semantics using module-level fixtures and real SDK serialization."""
+
+import base64
+
+import cloudpickle
+import numpy as np
+import pytest
+
+from marqov import task, workflow
+from marqov.workflows import TaskResultReference, WorkflowDispatch
+from marqov.workflows.graph import TransportGraph, extract_dependencies
+
+
+def _identity(value=None, **kwargs):
+    return value
+
+
+identity = task(_identity)
+
+
+def test_recursive_dependencies_match_serialized_arguments_and_do_not_duplicate():
+    @workflow
+    def program():
+        a = identity(1)
+        b = identity(2)
+        return identity({"nested": [(a, {"again": b})]}, direct=a, deep={"items": [b, a]})
+
+    dispatch = program()
+    a, b, join = list(dispatch.graph.nodes.values())
+    assert join.dependencies == [a.id, b.id]
+    levels = dispatch.get_parallel_groups()
+    assert len(levels) == 2
+    assert set(levels[0]) == {a.id, b.id}
+    assert levels[1] == [join.id]
+    assert join.args[0]["nested"][0][0] == {"__proxy__": True, "node_id": a.id}
+    assert join.kwargs["deep"]["items"][0] == {"__proxy__": True, "node_id": b.id}
+    assert cloudpickle.loads(base64.b64decode(join.func_ref))(3) == 3
+
+
+def test_named_nested_mixed_and_duplicate_outputs_preserve_shape_without_rerun():
+    calls = []
+
+    @workflow
+    def program():
+        calls.append("capture")
+        result = identity(7)
+        return {"named": result, "nested": [result, ("constant", result)], "none": None}
+
+    dispatch = program()
+    before = dispatch._prepare_workflow_input()
+    capture = dispatch.capture()
+    node_id = next(iter(capture.graph.nodes))
+    assert capture.output["named"] == TaskResultReference(node_id)
+    assert capture.resolve_output({node_id: 7}) == {
+        "named": 7,
+        "nested": [7, ("constant", 7)],
+        "none": None,
+    }
+    assert calls == ["capture"]
+    assert dispatch.capture().output == capture.output
+    assert dispatch._prepare_workflow_input() == before
+    with pytest.raises(KeyError):
+        capture.resolve_output({})
+
+
+@pytest.mark.parametrize("value", [None, 3.5, [], (), {}, {"literal": [1, 2]}])
+def test_constant_only_output_is_preserved(value):
+    @workflow
+    def program():
+        return value
+
+    capture = program().capture()
+    assert capture.resolve_output({}) == value
+
+
+def test_arrays_are_opaque_leaves_and_no_platform_credentials_are_needed(monkeypatch):
+    for key in list(__import__("os").environ):
+        if key.startswith(("MARQOV_", "AWS_", "SUPABASE_", "TEMPORAL_")):
+            monkeypatch.delenv(key)
+    array = np.array([0.25, 1.5])
+
+    @workflow
+    def program():
+        return {"constant": array, "task": identity(array)}
+
+    capture = program().capture()
+    node = next(iter(capture.graph.nodes.values()))
+    assert node.args[0] is array
+    result = capture.resolve_output({node.id: array * 2})
+    assert result["constant"] is array
+    np.testing.assert_array_equal(result["task"], [0.5, 3.0])
+
+
+def test_container_cycles_rejected_but_shared_containers_are_allowed():
+    cyclic = []
+    cyclic.append(cyclic)
+    with pytest.raises(ValueError, match="Cyclic task argument"):
+        extract_dependencies((cyclic,), {})
+
+    @workflow
+    def program(value):
+        return value
+
+    with pytest.raises(ValueError, match="Cyclic workflow return"):
+        program(cyclic).capture()
+    shared = [1, 2]
+    assert program([shared, shared]).capture().resolve_output({}) == [[1, 2], [1, 2]]
+
+
+def test_unresolved_boolean_control_flow_rejected():
+    @workflow
+    def program():
+        if identity(True):
+            return identity(1)
+        return identity(2)
+
+    with pytest.raises(TypeError, match="unresolved task result"):
+        program()
+
+
+def test_async_and_nested_workflow_returns_rejected_by_capture():
+    @workflow
+    async def asynchronous():
+        return 1
+
+    with pytest.raises(TypeError, match="Awaitable workflow output"):
+        asynchronous().capture()
+
+    @workflow
+    def inner():
+        return identity(1)
+
+    @workflow
+    def outer():
+        return {"inner": inner()}
+
+    with pytest.raises(TypeError, match="Nested workflow dispatch"):
+        outer().capture()
+
+
+def test_foreign_graph_output_and_missing_capture_fail_explicitly():
+    @workflow
+    def first():
+        return identity(1)
+
+    foreign = first()._captured_result
+
+    @workflow
+    def second():
+        return foreign
+
+    with pytest.raises(ValueError, match="different graph"):
+        second().capture()
+    dispatch = WorkflowDispatch(TransportGraph(), "manual", (), {})
+    with pytest.raises(ValueError, match="no captured return"):
+        dispatch.capture()
+
+
+def test_container_subclasses_and_proxy_keys_do_not_silently_change_shape():
+    class CustomList(list):
+        pass
+
+    @workflow
+    def custom():
+        return CustomList([1])
+
+    with pytest.raises(TypeError, match="plain list"):
+        custom().capture()
+
+    @workflow
+    def keyed():
+        return {identity(1): "value"}
+
+    with pytest.raises(TypeError, match="dictionary keys"):
+        keyed().capture()

--- a/tests/workflow_capture_wheel_probe.py
+++ b/tests/workflow_capture_wheel_probe.py
@@ -1,0 +1,98 @@
+"""Offline, disposable-runtime probe of a built wheel using synthetic code only.
+
+Run with the wheel path as the only argument in a Python 3.12 environment with
+the runtime dependencies installed. No provider or hosted API is contacted.
+"""
+
+import base64
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+
+def main():
+    import cloudpickle
+
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        package_root = root / "installed"
+        with zipfile.ZipFile(sys.argv[1]) as wheel:
+            wheel.extractall(package_root)
+        sys.path.insert(0, str(package_root))
+        from marqov import task, workflow
+        import marqov
+
+        assert Path(marqov.__file__).is_relative_to(package_root)
+
+        @workflow
+        def program(value):
+            offset = 0.25
+
+            @task
+            def add(x):
+                return x + offset
+
+            @task
+            def join(values):
+                return sum(values["nested"])
+
+            a = add(value)
+            b = add(value + 1)
+            total = join({"nested": (a, b)})
+            return {"answer": total, "repeat": [total, (a, "units")], "constant": 0.5}
+
+        capture = program(1.5).capture()
+        nodes = list(capture.graph.nodes.values())
+        assert nodes[2].dependencies == [nodes[0].id, nodes[1].id]
+        # Callable loading/execution happens in fresh child interpreters, with
+        # the exact wheel first on their path, not the checkout or installed SDK.
+        child_env = {**os.environ, "PYTHONPATH": str(package_root)}
+        values = {}
+        for level in capture.graph.get_execution_order():
+            for node_id in level:
+                node = capture.graph.nodes[node_id]
+                payload = root / "task.bin"
+                payload.write_bytes(
+                    cloudpickle.dumps(
+                        (base64.b64decode(node.func_ref), node.args, node.kwargs, values)
+                    )
+                )
+                result = root / "result.bin"
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        "import cloudpickle,sys\n"
+                        "fn,args,kwargs,values=cloudpickle.load(open(sys.argv[1],'rb'))\n"
+                        "def resolve(v):\n"
+                        " if isinstance(v,dict):\n"
+                        "  if v.get('__proxy__') is True: return values[v['node_id']]\n"
+                        "  return {k:resolve(x) for k,x in v.items()}\n"
+                        " if isinstance(v,(list,tuple)): return type(v)(resolve(x) for x in v)\n"
+                        " return v\n"
+                        "value=cloudpickle.loads(fn)(*resolve(args),**resolve(kwargs))\n"
+                        "cloudpickle.dump(value,open(sys.argv[2],'wb'))\n",
+                        str(payload),
+                        str(result),
+                    ],
+                    env=child_env,
+                    check=True,
+                    timeout=30,
+                )
+                values[node_id] = cloudpickle.loads(result.read_bytes())
+        assert capture.resolve_output(values) == {
+            "answer": 4.5,
+            "repeat": [4.5, (1.75, "units")],
+            "constant": 0.5,
+        }
+        # The typed output descriptor also survives its own artifact roundtrip.
+        template = cloudpickle.loads(cloudpickle.dumps(capture.output))
+        assert template == capture.output
+        print("Built-wheel capture, closures, recursive dependencies and return shape passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Workflow arguments nested in mappings were serialized without matching dependency edges, and execution adapters could obtain only output node IDs rather than the declared return structure.

This fixes recursive dependency collection and adds `WorkflowDispatch.capture()`, exposing the existing graph plus a typed return template without rerunning or submitting the workflow. Named, nested, constant and repeated outputs can be reconstructed from completed node results. The capture remains process-local executable material; adapters choose codecs, isolation and execution policy. Legacy `run()`/`start()` transport is unchanged. Unsupported capture containers, cycles, awaitables and nested dispatch outputs fail explicitly.

Behavior correction: unresolved task proxies now reject boolean evaluation instead of silently choosing the true branch. Dynamic DAG execution remains separate work (marqov-sdk#30).

Validation:
- Full SDK suite: 778 passed, 20 existing skips, 13 existing XPASS results; no failures, including the real Temporal test-server isolation test.
- Built wheel and sdist. The actual wheel passed an offline, unprivileged Python 3.12 / cloudpickle 3.1.2 container probe: closures executed in fresh processes, nested dependencies matched and named/mixed/repeated return values reconstructed correctly.
- Fourteen capture tests plus public-reference hygiene passed. New-file Ruff and capture-module mypy passed; two existing unused-import findings remain in touched legacy modules.

No SDK version bump, tag, publication or new service dependency. Documentation and the unreleased changelog describe the supported capture profile and its limits.
