### PR TITLE
docs(changelog): record SDK 0.6.1 publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ release.
 
 ## [Unreleased]
 
-Prepared release version: **0.6.1**. Publication is pending; the changes below
-are not a record of a published package.
+### Documentation
+
+- Added the [QuTiP guide](docs/qutip.md) covering local installation,
+  copy-and-run examples, result recording, seed replay, saved states and
+  troubleshooting. This guide was added after the 0.6.1 release.
+
+## [0.6.1] — 2026-09-08
 
 ### Added
 


### PR DESCRIPTION
Record SDK 0.6.1 as released on September 8, 2026, replacing the stale publication-pending wording. Keep the QuTiP guide added after publication under Unreleased so it is not attributed to the shipped archive.

Changelog only; no version, runtime, dependency, or published artifact changes.

Validation: full SDK suite passed (778 passed, 20 skipped, 13 xpassed), wheel/source build passed, and `git diff --check` passed.
