### PR TITLE
fix: reject silently ignored QiliSDK execution options

### DIFF
--- a/marqov/executors/qilisdk.py
+++ b/marqov/executors/qilisdk.py
@@ -120,11 +120,18 @@ class QiliSDKExecutor(BaseExecutor):
         Args:
             circuit: The circuit to execute.
             shots: Number of measurement shots.
-            **kwargs: Additional options (ignored today).
+            **kwargs: Unsupported options; any supplied option raises TypeError.
 
         Returns:
             ExecutionResult with measurement counts.
+
+        Raises:
+            TypeError: If unsupported keyword options are supplied.
         """
+        if kwargs:
+            names = ", ".join(sorted(kwargs))
+            raise TypeError(f"QiliSDKExecutor.execute() got unsupported options: {names}")
+
         circuit = self._validate_circuit(circuit)
 
         from qilisdk.functionals import DigitalPropagation
@@ -173,11 +180,18 @@ class QiliSDKExecutor(BaseExecutor):
                 value or an explicit `QTensor`. Defaults to
                 `InitialState.UNIFORM` (equal superposition), the standard
                 starting point for a transverse-field-driver anneal.
-            **kwargs: Additional options (ignored today).
+            **kwargs: Unsupported options; any supplied option raises TypeError.
 
         Returns:
             ExecutionResult with measurement counts.
+
+        Raises:
+            TypeError: If unsupported keyword options are supplied.
         """
+        if kwargs:
+            names = ", ".join(sorted(kwargs))
+            raise TypeError(f"QiliSDKExecutor.execute_analog() got unsupported options: {names}")
+
         from qilisdk.core.qtensor import InitialState as _InitialState
         from qilisdk.functionals import AnalogEvolution
         from qilisdk.readout import Readout

--- a/tests/test_qilisdk_options.py
+++ b/tests/test_qilisdk_options.py
@@ -1,0 +1,26 @@
+"""Unsupported options must fail before any simulator or input processing."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from marqov.executors.qilisdk import QiliSDKExecutor
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["execute", "execute_analog"])
+@pytest.mark.parametrize(
+    "options", [{"seed": 42}, {"num_threads": 2}, {"z_option": "secret-value", "a_option": True}]
+)
+async def test_unsupported_options_fail_before_execution(method, options):
+    executor = object.__new__(QiliSDKExecutor)
+    executor._backend = Mock()
+    executor._validate_circuit = Mock()
+    with pytest.raises(TypeError) as caught:
+        await getattr(executor, method)(object(), **options)
+    assert str(caught.value) == (
+        f"QiliSDKExecutor.{method}() got unsupported options: " + ", ".join(sorted(options))
+    )
+    assert "secret-value" not in str(caught.value)
+    executor._validate_circuit.assert_not_called()
+    executor._backend.execute.assert_not_called()


### PR DESCRIPTION
QiliSDKExecutor accepted options such as `seed=42` and silently discarded them, so callers could believe a run was seeded. Both `execute()` and `execute_analog()` now reject unsupported keyword options with `TypeError` before input processing or simulator execution. Errors list option names without exposing their values. Named arguments retain their existing behavior.

Fixes #124. This is the interim rejection fix; seed support is not introduced.

Validation: six regression cases verify rejection on both paths and no backend invocation; Ruff passes. Full local SDK suite: 786 passed, 20 existing skips, 13 existing XPASS, with `OMP_NUM_THREADS=1` outside the sandbox. The first sandboxed run aborted inside Qiskit Aer; the complete rerun passed. No provider jobs submitted.
