### PR TITLE
feat(qutip): prepare optional solver support for 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@ release.
 
 ## [Unreleased]
 
-Prepared release version: **0.6.0**. Publication is pending; the changes below
+Prepared release version: **0.6.1**. Publication is pending; the changes below
 are not a record of a published package.
+
+### Added
+
+- Optional `marqov[qutip]` installation includes QuTiP 5 dependencies
+  (`>=5.3.0,<6.0.0`) for solver use with the existing `marqov.qutip.record` helper.
+  QuTiP is also included in `marqov[all]`; the base SDK dependencies are unchanged.
+
+- A runnable local QuTiP decay example and a clean-install wheel smoke check
+  verify optional installation and recorded observables against analytic decay.
+
+## [0.6.0] — 2026-09-08
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,32 @@ Independent tasks execute in parallel automatically. Marqov handles scheduling, 
 pip install marqov
 ```
 
-With backend-specific extras:
+With framework- or backend-specific extras:
 
 ```bash
 # IBM Quantum
 pip install "marqov[ibm]"
 
-# All extras
+# QuTiP solvers and Marqov's result-recording helper
+pip install "marqov[qutip]"
+
+# Combine selected frameworks
+pip install "marqov[qutip,qiskit]"
+
+# Broad framework bundle
 pip install "marqov[all]"
 ```
+
+Run the local [QuTiP decay example](examples/qutip_decay.py) after installing
+`marqov[qutip]`:
+
+```bash
+python examples/qutip_decay.py
+```
+
+It prints solver times and the `sigma_z` observable as JSON. No account is
+required. Managed execution requires separate runtime support; installing this
+extra does not enable a hosted service.
 
 For local development:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,6 +49,17 @@ rather than a failure, but the first upload of a version is still one-way.
       provider API, or a transient timeout, is a **WARN**, not a failure — eyeball
       each so an outage on release day doesn't block the tag.
 
+For releases containing QuTiP packaging changes, run the isolated wheel check
+after building (requires `uv` on PATH):
+
+```bash
+.venv/bin/python tools/smoke_qutip_wheel.py /absolute/path/to/marqov-X.Y.Z-py3-none-any.whl
+```
+
+It installs the base wheel in a temporary environment, verifies QuTiP is absent,
+then installs the same wheel with `[qutip]` and runs the local decay example.
+Dependencies resolve from real PyPI; it does not upload anything.
+
 ## 3. Build, inspect, dry-run to TestPyPI
 - [ ] Look inside the artifact before any upload:
       ```

--- a/docs/releases/0.6.0.md
+++ b/docs/releases/0.6.0.md
@@ -1,7 +1,9 @@
-# Marqov 0.6.0 release candidate
+# Marqov 0.6.0
 
-Status: prepared for review; not published. The package version is 0.6.0 and the
-changelog remains explicitly unreleased until publication is recorded.
+Status: published on 2026-09-08. See the
+[release record](https://github.com/marqov-dev/marqov-sdk/releases/tag/v0.6.0).
+The published artifacts retain their original pre-publication wording; this
+source document now records publication.
 
 This minor release adds workflow capture and includes all changes since the
 published 0.5.1 tag: workflow capture/dependency correctness (marqov-sdk#116),

--- a/examples/qutip_decay.py
+++ b/examples/qutip_decay.py
@@ -1,0 +1,27 @@
+"""Run locally after installing marqov[qutip]; print recorded solver observables.
+
+This example does not submit a cloud job or require an account.
+"""
+
+import numpy as np
+from qutip import basis, mesolve, sigmam, sigmaz
+
+from marqov.qutip import record
+
+
+def main():
+    times = np.linspace(0, 5, 11)
+    # QuTiP's basis(2, 0) has sigma-z = +1; relaxation drives it toward -1.
+    result = mesolve(
+        0.5 * sigmaz(),
+        basis(2, 0),
+        times,
+        c_ops=[np.sqrt(0.4) * sigmam()],
+        e_ops=[sigmaz()],
+        options={"store_states": False, "progress_bar": ""},
+    )
+    record(result, observable_names=["sigma_z"])
+
+
+if __name__ == "__main__":
+    main()

--- a/marqov/__init__.py
+++ b/marqov/__init__.py
@@ -34,7 +34,7 @@ Simple circuit execution:
     >>> result = await executor.execute(circuit, shots=1000)
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 # Re-export commonly used items for convenience
 from marqov.circuits import Circuit, bell_state, ghz_state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,14 +49,17 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.8.0",
     # Test-only: exercises marqov.qutip.record's mesolve/mcsolve integration
-    # tests (tests/qutip/test_record.py). Not a runtime dependency — record.py
-    # duck-types the qutip Result and never imports qutip itself.
+    # tests (tests/qutip/test_record.py). Also available through the qutip extra;
+    # record.py duck-types the qutip Result and never imports qutip itself.
     "qutip>=5.3.0,<6.0.0",
     # Test-only: tests/test_cunqa_qpe_reference_circuit.py simulates the QPE
     # reference circuit directly via AerSimulator to verify it independently
     # of any live CUNQA cluster. Not a runtime dependency of cunqa.py itself
     # (CUNQA wraps its own Aer internally, on the cluster).
     "qiskit-aer>=0.14.0",
+]
+qutip = [
+    "qutip>=5.3.0,<6.0.0",
 ]
 qiskit = [
     "qiskit>=1.0.0",
@@ -108,6 +111,7 @@ rigetti = [
     "pyquil>=4.0.0",
 ]
 all = [
+    "qutip>=5.3.0,<6.0.0",
     "qiskit>=1.0.0",
     "qiskit-ibm-runtime>=0.20.0",
     "qiskit-qasm3-import>=0.5.0",

--- a/tools/smoke_qutip_wheel.py
+++ b/tools/smoke_qutip_wheel.py
@@ -1,0 +1,78 @@
+"""Check a built wheel in a fresh environment (requires uv on PATH).
+
+Run: .venv/bin/python tools/smoke_qutip_wheel.py /absolute/path/marqov-X.Y.Z-py3-none-any.whl
+Dependencies resolve only from real PyPI. Nothing is published.
+"""
+
+import argparse
+import json
+import math
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+from email.parser import Parser
+from zipfile import ZipFile
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel", type=Path)
+    args = parser.parse_args()
+    wheel = args.wheel.resolve(strict=True)
+    uv = shutil.which("uv")
+    if uv is None:
+        parser.error("uv must be installed and available on PATH")
+    with ZipFile(wheel) as archive:
+        metadata = [n for n in archive.namelist() if n.endswith(".dist-info/METADATA")]
+        if len(metadata) != 1:
+            parser.error("expected one distribution metadata file")
+        version = Parser().parsestr(archive.read(metadata[0]).decode())["Version"]
+    example = Path(__file__).resolve().parents[1] / "examples" / "qutip_decay.py"
+    with tempfile.TemporaryDirectory(prefix="marqov-qutip-smoke-") as directory:
+        root = Path(directory)
+        env = root / "venv"
+        subprocess.run([uv, "venv", "--python", sys.executable, str(env)], check=True)
+        python = env / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+        def install(requirement):
+            subprocess.run(
+                [uv, "--no-config", "pip", "install", "--python", str(python),
+                 "--default-index", "https://pypi.org/simple", requirement],
+                check=True, cwd=root,
+                env={k: v for k, v in os.environ.items()
+                     if not k.startswith(("UV_", "PIP_"))},
+            )
+
+        install(str(wheel))
+        subprocess.run(
+            [str(python), "-I", "-c",
+             "import importlib.util; assert importlib.util.find_spec('qutip') is None"],
+            check=True, cwd=root,
+        )
+        install(str(wheel) + "[qutip]")
+        subprocess.run(
+            [str(python), "-I", "-c",
+             "import marqov, sys; from pathlib import Path; "
+             "assert marqov.__version__ == sys.argv[1]; "
+             "assert Path(marqov.__file__).is_relative_to(Path(sys.prefix)); "
+             "import qutip", version], check=True, cwd=root,
+        )
+        script = root / "qutip_decay.py"
+        shutil.copyfile(example, script)
+        output = subprocess.check_output([str(python), "-I", str(script)], text=True, cwd=root)
+        payload = json.loads(output)
+        assert payload["result_type"] == "open-system-dynamics"
+        assert payload["schema_version"] == 1
+        assert payload["times"] == [i / 2 for i in range(11)]
+        values = payload["observables"]["sigma_z"]
+        assert len(values) == 11
+        for time, value in zip(payload["times"], values):
+            assert math.isclose(value, 2 * math.exp(-0.4 * time) - 1, abs_tol=1e-5)
+    print(f"marqov {version}: base excludes QuTiP; extra installs it; wheel example matches analytic decay.")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -1465,6 +1465,7 @@ all = [
     { name = "qiskit" },
     { name = "qiskit-ibm-runtime" },
     { name = "qiskit-qasm3-import" },
+    { name = "qutip" },
     { name = "requests" },
 ]
 azure = [
@@ -1519,6 +1520,9 @@ quantinuum = [
     { name = "pytket-quantinuum" },
     { name = "qiskit" },
 ]
+qutip = [
+    { name = "qutip" },
+]
 rigetti = [
     { name = "pyquil" },
 ]
@@ -1566,7 +1570,9 @@ requires-dist = [
     { name = "qiskit-qasm3-import", marker = "extra == 'all'", specifier = ">=0.5.0" },
     { name = "qiskit-qasm3-import", marker = "extra == 'openqasm'", specifier = ">=0.5.0" },
     { name = "qiskit-qasm3-import", marker = "extra == 'qiskit'", specifier = ">=0.5.0" },
+    { name = "qutip", marker = "extra == 'all'", specifier = ">=5.3.0,<6.0.0" },
     { name = "qutip", marker = "extra == 'dev'", specifier = ">=5.3.0,<6.0.0" },
+    { name = "qutip", marker = "extra == 'qutip'", specifier = ">=5.3.0,<6.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "requests", marker = "extra == 'all'", specifier = ">=2.31.0" },
     { name = "requests", marker = "extra == 'ionq'", specifier = ">=2.31.0" },
@@ -1575,7 +1581,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=24.0.0" },
     { name = "temporalio", specifier = ">=1.7.0" },
 ]
-provides-extras = ["all", "azure", "cirq", "cudaq", "dev", "ibm", "ionq", "openqasm", "pennylane", "pyquil", "pytket", "qiskit", "quantinuum", "rigetti"]
+provides-extras = ["all", "azure", "cirq", "cudaq", "dev", "ibm", "ionq", "openqasm", "pennylane", "pyquil", "pytket", "qiskit", "quantinuum", "qutip", "rigetti"]
 
 [[package]]
 name = "marqov-quantumflow"


### PR DESCRIPTION
Adds an optional `marqov[qutip]` installation for the existing result-recording helper, also included in `[all]`, with QuTiP `>=5.3.0,<6.0.0`. Base dependencies and external locked package versions are unchanged.

Prepares version 0.6.1, separates its pending changelog from published 0.6.0, and corrects the earlier release-document status. Includes a runnable local decay example and a reusable clean-install wheel check, documented in the README and release procedure. The example and check ship in the source archive but are excluded from the installed wheel. Managed execution requires separate runtime qualification.

Validation:
- Full suite: 778 passed, 20 skipped, 13 xpassed; no failures.
- Fresh environment: base wheel excludes QuTiP; the same wheel with `[qutip]` installs it; isolated example output matches analytic decay.
- Wheel/source archive build and Twine metadata checks passed; wheel version/optional requirements and archive contents inspected.
- Ruff on new Python files and `git diff --check` passed.
- URL check: 14 clean, two existing IonQ endpoint HTTP warnings, no unresolved hosts.

This PR does not publish or tag a release. TestPyPI/PyPI publication remains subject to the release procedure and separate approval.
