### PR TITLE
Release SDK 0.7.0 with optional Braket dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `marqov` SDK are documented here. This project follow
 still change between minor versions; `1.0.0` is reserved for the first API-stable
 release.
 
-## [Unreleased]
+## [0.7.0] — release candidate
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- AWS Braket is now an optional `marqov[braket]` dependency, also included in
+  `marqov[all]`, with a security floor of `amazon-braket-sdk>=1.117.0`.
+  Existing Braket users must select that extra when installing or upgrading.
+  This includes `MarqovDevice`'s `local`/`marqov-sim` simulator and Braket circuit
+  conversions. Their execution semantics are unchanged; missing installations
+  now report the required extra.
+- Workflow serialization declares `cloudpickle>=2.2.1` directly. A core-only
+  compiler/task environment can pin its own compatible serialization version
+  without inheriting Braket's job serialization dependency constraint.
+
 ### Documentation
 
 - Added the [QuTiP guide](docs/qutip.md) covering local installation,

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ pip install marqov
 With framework- or backend-specific extras:
 
 ```bash
+# AWS Braket
+pip install "marqov[braket]"
+
 # IBM Quantum
 pip install "marqov[ibm]"
 
@@ -62,6 +65,14 @@ pip install "marqov[qutip,qiskit]"
 # Broad framework bundle
 pip install "marqov[all]"
 ```
+
+AWS Braket is an optional provider dependency. Existing Braket installations
+should use `marqov[braket]` (or `marqov[all]`) when upgrading. Core workflows,
+`LocalExecutor` and `Circuit.simulate()` do not require it. `MarqovDevice` with
+`local` or `marqov-sim` uses Braket's local simulator and needs the extra, as do
+Braket circuit conversions. Hosted compiler/task environments can pin
+their serialization version without inheriting Braket's separate job serializer
+constraint.
 
 See the [QuTiP guide](docs/qutip.md) for a copy-and-run simulation, recorded
 observables, seed replay and saved-state handling. In a source checkout, run:

--- a/docs/design/optional-braket-runtime.md
+++ b/docs/design/optional-braket-runtime.md
@@ -42,3 +42,22 @@ It must not replace the released 0.6.1 artifact. A reviewed new release/version,
 published wheel hash, refreshed frozen platform profiles and exact container
 qualification are required before runtime adoption. No package was published and
 no hosted runtime was changed by this qualification.
+
+## Release candidate
+
+The candidate is version0.7.0 because default installation no longer supplies
+Braket execution, circuit conversion or the MarqovDevice local simulator.
+Existing users of those paths must install `marqov[braket]` (or `[all]`).
+Independent review found no blocking code issue. The earlier0.6.1 local wheel
+was qualification evidence only; published0.6.1 remains immutable. The0.7.0
+artifact must be reviewed, published, pinned and qualified by the platform before
+adoption. No publication is implied by this version change.
+
+The built0.7.0 local candidate wheel passed the same installed-core proof with
+cloudpickle3.1.2, Braket absent,100-shot local Bell simulation and a captured
+function executed in a fresh process returning the structured answer42.
+Candidate SHA256: `8843a6d43201ef219aba06ca35d2ee02326a83ff216cec618aedd50b1c8e24c7`.
+This local build hash is not a claim about a future published artifact.
+
+Final0.7.0 candidate full suite:780 passed,20 skipped and13 pre-existing XPASS,
+with no new skips or expected failures. Log: `/private/tmp/marqov-sdk-070-full-tests.log`.

--- a/docs/design/optional-braket-runtime.md
+++ b/docs/design/optional-braket-runtime.md
@@ -1,0 +1,44 @@
+# Optional Braket installation for managed compiler compatibility
+
+The hosted compiler/task contract pins cloudpickle 3.1.2 and uses released SDK
+capture across separate processes. Braket's patched SDK versions currently pin
+cloudpickle 2.2.1. Keeping Braket in every SDK installation forces the hosted lock
+resolver back to an older Braket release. Both the first patched release 1.117.0
+and the available patched range through 1.127.0 were tested and conflict with the
+hosted serialization pin. The [vendor advisory](https://github.com/amazon-braket/amazon-braket-sdk-python/security/advisories/GHSA-g697-2xrc-gc46)
+identifies the affected job-result/checkpoint deserialization path and the fix.
+
+Braket now belongs to the `braket` and `all` extras, with minimum version 1.117.0.
+Core workflow serialization declares cloudpickle directly. Platform runtime
+profiles retain their exact serialization pin; the SDK does not override
+Braket's dependency metadata or downgrade the platform contract. Existing locked
+SDK development/provider dependency versions remain unchanged.
+
+This is an installation compatibility change. Existing Braket users select
+`marqov[braket]` or `marqov[all]`. `MarqovDevice("local", ...)` and `marqov-sim`
+use Braket's local simulator and also need the extra. `LocalExecutor`,
+`Circuit.simulate()` and core workflow capture remain independent. Missing
+provider/conversion dependencies give an actionable installation error; unrelated
+broken transitive imports still propagate. Simulator semantics are unchanged.
+
+## Local qualification
+
+- Full SDK suite: 780 passed, 20 skipped, 13 existing expected-failure tests passed;
+  zero failures. No new skip/xfail marks were introduced. The initial sandbox run
+  could not download/start the official Temporal test server; the permitted run
+  passed the real workflow isolation test.
+- `tests/test_optional_braket.py` covers core capture without Braket, explicit
+  provider/local-device/conversion refusal and an unrelated broken dependency.
+- A built candidate wheel was installed in a fresh environment with
+  cloudpickle 3.1.2 and no amazon-braket-sdk distribution. Metadata exposes Braket
+  only under its two extras. Actual LocalExecutor Bell execution produced 100
+  shots; a captured function executed in a separate child process and reconstructed
+  its structured answer 42.
+- Changed Python files pass Ruff; the candidate diff passes the secret scan.
+
+The local wheel retains the checkout's 0.6.1 version only as an unpublished test
+artifact (SHA256 321360d291c311ec7dd1bfd12bccd42e10d1aef650d099145883e768df3c1d2c).
+It must not replace the released 0.6.1 artifact. A reviewed new release/version,
+published wheel hash, refreshed frozen platform profiles and exact container
+qualification are required before runtime adoption. No package was published and
+no hosted runtime was changed by this qualification.

--- a/marqov/__init__.py
+++ b/marqov/__init__.py
@@ -34,7 +34,7 @@ Simple circuit execution:
     >>> result = await executor.execute(circuit, shots=1000)
 """
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 # Re-export commonly used items for convenience
 from marqov.circuits import Circuit, bell_state, ghz_state

--- a/marqov/_optional.py
+++ b/marqov/_optional.py
@@ -1,0 +1,12 @@
+"""Actionable dependency checks at optional provider boundaries."""
+
+from importlib import import_module
+
+
+def require_braket() -> None:
+    try:
+        import_module("braket")
+    except ModuleNotFoundError as error:
+        if error.name != "braket":
+            raise
+        raise ImportError('AWS Braket requires pip install "marqov[braket]"') from error

--- a/marqov/circuits.py
+++ b/marqov/circuits.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING
 
 import quantumflow as qf
 
+from marqov._optional import require_braket
+
 if TYPE_CHECKING:
     from braket.circuits import Circuit as BraketCircuit
     from pyquil import Program as PyQuilProgram
@@ -213,6 +215,7 @@ class Circuit:
         Returns:
             Braket Circuit object ready for execution.
         """
+        require_braket()
         return qf.circuit_to_braket(self._qf, translate=True)
 
     def to_qiskit(self):
@@ -323,6 +326,7 @@ class Circuit:
             New Circuit instance.
         """
         circuit = cls()
+        require_braket()
         circuit._qf = qf.braket_to_circuit(braket_circuit)
         return circuit
 

--- a/marqov/device.py
+++ b/marqov/device.py
@@ -6,6 +6,7 @@ import asyncio
 
 from marqov.backends import is_azure, is_braket, is_ibm, is_simulator
 from marqov.circuits import Circuit
+from marqov._optional import require_braket
 
 
 def _run_loop_safe(fn):
@@ -68,6 +69,7 @@ class MarqovDevice:
             return self._provider_device
 
         if self._backend in ("local", "marqov-sim"):
+            require_braket()
             from braket.devices import LocalSimulator
 
             self._provider_device = LocalSimulator()

--- a/marqov/executors/braket.py
+++ b/marqov/executors/braket.py
@@ -24,9 +24,14 @@ from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
-import boto3
-from braket.aws import AwsDevice, AwsSession
-from braket.circuits import Circuit as BraketCircuit
+try:
+    import boto3
+    from braket.aws import AwsDevice, AwsSession
+    from braket.circuits import Circuit as BraketCircuit
+except ModuleNotFoundError as error:
+    if error.name not in {"boto3", "braket"}:
+        raise
+    boto3 = AwsDevice = AwsSession = BraketCircuit = None
 
 from marqov.executors._counts import allocate_counts
 from marqov.executors.base import BaseExecutor, DeviceStatus, ExecutionResult
@@ -125,6 +130,8 @@ class BraketExecutor(BaseExecutor):
         Args:
             config: Executor configuration including device ARN and S3 settings.
         """
+        if AwsDevice is None:
+            raise ImportError('AWS Braket requires pip install "marqov[braket]"')
         self.config = config
         self._device: AwsDevice | None = None
         self._aws_session: AwsSession | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
     "temporalio>=1.7.0",
     # Circuit transpilation (marqov-owned fork of QuantumFlow v1.4.0; see marqov-dev/marqov-quantumflow)
     "marqov-quantumflow==1.0.0",
-    # AWS Braket
-    "amazon-braket-sdk>=1.80.0",
+    # Workflow serialization is core, independent of provider installations.
+    "cloudpickle>=2.2.1",
     # Azure Quantum
     "azure-quantum>=1.0.0",
     # CLI
@@ -43,6 +43,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+braket = [
+    # Earlier versions permit unsafe deserialization of job results/checkpoints.
+    "amazon-braket-sdk>=1.117.0",
+]
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
@@ -111,6 +115,7 @@ rigetti = [
     "pyquil>=4.0.0",
 ]
 all = [
+    "amazon-braket-sdk>=1.117.0",
     "qutip>=5.3.0,<6.0.0",
     "qiskit>=1.0.0",
     "qiskit-ibm-runtime>=0.20.0",

--- a/tests/test_optional_braket.py
+++ b/tests/test_optional_braket.py
@@ -1,0 +1,80 @@
+"""Core workflow imports must not depend on the optional AWS provider SDK."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_core_capture_and_provider_refusal_without_braket():
+    code = '''
+import importlib.abc
+import sys
+
+class MissingBraket(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "braket" or fullname.startswith("braket."):
+            raise ModuleNotFoundError("Braket deliberately absent", name="braket")
+
+sys.meta_path.insert(0, MissingBraket())
+from marqov import task, workflow, Circuit, LocalExecutor, MarqovDevice
+from marqov.executors import BraketExecutor, BraketExecutorConfig
+
+@task
+def twice(value):
+    return value * 2
+
+@workflow
+def example(value):
+    return {"answer": twice(value), "labels": ["managed", "native"]}
+
+captured = example(21).capture()
+assert len(captured.graph.nodes) == 1
+node_id = next(iter(captured.graph.nodes))
+assert captured.resolve_output({node_id: 42}) == {
+    "answer": 42, "labels": ["managed", "native"]}
+assert LocalExecutor is not None and Circuit is not None
+for action in (
+    lambda: BraketExecutor(BraketExecutorConfig(device_arn="unused", s3_bucket="unused")),
+    lambda: Circuit().h(0).to_braket(),
+    lambda: Circuit.from_braket(object()),
+    lambda: MarqovDevice("local", {})._get_provider_device(),
+    lambda: MarqovDevice("marqov-sim", {})._get_provider_device(),
+):
+    try:
+        action()
+    except ImportError as error:
+        assert str(error) == 'AWS Braket requires pip install "marqov[braket]"'
+    else:
+        raise AssertionError("Missing provider dependency was accepted")
+assert not any(name == "braket" or name.startswith("braket.") for name in sys.modules)
+'''
+    result = subprocess.run(
+        [sys.executable, "-c", code], cwd=Path(__file__).resolve().parents[1],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_broken_provider_installation_is_not_reported_as_an_absent_extra():
+    code = '''
+import importlib.abc
+import sys
+
+class BrokenBraket(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "braket":
+            raise ModuleNotFoundError("Broken transitive dependency", name="broken_transitive")
+
+sys.meta_path.insert(0, BrokenBraket())
+try:
+    import marqov
+except ModuleNotFoundError as error:
+    assert error.name == "broken_transitive"
+else:
+    raise AssertionError("Broken provider installation was silently hidden")
+'''
+    result = subprocess.run(
+        [sys.executable, "-c", code], cwd=Path(__file__).resolve().parents[1],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/uv.lock
+++ b/uv.lock
@@ -1442,9 +1442,9 @@ wheels = [
 name = "marqov"
 source = { editable = "." }
 dependencies = [
-    { name = "amazon-braket-sdk" },
     { name = "azure-quantum" },
     { name = "click" },
+    { name = "cloudpickle" },
     { name = "marqov-quantumflow" },
     { name = "numpy" },
     { name = "pydantic" },
@@ -1456,6 +1456,7 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
+    { name = "amazon-braket-sdk" },
     { name = "cirq-core" },
     { name = "pennylane" },
     { name = "pyquil" },
@@ -1471,6 +1472,9 @@ all = [
 azure = [
     { name = "cirq" },
     { name = "qiskit" },
+]
+braket = [
+    { name = "amazon-braket-sdk" },
 ]
 cirq = [
     { name = "cirq-core" },
@@ -1529,12 +1533,14 @@ rigetti = [
 
 [package.metadata]
 requires-dist = [
-    { name = "amazon-braket-sdk", specifier = ">=1.80.0" },
+    { name = "amazon-braket-sdk", marker = "extra == 'all'", specifier = ">=1.117.0" },
+    { name = "amazon-braket-sdk", marker = "extra == 'braket'", specifier = ">=1.117.0" },
     { name = "azure-quantum", specifier = ">=1.0.0" },
     { name = "cirq", marker = "extra == 'azure'", specifier = ">=1.0.0" },
     { name = "cirq-core", marker = "extra == 'all'", specifier = ">=1.0.0" },
     { name = "cirq-core", marker = "extra == 'cirq'", specifier = ">=1.0.0" },
     { name = "click", specifier = ">=8.0.0" },
+    { name = "cloudpickle", specifier = ">=2.2.1" },
     { name = "cudaq", marker = "sys_platform == 'linux' and extra == 'cudaq'", specifier = ">=0.14.2" },
     { name = "marqov-quantumflow", specifier = "==1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
@@ -1581,7 +1587,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=24.0.0" },
     { name = "temporalio", specifier = ">=1.7.0" },
 ]
-provides-extras = ["all", "azure", "cirq", "cudaq", "dev", "ibm", "ionq", "openqasm", "pennylane", "pyquil", "pytket", "qiskit", "quantinuum", "qutip", "rigetti"]
+provides-extras = ["all", "azure", "braket", "cirq", "cudaq", "dev", "ibm", "ionq", "openqasm", "pennylane", "pyquil", "pytket", "qiskit", "quantinuum", "qutip", "rigetti"]
 
 [[package]]
 name = "marqov-quantumflow"


### PR DESCRIPTION
The managed compiler/task contract pins cloudpickle3.1.2. Patched Braket SDK versions pin2.2.1, so making Braket a mandatory core dependency prevents that runtime from installing a patched provider SDK. Move Braket into explicit `[braket]` and `[all]` extras with minimum1.117.0, and declare workflow serialization directly. Core capture and local simulation can then use the platform serialization contract without Braket.

This is SDK0.7.0 because default installation behavior changes. Existing Braket execution, circuit conversion and `MarqovDevice("local"/"marqov-sim")` users must install `marqov[braket]` or `[all]`. Execution semantics are unchanged. Missing optional dependencies produce actionable errors; unrelated broken imports are not hidden. Development/provider lock versions are preserved.

Validation: full final suite780 passed,20 skipped and13 pre-existing XPASS; no new skips or expected failures. Independent code review found no blocking issue. A built0.7.0 wheel installed in a Braket-free environment with cloudpickle3.1.2 and passed100-shot LocalExecutor simulation plus captured structured output across a separate task process. Ruff, diff and changed-file secret scans passed.

No artifact is published by this PR. The prior released0.6.1 remains immutable. After review/merge, publication and exact published wheel hash must precede platform frozen-lock and image qualification. The local candidate wheel hash is recorded as local evidence only.

Refs #121; platform#2160 and#2040. Detailed dependency and release evidence: `docs/design/optional-braket-runtime.md`.
