### PR TITLE
Document SDK 0.7.0 publication and upgrade guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to the `marqov` SDK are documented here. This project follow
 still change between minor versions; `1.0.0` is reserved for the first API-stable
 release.
 
-## [0.7.0] — release candidate
+## [0.7.0] — 2026-09-12
+
+Published on [PyPI](https://pypi.org/project/marqov/0.7.0/). See the
+[upgrade guide](docs/releases/0.7.0.md) and
+[release record](https://github.com/marqov-dev/marqov-sdk/releases/tag/v0.7.0).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ dispatch = multi_shot_study([100, 500, 1000, 5000])
 # dispatch.run(client) — needs a Temporal worker
 ```
 
-Independent tasks execute in parallel automatically. Marqov handles scheduling, retries, and result collection across any supported backend. Run your own Temporal worker (see `marqov/workflows/`) — or skip the infrastructure entirely with the hosted [Marqov Platform](https://marqov.ai).
+Independent tasks execute in parallel automatically. Marqov handles scheduling, retries, and result collection across any supported backend. Run your own Temporal worker (see `marqov/workflows/`). Hosted execution is provided separately by the [Marqov Platform](https://marqov.ai); SDK installation alone does not enable managed execution.
 
 ---
 
 ## Installation
+
+SDK 0.7.0 is published. See the [changelog](CHANGELOG.md) and
+[0.7.0 upgrade guide](docs/releases/0.7.0.md), especially if you use AWS Braket.
 
 ```bash
 pip install marqov
@@ -98,7 +101,8 @@ pytest tests/ -v
 ## Cloud Executors
 
 Swap in a cloud backend when you're ready to run on hardware — on **your own
-provider accounts**, no Marqov account needed:
+provider accounts**, no Marqov account needed. The AWS example below requires
+`pip install "marqov[braket]"` and your AWS credentials:
 
 ```python
 import asyncio
@@ -169,7 +173,7 @@ from marqov.circuits import Circuit
 circuit = Circuit().h(0).cnot(0, 1)
 
 circuit.to_qiskit()   # qiskit.QuantumCircuit
-circuit.to_braket()   # braket.circuits.Circuit
+circuit.to_braket()   # braket.circuits.Circuit (requires marqov[braket])
 circuit.to_cirq()     # cirq.Circuit
 circuit.to_pyquil()   # pyquil.Program  (requires pip install marqov[pyquil])
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ dispatch = multi_shot_study([100, 500, 1000, 5000])
 # dispatch.run(client) — needs a Temporal worker
 ```
 
-Independent tasks execute in parallel automatically. Marqov handles scheduling, retries, and result collection across any supported backend. Run your own Temporal worker (see `marqov/workflows/`). Hosted execution is provided separately by the [Marqov Platform](https://marqov.ai); SDK installation alone does not enable managed execution.
+Independent tasks execute in parallel automatically. Marqov handles scheduling, retries, and result collection across any supported backend. Run your own Temporal worker (see `marqov/workflows/`). Hosted execution is provided separately by the [Marqov Platform](https://marqov.ai). SDK installation alone does not enable managed execution.
 
 ---
 

--- a/docs/releases/0.7.0.md
+++ b/docs/releases/0.7.0.md
@@ -1,0 +1,65 @@
+# Marqov SDK 0.7.0
+
+Published on 2026-09-12: [PyPI](https://pypi.org/project/marqov/0.7.0/) ·
+[GitHub release](https://github.com/marqov-dev/marqov-sdk/releases/tag/v0.7.0).
+
+This release makes AWS Braket an optional dependency and declares workflow
+serialization dependencies directly. It lets core compiler/task environments
+choose a compatible serializer without inheriting Braket's separate job
+serialization constraint. Python remains >=3.12.
+
+## Upgrade
+
+For core workflows, `LocalExecutor` and `Circuit.simulate()`:
+
+```bash
+python -m pip install --upgrade "marqov==0.7.0"
+```
+
+For AWS Braket, Braket circuit conversions, or `MarqovDevice` with `local` or
+`marqov-sim`:
+
+```bash
+python -m pip install --upgrade "marqov[braket]==0.7.0"
+```
+
+`marqov[all]` also includes Braket. The Braket extra requires
+`amazon-braket-sdk>=1.117.0`. Missing optional dependencies now produce an
+installation hint. Execution semantics have not changed: `MarqovDevice`'s local
+simulator still uses Braket; `LocalExecutor` does not require it.
+
+Upgrading an existing environment does not necessarily uninstall old Braket
+packages. For a core-only runtime, create a fresh environment or regenerate your
+lockfile and inspect the resolved dependencies. Keep compiler and task serializer
+versions compatible; this release does not guarantee compatibility between
+arbitrary cloudpickle versions or bypass Braket's own requirements.
+
+## What changed—and what already existed
+
+- Braket is optional rather than part of the default SDK installation.
+- Core serialization declares `cloudpickle>=2.2.1` directly. Applications retain
+  responsibility for pinning and qualifying their execution environments.
+- The release includes the [QuTiP guide](../qutip.md) added after 0.6.1; optional
+  QuTiP installation itself shipped in 0.6.1.
+- [`WorkflowDispatch.capture()`](../workflow-capture.md) and structured workflow
+  returns shipped in 0.6.0. This release supports their runtime packaging; it does
+  not introduce a new workflow compiler or enable hosted execution.
+
+## Publication evidence
+
+Tag `v0.7.0` identifies commit
+`7991b873d5da54d8e1bd6cf4e8e1f7fd925ee83b`.
+
+- Wheel SHA-256:
+  `8843a6d43201ef219aba06ca35d2ee02326a83ff216cec618aedd50b1c8e24c7`
+- Source archive SHA-256:
+  `0a7ad22df0bad8aeb2b1c7c87bb0102aab1ac04b762272c507798790355f6e74`
+
+The downloaded PyPI wheel matched the tested TestPyPI artifact. Fresh installed
+core checks covered dependency consistency, local Bell-state execution and a
+captured structured return across separate processes. These are SDK checks, not
+hosted platform or live quantum-provider acceptance.
+
+The immutable published artifacts retain their original candidate changelog
+heading. This source documentation and the dated GitHub release record confirm
+publication; the artifact has not been replaced.


### PR DESCRIPTION
SDK 0.7.0 is published, but main still labels it a release candidate and lacks a dedicated upgrade guide. Record the publication date and artifact hashes, link the upgrade guide from the README, and make the Braket extra explicit beside the cloud and conversion examples.

The guide distinguishes the packaging change in0.7.0 from capture introduced in0.6.0 and QuTiP packaging introduced in0.6.1. It also explains fresh-environment/lockfile upgrades and avoids claiming hosted-platform readiness. Published artifacts remain immutable.

Validation: live PyPI wheel/source metadata verified; prior downloaded-wheel fresh-install proof passed. Private-reference hygiene passes; URL checker passes with18clean and two existing IonQ403/404 warnings; diff check passes. Documentation only.

This is one release-documentation batch. Recommend a short release announcement now and a broader platform blog post after hosted native Project/Report reload acceptance; no blog has been published.
