### PR TITLE
Prepare SDK 0.6.0 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ release.
 
 ## [Unreleased]
 
+Prepared release version: **0.6.0**. Publication is pending; the changes below
+are not a record of a published package.
+
 ### Added
 
 - `WorkflowDispatch.capture()` exposes the existing graph and a process-local
@@ -17,6 +20,14 @@ release.
   responsibilities. Legacy `run()`/`start()` result transport is unchanged.
 
 ### Fixed
+
+- **Executor result normalization:** IBM now selects classical registers by their
+  count-reading capability and normalizes bitstrings to qubit 0 leftmost. Results
+  containing multiple measured registers raise `NotImplementedError` instead of
+  silently returning only one register. Braket probability fallback and IonQ
+  histogram conversion now use shared largest-remainder allocation so counts
+  sum to the requested shots, including unnormalized histograms. Asymmetric
+  result fixtures cover bit order. (marqov-sdk#114)
 
 - Task dependency extraction now follows nested list/tuple/dictionary values,
   matching argument serialization, and deduplicates predecessors in encounter

--- a/docs/releases/0.6.0.md
+++ b/docs/releases/0.6.0.md
@@ -1,0 +1,48 @@
+# Marqov 0.6.0 release candidate
+
+Status: prepared for review; not published. The package version is 0.6.0 and the
+changelog remains explicitly unreleased until publication is recorded.
+
+This minor release adds workflow capture and includes all changes since the
+published 0.5.1 tag: workflow capture/dependency correctness (marqov-sdk#116),
+circuit semantic refusal (marqov-sdk#113), executor result normalization
+(marqov-sdk#114), and the analog-executor changelog citation (marqov-sdk#112).
+Contributor in that commit range: David Ryan.
+
+## Compatibility and migration
+
+- Python remains `>=3.12`; no dependency upgrade is part of this version change.
+- `WorkflowDispatch.capture()` exports the existing graph and a return template
+  preserving supported names, containers, constants and repeated task references.
+  Adapters choose serialization/runtime compatibility and enforce their own
+  execution policy. See [workflow capture](../workflow-capture.md).
+- Nested argument dependencies now agree with serialization. An unresolved task
+  proxy used as a boolean raises `TypeError`; replace capture-time branching on
+  task results with a supported execution mechanism. This does not implement
+  dynamic DAGs. Legacy run/start result transport is unchanged.
+- Circuit importers now reject unsupported mid-circuit measurement, reset and
+  delay instead of silently dropping those operations. Programs relying on that
+  loss must be corrected; this release does not add support for those semantics.
+- IBM results normalize to qubit 0 leftmost and refuse unsupported multi-register
+  extraction. Check downstream code for manual bit reversal that would now reverse
+  twice. Braket/IonQ probability conversions conserve the requested shot count.
+- Numerical conversion fixtures are local evidence, not a new live-provider
+  qualification. No new backend, credential flow or hosted service is activated.
+
+## Artifact and adoption requirements
+
+Source version and built distribution metadata must both be 0.6.0. Build the
+wheel and source distribution, inspect their contents and validate package metadata.
+Run the full test suite plus the built-wheel capture probe in the intended
+Python/serializer environment; the probe must import the wheel rather than the
+checkout. Preserve the exact commit, artifact hashes and runtime evidence outside
+the artifacts themselves.
+
+Do not treat this source tree or a version string as an installed release. After
+publication, consumers should pin the identified artifact and requalify their
+own runtime/image locks. Core capture requires no hosted API account; the optional
+HTTP client and execution adapters have separate compatibility obligations.
+
+Follow [the release procedure](../../RELEASING.md) for the TestPyPI and PyPI gates.
+Both publication targets permanently claim a version. No tag or publication is
+performed by the release-candidate PR.

--- a/marqov/__init__.py
+++ b/marqov/__init__.py
@@ -34,7 +34,7 @@ Simple circuit execution:
     >>> result = await executor.execute(circuit, shots=1000)
 """
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 
 # Re-export commonly used items for convenience
 from marqov.circuits import Circuit, bell_state, ghz_state


### PR DESCRIPTION
Prepares SDK 0.6.0 from all changes merged since the published 0.5.1 tag. The minor version reflects the new capture API and deliberate behavior corrections. Changelog and release notes remain explicitly unpublished.

Included: workflow capture/recursive dependencies and supported return preservation; refusal of unsupported circuit operations; IBM result extraction/bit order plus Braket/IonQ shot-conserving normalization; the existing analog-executor changelog citation. No dependency upgrades or additional runtime implementation.

Validation:
- Release-checklist extras and fresh package metadata: full suite 778 passed, 20 existing skips, 13 existing XPASS; real Temporal isolation test included.
- Built 0.6.0 wheel and sdist; metadata/content inspection and `twine check` passed. Wheel version/source agree and include the new capture module.
- Exact wheel passed the offline, unprivileged Python 3.12/cloudpickle 3.1.2 container probe, with fresh-process closures, recursive references and structured returns.
- URL check: 13 clean, two API-base warnings (IonQ 403/404), zero non-resolving hosts. These are reachability checks, not authenticated provider qualification.
- Version 0.6.0 absent on PyPI/TestPyPI and remote tags when prepared. Hygiene/version tests and diff checks passed.

Local artifact hashes:
- wheel: `d5508e106b4c0eb3ca73bad3d875d68d5b1ed794e5210853e062dfc4736f61ac`
- sdist: `9cce6a6a48fcb8bd3d646adf5bb90998e1a87eb11165ccb3fcaf96ff891c108f`

Release gate: review and CI first; then explicitly approved TestPyPI publication and clean installed-artifact verification before merge/tag publication. No tag, TestPyPI/PyPI upload or downstream runtime adoption has occurred. Cloud-built artifacts must be inspected and identified independently; the local hashes are not assumed to match a future build.
